### PR TITLE
Add C++ 14 standard requirement to cmake file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@
 # SPDX-License-Identifier: MIT
 
 cmake_minimum_required(VERSION 3.2.0 FATAL_ERROR)
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 if(MSVC AND (MSVC_VERSION LESS 1900))
     message(FATAL_ERROR "Visual Studio Compiler Version >= 1900 Required to build.")


### PR DESCRIPTION
Level Zero loader sources use make_unique after some recent changes.
This feature is supported only since c++14.

Signed-off-by: Artur Gainullin <artur.gainullin@intel.com>