### PR TITLE
Fix Level Zero loader build on Windows

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -33,6 +33,7 @@ if(WIN32)
 endif()
 
 install(TARGETS ze_loader
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     LIBRARY
         DESTINATION ${CMAKE_INSTALL_LIBDIR}
         COMPONENT level-zero
@@ -40,6 +41,7 @@ install(TARGETS ze_loader
 )
 
 install(TARGETS ze_loader
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     LIBRARY
         DESTINATION ${CMAKE_INSTALL_LIBDIR}
         COMPONENT level-zero-devel

--- a/source/layers/validation/CMakeLists.txt
+++ b/source/layers/validation/CMakeLists.txt
@@ -26,6 +26,7 @@ set_target_properties(${TARGET_NAME} PROPERTIES
 )
 
 install(TARGETS ze_validation_layer
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     LIBRARY
         DESTINATION ${CMAKE_INSTALL_LIBDIR}
         COMPONENT level-zero
@@ -33,6 +34,7 @@ install(TARGETS ze_validation_layer
 )
 
 install(TARGETS ze_validation_layer
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     LIBRARY
         DESTINATION ${CMAKE_INSTALL_LIBDIR}
         COMPONENT level-zero-devel


### PR DESCRIPTION
On DLL platforms like Windows a shared library has the corresponding
import library (has .lib extension but not same as static library). This
import library is treated as ARCHIVE target. That is why ARCHIVE target
must be specified in cmake file so that cmake knows where to put import
file.

Signed-off-by: Gainullin <artur.gainullin@intel.com>