### PR TITLE
Fix Fan configuration structure

### DIFF
--- a/include/zes.py
+++ b/include/zes.py
@@ -841,7 +841,7 @@ class zes_fan_config_t(Structure):
         ("pNext", c_void_p),                                            ## [in][optional] pointer to extension-specific structure
         ("mode", zes_fan_speed_mode_t),                                 ## [in,out] The fan speed mode (fixed, temp-speed table)
         ("speedFixed", zes_fan_speed_t),                                ## [in,out] The current fixed fan speed setting
-        ("speedTable", zes_fan_temp_speed_t)                            ## [out] Array of temperature/fan speed pairs currently configured
+        ("speedTable", zes_fan_speed_table_t)                           ## [out] The currently configured fan speed table
     ]
 
 ###############################################################################

--- a/include/zes_api.h
+++ b/include/zes_api.h
@@ -1773,7 +1773,7 @@ typedef struct _zes_fan_config_t
     const void* pNext;                              ///< [in][optional] pointer to extension-specific structure
     zes_fan_speed_mode_t mode;                      ///< [in,out] The fan speed mode (fixed, temp-speed table)
     zes_fan_speed_t speedFixed;                     ///< [in,out] The current fixed fan speed setting
-    zes_fan_temp_speed_t speedTable;                ///< [out] Array of temperature/fan speed pairs currently configured
+    zes_fan_speed_table_t speedTable;               ///< [out] The currently configured fan speed table
 
 } zes_fan_config_t;
 


### PR DESCRIPTION
From logic point of view and documentation comment 'speedTable' field
should have 'zes_fan_speed_table_t' type instead 'zes_fan_temp_speed_t'.
This field should contain a speed's table that was configured instead
a single entry from speed's table.