### PR TITLE
Adjust zeCommandListGetNextCommandIdExp validation to changes in graph extension

### DIFF
--- a/source/layers/validation/parameter_validation/ze_parameter_validation.cpp
+++ b/source/layers/validation/parameter_validation/ze_parameter_validation.cpp
@@ -3788,7 +3788,7 @@ namespace validation_layer
         if( nullptr == pCommandId )
             return ZE_RESULT_ERROR_INVALID_NULL_POINTER;
 
-        if( 0x3f < desc->flags )
+        if( 0x80 < desc->flags )
             return ZE_RESULT_ERROR_INVALID_ENUMERATION;
 
         return ParameterValidation::validateExtensions(desc);


### PR DESCRIPTION
level-zero-npu-extensions recently introduced new structs and enumerations for mutable command list feature:
https://github.com/intel/level-zero-npu-extensions/pull/8. Therefore the maximum expected value for
ze_mutable_command_id_exp_desc_t::flags has to be increased.