### PR TITLE
Fix patch version when running CMake outside the source tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,12 +23,12 @@ else()
 	set(GIT_TAG "v${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}")
 	if(MSVC)
 		execute_process(
-			COMMAND CMD /c git rev-list ${GIT_TAG}..HEAD --count
+			COMMAND CMD /c git -C "${CMAKE_SOURCE_DIR}" rev-list ${GIT_TAG}..HEAD --count
 			OUTPUT_VARIABLE VERSION_PATCH
 		)
 	else()
 		execute_process(
-			COMMAND git rev-list ${GIT_TAG}..HEAD --count
+			COMMAND git -C "${CMAKE_SOURCE_DIR}" rev-list ${GIT_TAG}..HEAD --count
 			OUTPUT_VARIABLE VERSION_PATCH
 		)
 	endif()


### PR DESCRIPTION
Determination of patch version fails when running CMake outside the source tree.

For example, this currently fails to determine the patch version:
```
$ git clone https://github.com/oneapi-src/level-zero.git
$ cmake -B build -S level-zero
$ make -C build
```

To fix this, we must ensure that the `git` command runs in the `${CMAKE_SOURCE_DIR}` directory. This can be done by specifying the source tree with the git `-C` option.