### PR TITLE
Define FMT_HEADER_ONLY

### DIFF
--- a/source/utils/logging.h
+++ b/source/utils/logging.h
@@ -9,6 +9,10 @@
 #ifndef level_zero_loader_LOGGING_HPP
 #define level_zero_loader_LOGGING_HPP
 
+#ifndef FMT_HEADER_ONLY
+#define FMT_HEADER_ONLY
+#endif
+
 #define LOADER_LOG_FILE_DEFAULT "ze_loader.log"
 
 #include <iostream>


### PR DESCRIPTION
The project is not using fmt and spdlog can pollute it with that otherwise.