### PR TITLE
Fix first zeinit to allow for layer checks

### DIFF
--- a/source/lib/ze_lib.cpp
+++ b/source/lib/ze_lib.cpp
@@ -108,7 +108,7 @@ namespace ze_lib
         {
             // Check which drivers support the ze_driver_flag_t specified
             // No need to check if only initializing sysman
-            result = zelLoaderDriverCheck(flags);
+            result = zelLoaderDriverCheck(flags, &ze_lib::context->initialzeDdiTable.Global);
         }
 
         if( ZE_RESULT_SUCCESS == result )

--- a/source/loader/ze_loader_api.cpp
+++ b/source/loader/ze_loader_api.cpp
@@ -33,9 +33,9 @@ zeLoaderInit()
 ///     - ::ZE_RESULT_SUCCESS
 ///     - ::ZE_RESULT_ERROR_UNINITIALIZED
 ZE_DLLEXPORT ze_result_t ZE_APICALL
-zelLoaderDriverCheck(ze_init_flags_t flags)
+zelLoaderDriverCheck(ze_init_flags_t flags, ze_global_dditable_t *globalInitStored)
 {
-    return loader::context->check_drivers(flags);
+    return loader::context->check_drivers(flags, globalInitStored);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/source/loader/ze_loader_api.h
+++ b/source/loader/ze_loader_api.h
@@ -33,7 +33,7 @@ zeLoaderInit();
 ///     - ::ZE_RESULT_SUCCESS
 ///     - ::ZE_RESULT_ERROR_UNINITIALIZED
 ZE_DLLEXPORT ze_result_t ZE_APICALL
-zelLoaderDriverCheck(ze_init_flags_t flags);
+zelLoaderDriverCheck(ze_init_flags_t flags, ze_global_dditable_t *globalInitStored);
 
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/source/loader/ze_loader_internal.h
+++ b/source/loader/ze_loader_internal.h
@@ -53,10 +53,10 @@ namespace loader
         std::vector<zel_component_version_t> compVersions;
         const char *LOADER_COMP_NAME = "loader";
 
-        ze_result_t check_drivers(ze_init_flags_t flags);
+        ze_result_t check_drivers(ze_init_flags_t flags, ze_global_dditable_t *globalInitStored);
         void debug_trace_message(std::string errorMessage, std::string errorValue);
         ze_result_t init();
-        ze_result_t init_driver(driver_t driver, ze_init_flags_t flags);
+        ze_result_t init_driver(driver_t driver, ze_init_flags_t flags, ze_global_dditable_t *globalInitStored);
         void add_loader_version();
         ~context_t();
         bool intercept_enabled = false;


### PR DESCRIPTION
- Use ddi table init of zeinit for the first call to zeInit to enable intercept in layers.