### PR TITLE
Add level-zero.pc

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -67,4 +67,9 @@ if(UNIX)
         ${CMAKE_CURRENT_BINARY_DIR}/libze_loader.pc
         @ONLY)
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libze_loader.pc" DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig" COMPONENT level-zero-devel)
+    configure_file(
+        ${CMAKE_CURRENT_SOURCE_DIR}/level-zero.pc.in
+        ${CMAKE_CURRENT_BINARY_DIR}/level-zero.pc
+        @ONLY)
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/level-zero.pc" DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig" COMPONENT level-zero-devel)
 endif()

--- a/source/level-zero.pc.in
+++ b/source/level-zero.pc.in
@@ -1,0 +1,12 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+includedir=${prefix}/include
+libdir=${prefix}/lib
+
+
+Name: Level Zero
+Description: Level Zero
+URL: https://github.com/oneapi-src/level-zero
+Version: @PROJECT_VERSION_MAJOR@.@PROJECT_VERSION_MINOR@.@PROJECT_VERSION_PATCH@
+Requires: libze_loader
+Libs: -L${libdir}
+CFlags: -I${includedir}/level_zero


### PR DESCRIPTION
Compiling against level-zero is currently inconvenient because headers are under include/level_zero instead of include. One has to manually change CPPFLAGS to find them. This PR adds a level-zero.pc on top of libze_loader.pc to make things easy.

Note that the CMake code might be suboptimal but at least it returns what I need for building hwloc with L0 support:
```
$ export PKG_CONFIG_PATH=$PWD/install/lib/pkgconfig/
$ pkg-config level-zero --cflags
-I/home/bgoglin/SOFT/oneapi/level-zero/build/install/include/level_zero -I/home/bgoglin/SOFT/oneapi/level-zero/build/install/include
$ pkg-config level-zero --libs  
-L/home/bgoglin/SOFT/oneapi/level-zero/build/install/lib -lze_loader
```

Signed-off-by: Brice Goglin <Brice.Goglin@inria.fr>
