### PR TITLE
Fix generated pkg-config files

### DIFF
--- a/source/level-zero.pc.in
+++ b/source/level-zero.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 includedir=${prefix}/include
-libdir=${prefix}/lib
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
 
 
 Name: Level Zero

--- a/source/libze_loader.pc.in
+++ b/source/libze_loader.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 includedir=${prefix}/include
-libdir=${prefix}/lib
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
 
 
 Name: Level Zero Loader


### PR DESCRIPTION
Fixes https://github.com/oneapi-src/level-zero/issues/131.

The generated files now use the standard paths defined by the [GNUInstallDirs CMake module](https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html), which matches the directories the libraries are actually installed to.