### PR TITLE
Unbreak build on FreeBSD

### DIFF
--- a/source/inc/ze_util.h
+++ b/source/inc/ze_util.h
@@ -17,15 +17,7 @@
 #define L0_VALIDATION_LAYER_SUPPORTED_VERSION "0.91"
 
 ///////////////////////////////////////////////////////////////////////////////
-#if defined(__linux__)
-#  include <dlfcn.h>
-#  define HMODULE void*
-#  define MAKE_LIBRARY_NAME(NAME, VERSION)    "lib" NAME ".so." VERSION
-#  define MAKE_VALIDATION_LAYER_NAME(NAME)    "lib" NAME ".so." L0_VALIDATION_LAYER_SUPPORTED_VERSION
-#  define LOAD_DRIVER_LIBRARY(NAME) dlopen(NAME, RTLD_LAZY|RTLD_LOCAL)
-#  define FREE_DRIVER_LIBRARY(LIB)  if(LIB) dlclose(LIB)
-#  define GET_FUNCTION_PTR(LIB, FUNC_NAME) dlsym(LIB, FUNC_NAME)
-#elif defined(_WIN32)
+#if defined(_WIN32)
 #  include <Windows.h>
 #  define MAKE_LIBRARY_NAME(NAME, VERSION)    NAME".dll"
 #  define MAKE_VALIDATION_LAYER_NAME(NAME)    NAME".dll"
@@ -33,7 +25,13 @@
 #  define FREE_DRIVER_LIBRARY(LIB)  if(LIB) FreeLibrary(LIB)
 #  define GET_FUNCTION_PTR(LIB, FUNC_NAME) GetProcAddress(LIB, FUNC_NAME)
 #else
-#  error "Unsupported OS"
+#  include <dlfcn.h>
+#  define HMODULE void*
+#  define MAKE_LIBRARY_NAME(NAME, VERSION)    "lib" NAME ".so." VERSION
+#  define MAKE_VALIDATION_LAYER_NAME(NAME)    "lib" NAME ".so." L0_VALIDATION_LAYER_SUPPORTED_VERSION
+#  define LOAD_DRIVER_LIBRARY(NAME) dlopen(NAME, RTLD_LAZY|RTLD_LOCAL)
+#  define FREE_DRIVER_LIBRARY(LIB)  if(LIB) dlclose(LIB)
+#  define GET_FUNCTION_PTR(LIB, FUNC_NAME) dlsym(LIB, FUNC_NAME)
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Most Unices are ELF, so Linux logic should work.
https://github.com/oneapi-src/level-zero/blob/ebb363e938a279cf866cb93d28e31aaf0791ea19/source/loader/CMakeLists.txt#L14-L24

<details><summary>GPU test via Intel NEO</summary>

```
$ pkg install git cmake ninja png boost-libs level-zero opencl ocl-icd intel-compute-runtime
$ git clone https://github.com/oneapi-src/level-zero-tests
$ cd level-zero-tests
$ fetch -qo- https://github.com/oneapi-src/level-zero-tests/pull/1.patch | git am
$ cmake -GNinja -DREQUIRE_LEVELZERO_OPENCL_INTEROP=YES -DREQUIRE_OPENCL_BENCHMARKS=YES .
$ ninja install
$ cd out

$ ./ze_peak

zeDriverGet...
Device :
 * name : Intel(R) Gen9
 * vendorId : 32902
 * deviceId : 6418
 * subdeviceId : 0
 * isSubdevice : FALSE
 * coreClockRate : 1150
 * numAsyncComputeEngines : 3
 * numAsyncCopyEngines  : 1
 * maxCommandQueuePriority : 0
Global memory bandwidth (GBPS)
float : 27.951 GBPS
float2 : 29.2396 GBPS
float4 : 32.1935 GBPS
float8 : 32.7776 GBPS
float16 : 30.1365 GBPS
[...]

$ ./ze_image_copy
Host2Device2Host: Measuring Bandwidth for copying the image buffer size 2048X2048X1 from Host->Device->Host
18.8622 GBPS
Host2Device: Measuring Bandwidth/Latency for copying the image buffer size 2048X2048X1 from Host->Device
21.9384 GBPS
764.743168 us (Latency: Host->Device)
0.21751100683 GBPS
77132.7219 us (Latency: Host->Device)
Device2Host: Measurign Bandwidth/Latency for copying the image buffer size 2048X2048X1 from Device->Host
27.916375297 GBPS
600.981174 us (Latency: Device->Host)
0.27833762704 GBPS
60276.4929 us (Latency: Device->Host)
Host2Device: Measuring Bandwidth/Latency for copying the image buffer size 1X1X1   Image format=  ZE_IMAGE_FORMAT_TYPE_UINT  Image Layout=  ZE_IMAGE_FORMAT_LAYOUT_8  from Host->Device
0.0020535460068 GBPS
1.9478502 us (Latency: Host->Device)
Device2Host: Measuring Bandwidth/Latency for copying the image buffer size 1X1X1   Image format=  ZE_IMAGE_FORMAT_TYPE_UINT  Image Layout=  ZE_IMAGE_FORMAT_LAYOUT_8  from Device->Host
0.0049861646397 GBPS
0.8022198 us (Latency: Device->Host)
```
</details>
