### PR TITLE
[OS] - Put Apache 2.0 license headers in dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-# Copyright (C) 2020-2021 Intel Corporation
-# SPDX-License-Identifier: MIT
+# Copyright (C) 2023 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
 
 cmake_minimum_required(VERSION 3.2.0 FATAL_ERROR)
 set(CMAKE_CXX_STANDARD 14)

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,201 @@
-MIT License
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (C) 2019-2021 Intel Corporation
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/docker/build-ubuntu.Dockerfile
+++ b/docker/build-ubuntu.Dockerfile
@@ -1,5 +1,7 @@
-# Copyright (C) 2020 Intel Corporation
-# SPDX-License-Identifier: MIT
+#
+# Copyright (C) 2023 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
+#
 
 ARG IMAGE_VERSION=eoan-20200114
 FROM ubuntu:$IMAGE_VERSION

--- a/include/layers/zel_tracing_api.h
+++ b/include/layers/zel_tracing_api.h
@@ -1,7 +1,7 @@
 /*
- * Copyright (C) 2020 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file zel_tracing_api.h
  */

--- a/include/layers/zel_tracing_ddi.h
+++ b/include/layers/zel_tracing_ddi.h
@@ -1,7 +1,7 @@
 /*
- * Copyright (C) 2020 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file zel_tracing_ddi.h
  *

--- a/include/layers/zel_tracing_register_cb.h
+++ b/include/layers/zel_tracing_register_cb.h
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2021-2022 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file zel_tracing_register_cb.h
  *

--- a/include/loader/ze_loader.h
+++ b/include/loader/ze_loader.h
@@ -1,7 +1,7 @@
 /*
- * Copyright (C) 2021 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file ze_loader.h
  */

--- a/include/ze.py
+++ b/include/ze.py
@@ -1,7 +1,7 @@
 """
- Copyright (C) 2019-2021 Intel Corporation
+ Copyright (C) 2023 Intel Corporation
 
- SPDX-License-Identifier: MIT
+ SPDX-License-Identifier: Apache 2.0
 
  @file ze.py
  @version v1.5-r1.5.8

--- a/include/ze_api.h
+++ b/include/ze_api.h
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2019-2021 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file ze_api.h
  * @version v1.5-r1.5.8

--- a/include/ze_ddi.h
+++ b/include/ze_ddi.h
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2019-2021 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file ze_ddi.h
  * @version v1.5-r1.5.8

--- a/include/zes.py
+++ b/include/zes.py
@@ -1,7 +1,7 @@
 """
- Copyright (C) 2019-2021 Intel Corporation
+ Copyright (C) 2023 Intel Corporation
 
- SPDX-License-Identifier: MIT
+ SPDX-License-Identifier: Apache 2.0
 
  @file zes.py
  @version v1.5-r1.5.8

--- a/include/zes_api.h
+++ b/include/zes_api.h
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2019-2021 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file zes_api.h
  * @version v1.5-r1.5.8

--- a/include/zes_ddi.h
+++ b/include/zes_ddi.h
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2019-2021 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file zes_ddi.h
  * @version v1.5-r1.5.8

--- a/include/zet.py
+++ b/include/zet.py
@@ -1,7 +1,7 @@
 """
- Copyright (C) 2019-2021 Intel Corporation
+ Copyright (C) 2023 Intel Corporation
 
- SPDX-License-Identifier: MIT
+ SPDX-License-Identifier: Apache 2.0
 
  @file zet.py
  @version v1.5-r1.5.8

--- a/include/zet_api.h
+++ b/include/zet_api.h
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2019-2021 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file zet_api.h
  * @version v1.5-r1.5.8

--- a/include/zet_ddi.h
+++ b/include/zet_ddi.h
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2019-2021 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file zet_ddi.h
  * @version v1.5-r1.5.8

--- a/os_release_info.cmake
+++ b/os_release_info.cmake
@@ -1,6 +1,5 @@
-# Copyright (C) 2020 Intel Corporation
-# SPDX-License-Identifier: MIT
-#
+# Copyright (C) 2023 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
 
 if(NOT DEFINED _os_release_info)
 set(_os_release_info TRUE)

--- a/samples/include/zello_init.h
+++ b/samples/include/zello_init.h
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2020-2021 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  */
 #pragma once

--- a/samples/include/zello_log.h
+++ b/samples/include/zello_log.h
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2020 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  */
 #pragma once

--- a/samples/zello_world/zello_world.cpp
+++ b/samples/zello_world/zello_world.cpp
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2020-2021 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  */
 #include <stdlib.h>

--- a/scripts/generate_code.py
+++ b/scripts/generate_code.py
@@ -1,7 +1,7 @@
 """
- Copyright (C) 2019-2021 Intel Corporation
+ Copyright (C) 2023 Intel Corporation
 
- SPDX-License-Identifier: MIT
+ SPDX-License-Identifier: Apache 2.0
 
 """
 import os

--- a/scripts/json2src.py
+++ b/scripts/json2src.py
@@ -1,8 +1,8 @@
 #! /usr/bin/env python3
 """
- Copyright (C) 2019-2021 Intel Corporation
+ Copyright (C) 2023 Intel Corporation
 
- SPDX-License-Identifier: MIT
+ SPDX-License-Identifier: Apache 2.0
 
 """
 import argparse

--- a/scripts/templates/ddi.h.mako
+++ b/scripts/templates/ddi.h.mako
@@ -9,9 +9,9 @@ from templates import helper as th
     X=x.upper()
 %>/*
  *
- * Copyright (C) 2019-2022 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file ${n}_ddi.h
  *

--- a/scripts/templates/helper.py
+++ b/scripts/templates/helper.py
@@ -1,7 +1,7 @@
 """
- Copyright (C) 2019-2021 Intel Corporation
+ Copyright (C) 2023 Intel Corporation
 
- SPDX-License-Identifier: MIT
+ SPDX-License-Identifier: Apache 2.0
 
 """
 import re

--- a/scripts/templates/ldrddi.cpp.mako
+++ b/scripts/templates/ldrddi.cpp.mako
@@ -9,9 +9,9 @@ from templates import helper as th
     X=x.upper()
 %>/*
  *
- * Copyright (C) 2019-2022 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file ${name}.cpp
  *

--- a/scripts/templates/ldrddi.h.mako
+++ b/scripts/templates/ldrddi.h.mako
@@ -9,9 +9,9 @@ from templates import helper as th
     X=x.upper()
 %>/*
  *
- * Copyright (C) 2019-2022 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file ${name}.h
  *

--- a/scripts/templates/libapi.cpp.mako
+++ b/scripts/templates/libapi.cpp.mako
@@ -17,9 +17,9 @@ def define_dbg(obj, tags):
     X=x.upper()
 %>/*
  *
- * Copyright (C) 2019-2022 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file ${name}.cpp
  *

--- a/scripts/templates/libddi.cpp.mako
+++ b/scripts/templates/libddi.cpp.mako
@@ -9,9 +9,9 @@ from templates import helper as th
     X=x.upper()
 %>/*
  *
- * Copyright (C) 2019-2022 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file ${name}.cpp
  *

--- a/scripts/templates/nullddi.cpp.mako
+++ b/scripts/templates/nullddi.cpp.mako
@@ -9,9 +9,9 @@ from templates import helper as th
     X=x.upper()
 %>/*
  *
- * Copyright (C) 2019-2022 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file ${name}.cpp
  *

--- a/scripts/templates/tracing/trc_cb_struct.h.mako
+++ b/scripts/templates/tracing/trc_cb_struct.h.mako
@@ -9,9 +9,9 @@ from templates import helper as th
     X=x.upper()
 %>/*
  *
- * Copyright (C) 2021-2022 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file ${name}.h
  *

--- a/scripts/templates/tracing/trc_register_cb_libapi.cpp.mako
+++ b/scripts/templates/tracing/trc_register_cb_libapi.cpp.mako
@@ -9,9 +9,9 @@ from templates import helper as th
     X=x.upper()
 %>/*
  *
- * Copyright (C) 2021-2022 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file ${name}.cpp
  *

--- a/scripts/templates/tracing/trc_setters.cpp.mako
+++ b/scripts/templates/tracing/trc_setters.cpp.mako
@@ -9,9 +9,9 @@ from templates import helper as th
     X=x.upper()
 %>/*
  *
- * Copyright (C) 2021-2022 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file ${name}.h
  *

--- a/scripts/templates/tracing/trc_setters.h.mako
+++ b/scripts/templates/tracing/trc_setters.h.mako
@@ -9,9 +9,9 @@ from templates import helper as th
     X=x.upper()
 %>/*
  *
- * Copyright (C) 2021-2022 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file ${name}.h
  *

--- a/scripts/templates/tracing/trcddi.cpp.mako
+++ b/scripts/templates/tracing/trcddi.cpp.mako
@@ -9,9 +9,9 @@ from templates import helper as th
     X=x.upper()
 %>/*
  *
- * Copyright (C) 2020-2022 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file ${name}.cpp
  *

--- a/scripts/templates/valddi.cpp.mako
+++ b/scripts/templates/valddi.cpp.mako
@@ -9,9 +9,9 @@ from templates import helper as th
     X=x.upper()
 %>/*
  *
- * Copyright (C) 2019-2022 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file ${name}.cpp
  *

--- a/scripts/util.py
+++ b/scripts/util.py
@@ -1,7 +1,7 @@
 """
- Copyright (C) 2019-2021 Intel Corporation
+ Copyright (C) 2023 Intel Corporation
 
- SPDX-License-Identifier: MIT
+ SPDX-License-Identifier: Apache 2.0
 
 """
 import re

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -1,5 +1,5 @@
-# Copyright (C) 2020 Intel Corporation
-# SPDX-License-Identifier: MIT
+# Copyright (C) 2023 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
 
 add_definitions(-DL0_LOADER_VERSION="${PROJECT_VERSION_MAJOR}")
 add_definitions(-DL0_VALIDATION_LAYER_SUPPORTED_VERSION="${PROJECT_VERSION_MAJOR}")

--- a/source/drivers/null/ze_null.cpp
+++ b/source/drivers/null/ze_null.cpp
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2019-2021 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file ze_null.cpp
  *

--- a/source/drivers/null/ze_null.h
+++ b/source/drivers/null/ze_null.h
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2019-2021 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file ze_null.h
  *

--- a/source/drivers/null/ze_nullddi.cpp
+++ b/source/drivers/null/ze_nullddi.cpp
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2019-2022 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file ze_nullddi.cpp
  *

--- a/source/drivers/null/zes_nullddi.cpp
+++ b/source/drivers/null/zes_nullddi.cpp
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2019-2022 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file zes_nullddi.cpp
  *

--- a/source/drivers/null/zet_nullddi.cpp
+++ b/source/drivers/null/zet_nullddi.cpp
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2019-2022 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file zet_nullddi.cpp
  *

--- a/source/inc/ze_singleton.h
+++ b/source/inc/ze_singleton.h
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2019-2021 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  */
 #pragma once

--- a/source/inc/ze_util.h
+++ b/source/inc/ze_util.h
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2019-2021 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  */
 

--- a/source/layers/CMakeLists.txt
+++ b/source/layers/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Intel Corporation
-# SPDX-License-Identifier: MIT
+# Copyright (C) 2023 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
 add_subdirectory(validation)
 add_subdirectory(tracing)

--- a/source/layers/tracing/CMakeLists.txt
+++ b/source/layers/tracing/CMakeLists.txt
@@ -1,5 +1,5 @@
-# Copyright (C) 2020 Intel Corporation
-# SPDX-License-Identifier: MIT
+# Copyright (C) 2023 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
 set(TARGET_NAME ze_tracing_layer)
 
 configure_file(

--- a/source/layers/tracing/linux/tracing_init.cpp
+++ b/source/layers/tracing/linux/tracing_init.cpp
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2019-2021 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  */
 #include "../tracing_imp.h"

--- a/source/layers/tracing/tracing.h
+++ b/source/layers/tracing/tracing.h
@@ -1,7 +1,7 @@
 /*
- * Copyright (C) 2020-2021 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  */
 

--- a/source/layers/tracing/tracing_imp.cpp
+++ b/source/layers/tracing/tracing_imp.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (C) 2020-2021 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  */
 

--- a/source/layers/tracing/tracing_imp.h
+++ b/source/layers/tracing/tracing_imp.h
@@ -1,7 +1,7 @@
 /*
- * Copyright (C) 2020-2021 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  */
 

--- a/source/layers/tracing/windows/tracing_init.cpp
+++ b/source/layers/tracing/windows/tracing_init.cpp
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2019-2021 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  */
 #include "../tracing_imp.h"

--- a/source/layers/tracing/ze_tracing.cpp
+++ b/source/layers/tracing/ze_tracing.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (C) 2020 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  */
 

--- a/source/layers/tracing/ze_tracing_cb_structs.h
+++ b/source/layers/tracing/ze_tracing_cb_structs.h
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2021-2022 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file ze_tracing_cb_structs.h
  *

--- a/source/layers/tracing/ze_tracing_layer.cpp
+++ b/source/layers/tracing/ze_tracing_layer.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (C) 2020 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file ze_layer.cpp
  *

--- a/source/layers/tracing/ze_tracing_layer.h
+++ b/source/layers/tracing/ze_tracing_layer.h
@@ -1,7 +1,7 @@
 /*
- * Copyright (C) 2020-2022 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file ze_layer.h
  *

--- a/source/layers/tracing/ze_tracing_register_cb.cpp
+++ b/source/layers/tracing/ze_tracing_register_cb.cpp
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2021-2022 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file ze_tracing_register_cb.h
  *

--- a/source/layers/tracing/ze_trcddi.cpp
+++ b/source/layers/tracing/ze_trcddi.cpp
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2020-2022 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file ze_trcddi.cpp
  *

--- a/source/layers/validation/CMakeLists.txt
+++ b/source/layers/validation/CMakeLists.txt
@@ -1,5 +1,5 @@
-# Copyright (C) 2020 Intel Corporation
-# SPDX-License-Identifier: MIT
+# Copyright (C) 2023 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
 set(TARGET_NAME ze_validation_layer)
 
 configure_file(

--- a/source/layers/validation/ze_valddi.cpp
+++ b/source/layers/validation/ze_valddi.cpp
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2019-2022 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file ze_valddi.cpp
  *

--- a/source/layers/validation/ze_validation_layer.cpp
+++ b/source/layers/validation/ze_validation_layer.cpp
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2019-2021 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file ze_validation_layer.cpp
  *

--- a/source/layers/validation/ze_validation_layer.h
+++ b/source/layers/validation/ze_validation_layer.h
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2019-2021 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file ze_layer.h
  *

--- a/source/layers/validation/zes_valddi.cpp
+++ b/source/layers/validation/zes_valddi.cpp
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2019-2022 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file zes_valddi.cpp
  *

--- a/source/layers/validation/zet_valddi.cpp
+++ b/source/layers/validation/zet_valddi.cpp
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2019-2022 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file zet_valddi.cpp
  *

--- a/source/lib/linux/lib_init.cpp
+++ b/source/lib/linux/lib_init.cpp
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2021 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  */
 

--- a/source/lib/windows/lib_init.cpp
+++ b/source/lib/windows/lib_init.cpp
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2021 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  */
 

--- a/source/lib/ze_lib.cpp
+++ b/source/lib/ze_lib.cpp
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2019-2021 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file ze_lib.cpp
  *

--- a/source/lib/ze_lib.h
+++ b/source/lib/ze_lib.h
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2019-2021 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file ze_lib.h
  *

--- a/source/lib/ze_libapi.cpp
+++ b/source/lib/ze_libapi.cpp
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2019-2022 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file ze_libapi.cpp
  *

--- a/source/lib/ze_libddi.cpp
+++ b/source/lib/ze_libddi.cpp
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2019-2022 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file ze_libddi.cpp
  *

--- a/source/lib/ze_tracing_register_cb_libapi.cpp
+++ b/source/lib/ze_tracing_register_cb_libapi.cpp
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2021-2022 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file ze_tracing_register_cb_libapi.cpp
  *

--- a/source/lib/zel_tracing_libapi.cpp
+++ b/source/lib/zel_tracing_libapi.cpp
@@ -1,7 +1,8 @@
 /*
- * Copyright (C) 2020 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file zel_tracing_libapi.cpp
  *

--- a/source/lib/zel_tracing_libddi.cpp
+++ b/source/lib/zel_tracing_libddi.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (C) 2020-2022 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file zel_tracing_libddi.cpp
  * Perhaps have this generated at some point.

--- a/source/lib/zes_libapi.cpp
+++ b/source/lib/zes_libapi.cpp
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2019-2022 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file zes_libapi.cpp
  *

--- a/source/lib/zes_libddi.cpp
+++ b/source/lib/zes_libddi.cpp
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2019-2022 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file zes_libddi.cpp
  *

--- a/source/lib/zet_libapi.cpp
+++ b/source/lib/zet_libapi.cpp
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2019-2022 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file zet_libapi.cpp
  *

--- a/source/lib/zet_libddi.cpp
+++ b/source/lib/zet_libddi.cpp
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2019-2022 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file zet_libddi.cpp
  *

--- a/source/loader/CMakeLists.txt
+++ b/source/loader/CMakeLists.txt
@@ -1,6 +1,5 @@
-# Copyright (C) 2020 Intel Corporation
-# SPDX-License-Identifier: MIT
-
+# Copyright (C) 2023 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
 
 target_sources(${TARGET_LOADER_NAME}
     PRIVATE

--- a/source/loader/driver_discovery.h
+++ b/source/loader/driver_discovery.h
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2020 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  */
 

--- a/source/loader/linux/driver_discovery_lin.cpp
+++ b/source/loader/linux/driver_discovery_lin.cpp
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2020 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  */
 

--- a/source/loader/linux/loader_init.cpp
+++ b/source/loader/linux/loader_init.cpp
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2021 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  */
 

--- a/source/loader/windows/driver_discovery_win.cpp
+++ b/source/loader/windows/driver_discovery_win.cpp
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2020 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  */
 

--- a/source/loader/windows/loader_init.cpp
+++ b/source/loader/windows/loader_init.cpp
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2021 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  */
 

--- a/source/loader/ze_ldrddi.cpp
+++ b/source/loader/ze_ldrddi.cpp
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2019-2022 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file ze_ldrddi.cpp
  *

--- a/source/loader/ze_ldrddi.h
+++ b/source/loader/ze_ldrddi.h
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2019-2022 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file ze_ldrddi.h
  *

--- a/source/loader/ze_loader.cpp
+++ b/source/loader/ze_loader.cpp
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2019-2021 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  */
 #include "ze_loader_internal.h"

--- a/source/loader/ze_loader_api.cpp
+++ b/source/loader/ze_loader_api.cpp
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2020-2021 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file ze_loader_api.cpp
  *

--- a/source/loader/ze_loader_api.h
+++ b/source/loader/ze_loader_api.h
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2020-2021 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file ze_loader_api.cpp
  *

--- a/source/loader/ze_loader_internal.h
+++ b/source/loader/ze_loader_internal.h
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2019-2022 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  */
 #pragma once

--- a/source/loader/ze_object.h
+++ b/source/loader/ze_object.h
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2019-2021 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file ze_object.h
  *

--- a/source/loader/zel_tracing_ldrddi.cpp
+++ b/source/loader/zel_tracing_ldrddi.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (C) 2020 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file zel_tracing_ldrddi.cpp
  *

--- a/source/loader/zes_ldrddi.cpp
+++ b/source/loader/zes_ldrddi.cpp
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2019-2022 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file zes_ldrddi.cpp
  *

--- a/source/loader/zes_ldrddi.h
+++ b/source/loader/zes_ldrddi.h
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2019-2022 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file zes_ldrddi.h
  *

--- a/source/loader/zet_ldrddi.cpp
+++ b/source/loader/zet_ldrddi.cpp
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2019-2022 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file zet_ldrddi.cpp
  *

--- a/source/loader/zet_ldrddi.h
+++ b/source/loader/zet_ldrddi.h
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (C) 2019-2022 Intel Corporation
+ * Copyright (C) 2023 Intel Corporation
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache 2.0
  *
  * @file zet_ldrddi.h
  *


### PR DESCRIPTION
As part of porting VPUX dependencies to open source, we must add the appropriate license.