### PR TITLE
logging: Allow to use spdlog from system if present

### DIFF
--- a/source/utils/CMakeLists.txt
+++ b/source/utils/CMakeLists.txt
@@ -1,15 +1,18 @@
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: MIT
 
-include(FetchContent)
-set(SPDLOG_REPO https://github.com/gabime/spdlog)
-set(SPDLOG_TAG v1.13.0)
-FetchContent_Declare(
-    spdlog
-    GIT_REPOSITORY ${SPDLOG_REPO}
-    GIT_TAG ${SPDLOG_TAG}
-)
-FetchContent_makeAvailable(spdlog)
+find_package(spdlog)
+if (NOT spdlog_FOUND)
+  include(FetchContent)
+  set(SPDLOG_REPO https://github.com/gabime/spdlog)
+  set(SPDLOG_TAG v1.13.0)
+  FetchContent_Declare(
+      spdlog
+      GIT_REPOSITORY ${SPDLOG_REPO}
+      GIT_TAG ${SPDLOG_TAG}
+  )
+  FetchContent_makeAvailable(spdlog)
+endif (NOT spdlog_FOUND)
 
 add_library(utils
   STATIC


### PR DESCRIPTION
Some distributions (like Fedora) disallow fetching content from the internet build-time. Let's allow to link with spdlog from the host and use that if present during the build-time instead of content fetch.