### PR TITLE
Don't exchange zet/zes DDI tables for tracing

### DIFF
--- a/source/lib/ze_lib.cpp
+++ b/source/lib/ze_lib.cpp
@@ -99,7 +99,7 @@ namespace ze_lib
         // Init the stored ddi tables for the tracing layer
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zelLoaderTracingLayerInit(this->pTracingZeDdiTable, this->pTracingZetDdiTable, this->pTracingZesDdiTable);
+            result = zelLoaderTracingLayerInit(this->pTracingZeDdiTable);
         }
         // End DDI Table Inits
 
@@ -167,8 +167,6 @@ zelEnableTracingLayer()
 {
     if (ze_lib::context->tracingLayerEnableCounter.fetch_add(1) == 0) {
         ze_lib::context->zeDdiTable.exchange(ze_lib::context->pTracingZeDdiTable);
-        ze_lib::context->zetDdiTable.exchange(ze_lib::context->pTracingZetDdiTable);
-        ze_lib::context->zesDdiTable.exchange(ze_lib::context->pTracingZesDdiTable);
     }
     return ZE_RESULT_SUCCESS;
 }
@@ -178,8 +176,6 @@ zelDisableTracingLayer()
 {
     if (ze_lib::context->tracingLayerEnableCounter.fetch_sub(1) <= 1) {
         ze_lib::context->zeDdiTable.exchange(&ze_lib::context->initialzeDdiTable);
-        ze_lib::context->zetDdiTable.exchange(&ze_lib::context->initialzetDdiTable);
-        ze_lib::context->zesDdiTable.exchange(&ze_lib::context->initialzesDdiTable);
     }
     return ZE_RESULT_SUCCESS;
 }

--- a/source/lib/ze_lib.h
+++ b/source/lib/ze_lib.h
@@ -51,8 +51,6 @@ namespace ze_lib
         ze_result_t zelTracingDdiTableInit();
         zel_tracing_dditable_t  zelTracingDdiTable = {};
         std::atomic<ze_dditable_t *> pTracingZeDdiTable = {nullptr};
-        std::atomic<zet_dditable_t *> pTracingZetDdiTable = {nullptr};
-        std::atomic<zes_dditable_t *> pTracingZesDdiTable = {nullptr};
         ze_dditable_t initialzeDdiTable;
         zet_dditable_t initialzetDdiTable;
         zes_dditable_t initialzesDdiTable;

--- a/source/loader/ze_loader_api.cpp
+++ b/source/loader/ze_loader_api.cpp
@@ -50,13 +50,11 @@ zeLoaderGetTracingHandle()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Internal function for Setting the ddi tables for the Tracing Layer.
+/// @brief Internal function for Setting the ddi table for the Tracing Layer.
 ///
 ZE_DLLEXPORT ze_result_t ZE_APICALL
-zelLoaderTracingLayerInit(std::atomic<ze_dditable_t *> &zeDdiTable, std::atomic<zet_dditable_t *> &zetDdiTable, std::atomic<zes_dditable_t *> &zesDdiTable) {
+zelLoaderTracingLayerInit(std::atomic<ze_dditable_t *> &zeDdiTable) {
     zeDdiTable.store(&loader::context->tracing_dditable.ze);
-    zetDdiTable.store(&loader::context->tracing_dditable.zet);
-    zesDdiTable.store(&loader::context->tracing_dditable.zes);
     return ZE_RESULT_SUCCESS;
 }
 

--- a/source/loader/ze_loader_api.h
+++ b/source/loader/ze_loader_api.h
@@ -37,10 +37,10 @@ zelLoaderDriverCheck(ze_init_flags_t flags);
 
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Internal function for Setting the ddi tables for the Tracing Layer.
+/// @brief Internal function for Setting the ddi table for the Tracing Layer.
 ///
 ZE_DLLEXPORT ze_result_t ZE_APICALL
-zelLoaderTracingLayerInit(std::atomic<ze_dditable_t *> &zeDdiTable, std::atomic<zet_dditable_t *> &zetDdiTable, std::atomic<zes_dditable_t *> &zesDdiTable);
+zelLoaderTracingLayerInit(std::atomic<ze_dditable_t *> &zeDdiTable);
 
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Tracing DDI tables for zet and zes functions are not setup, but were being used as if they were. zelEnableTracingLayer will no longer replace zetDdiTable or zesDdiTable so that they can actually be used while tracing is enabled.