### PR TITLE
Fix global teardown of loader handles and check driver status in init_driver

### DIFF
--- a/source/lib/ze_lib.cpp
+++ b/source/lib/ze_lib.cpp
@@ -111,7 +111,9 @@ namespace ze_lib
             bool requireDdiReinit = false;
             result = zelLoaderDriverCheck(flags, &ze_lib::context->initialzeDdiTable.Global, &requireDdiReinit);
             // If a driver was removed from the driver list, then the ddi tables need to be reinit to allow for passthru directly to the driver.
-            if (requireDdiReinit) {
+            // If ZET_ENABLE_PROGRAM_INSTRUMENTATION is enabled, then reInit is not possible due to the functions being intercepted with the previous ddi tables.
+            auto programInstrumentationEnabled = getenv_tobool( "ZET_ENABLE_PROGRAM_INSTRUMENTATION" );
+            if (requireDdiReinit && !programInstrumentationEnabled) {
                 // reInit the ZE DDI Tables
                 if( ZE_RESULT_SUCCESS == result )
                 {

--- a/source/lib/ze_lib.cpp
+++ b/source/lib/ze_lib.cpp
@@ -108,7 +108,26 @@ namespace ze_lib
         {
             // Check which drivers support the ze_driver_flag_t specified
             // No need to check if only initializing sysman
-            result = zelLoaderDriverCheck(flags, &ze_lib::context->initialzeDdiTable.Global);
+            bool requireDdiReinit = false;
+            result = zelLoaderDriverCheck(flags, &ze_lib::context->initialzeDdiTable.Global, &requireDdiReinit);
+            // If a driver was removed from the driver list, then the ddi tables need to be reinit to allow for passthru directly to the driver.
+            if (requireDdiReinit) {
+                // reInit the ZE DDI Tables
+                if( ZE_RESULT_SUCCESS == result )
+                {
+                    result = zeDdiTableInit();
+                }
+                // reInit the ZET DDI Tables
+                if( ZE_RESULT_SUCCESS == result )
+                {
+                    result = zetDdiTableInit();
+                }
+                // reInit the ZES DDI Tables
+                if( ZE_RESULT_SUCCESS == result )
+                {
+                    result = zesDdiTableInit();
+                }
+            }
         }
 
         if( ZE_RESULT_SUCCESS == result )

--- a/source/loader/ze_ldrddi.cpp
+++ b/source/loader/ze_ldrddi.cpp
@@ -12,29 +12,6 @@
 namespace loader
 {
     ///////////////////////////////////////////////////////////////////////////////
-    ze_driver_factory_t                 ze_driver_factory;
-    ze_device_factory_t                 ze_device_factory;
-    ze_context_factory_t                ze_context_factory;
-    ze_command_queue_factory_t          ze_command_queue_factory;
-    ze_command_list_factory_t           ze_command_list_factory;
-    ze_fence_factory_t                  ze_fence_factory;
-    ze_event_pool_factory_t             ze_event_pool_factory;
-    ze_event_factory_t                  ze_event_factory;
-    ze_image_factory_t                  ze_image_factory;
-    ze_module_factory_t                 ze_module_factory;
-    ze_module_build_log_factory_t       ze_module_build_log_factory;
-    ze_kernel_factory_t                 ze_kernel_factory;
-    ze_sampler_factory_t                ze_sampler_factory;
-    ze_physical_mem_factory_t           ze_physical_mem_factory;
-    ze_fabric_vertex_factory_t          ze_fabric_vertex_factory;
-    ze_fabric_edge_factory_t            ze_fabric_edge_factory;
-    ze_rtas_builder_exp_factory_t       ze_rtas_builder_exp_factory;
-    ze_rtas_parallel_operation_exp_factory_t    ze_rtas_parallel_operation_exp_factory;
-    ///////////////////////////////////////////////////////////////////////////////
-    std::unordered_map<ze_image_object_t *, ze_image_handle_t>            image_handle_map;
-    std::unordered_map<ze_sampler_object_t *, ze_sampler_handle_t>        sampler_handle_map;
-
-    ///////////////////////////////////////////////////////////////////////////////
     /// @brief Intercept function for zeInit
     __zedlllocal ze_result_t ZE_APICALL
     zeInit(
@@ -110,7 +87,7 @@ namespace loader
                     for( uint32_t i = 0; i < library_driver_handle_count; ++i ) {
                         uint32_t driver_index = total_driver_handle_count + i;
                         phDrivers[ driver_index ] = reinterpret_cast<ze_driver_handle_t>(
-                            ze_driver_factory.getInstance( phDrivers[ driver_index ], &drv.dditable ) );
+                            context->ze_driver_factory.getInstance( phDrivers[ driver_index ], &drv.dditable ) );
                     }
                 }
                 catch( std::bad_alloc& )
@@ -330,7 +307,7 @@ namespace loader
             // convert driver handles to loader handles
             for( size_t i = 0; ( nullptr != phDevices ) && ( i < *pCount ); ++i )
                 phDevices[ i ] = reinterpret_cast<ze_device_handle_t>(
-                    ze_device_factory.getInstance( phDevices[ i ], dditable ) );
+                    context->ze_device_factory.getInstance( phDevices[ i ], dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -369,7 +346,7 @@ namespace loader
         {
             // convert driver handle to loader handle
             *phRootDevice = reinterpret_cast<ze_device_handle_t>(
-                ze_device_factory.getInstance( *phRootDevice, dditable ) );
+                context->ze_device_factory.getInstance( *phRootDevice, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -416,7 +393,7 @@ namespace loader
             // convert driver handles to loader handles
             for( size_t i = 0; ( nullptr != phSubdevices ) && ( i < *pCount ); ++i )
                 phSubdevices[ i ] = reinterpret_cast<ze_device_handle_t>(
-                    ze_device_factory.getInstance( phSubdevices[ i ], dditable ) );
+                    context->ze_device_factory.getInstance( phSubdevices[ i ], dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -818,7 +795,7 @@ namespace loader
         {
             // convert driver handle to loader handle
             *phContext = reinterpret_cast<ze_context_handle_t>(
-                ze_context_factory.getInstance( *phContext, dditable ) );
+                context->ze_context_factory.getInstance( *phContext, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -874,7 +851,7 @@ namespace loader
         {
             // convert driver handle to loader handle
             *phContext = reinterpret_cast<ze_context_handle_t>(
-                ze_context_factory.getInstance( *phContext, dditable ) );
+                context->ze_context_factory.getInstance( *phContext, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -909,7 +886,7 @@ namespace loader
             return result;
 
         // release loader handle
-        ze_context_factory.release( hContext );
+        context->ze_context_factory.release( hContext );
 
         return result;
     }
@@ -972,7 +949,7 @@ namespace loader
         {
             // convert driver handle to loader handle
             *phCommandQueue = reinterpret_cast<ze_command_queue_handle_t>(
-                ze_command_queue_factory.getInstance( *phCommandQueue, dditable ) );
+                context->ze_command_queue_factory.getInstance( *phCommandQueue, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -1007,7 +984,7 @@ namespace loader
             return result;
 
         // release loader handle
-        ze_command_queue_factory.release( hCommandQueue );
+        context->ze_command_queue_factory.release( hCommandQueue );
 
         return result;
     }
@@ -1164,7 +1141,7 @@ namespace loader
         {
             // convert driver handle to loader handle
             *phCommandList = reinterpret_cast<ze_command_list_handle_t>(
-                ze_command_list_factory.getInstance( *phCommandList, dditable ) );
+                context->ze_command_list_factory.getInstance( *phCommandList, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -1208,7 +1185,7 @@ namespace loader
         {
             // convert driver handle to loader handle
             *phCommandList = reinterpret_cast<ze_command_list_handle_t>(
-                ze_command_list_factory.getInstance( *phCommandList, dditable ) );
+                context->ze_command_list_factory.getInstance( *phCommandList, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -1243,7 +1220,7 @@ namespace loader
             return result;
 
         // release loader handle
-        ze_command_list_factory.release( hCommandList );
+        context->ze_command_list_factory.release( hCommandList );
 
         return result;
     }
@@ -1396,7 +1373,7 @@ namespace loader
         {
             // convert driver handle to loader handle
             *phDevice = reinterpret_cast<ze_device_handle_t>(
-                ze_device_factory.getInstance( *phDevice, dditable ) );
+                context->ze_device_factory.getInstance( *phDevice, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -1435,7 +1412,7 @@ namespace loader
         {
             // convert driver handle to loader handle
             *phContext = reinterpret_cast<ze_context_handle_t>(
-                ze_context_factory.getInstance( *phContext, dditable ) );
+                context->ze_context_factory.getInstance( *phContext, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -2088,7 +2065,7 @@ namespace loader
         {
             // convert driver handle to loader handle
             *phEventPool = reinterpret_cast<ze_event_pool_handle_t>(
-                ze_event_pool_factory.getInstance( *phEventPool, dditable ) );
+                context->ze_event_pool_factory.getInstance( *phEventPool, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -2123,7 +2100,7 @@ namespace loader
             return result;
 
         // release loader handle
-        ze_event_pool_factory.release( hEventPool );
+        context->ze_event_pool_factory.release( hEventPool );
 
         return result;
     }
@@ -2158,7 +2135,7 @@ namespace loader
         {
             // convert driver handle to loader handle
             *phEvent = reinterpret_cast<ze_event_handle_t>(
-                ze_event_factory.getInstance( *phEvent, dditable ) );
+                context->ze_event_factory.getInstance( *phEvent, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -2193,7 +2170,7 @@ namespace loader
             return result;
 
         // release loader handle
-        ze_event_factory.release( hEvent );
+        context->ze_event_factory.release( hEvent );
 
         return result;
     }
@@ -2280,7 +2257,7 @@ namespace loader
         {
             // convert driver handle to loader handle
             *phEventPool = reinterpret_cast<ze_event_pool_handle_t>(
-                ze_event_pool_factory.getInstance( *phEventPool, dditable ) );
+                context->ze_event_pool_factory.getInstance( *phEventPool, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -2315,7 +2292,7 @@ namespace loader
             return result;
 
         // release loader handle
-        ze_event_pool_factory.release( hEventPool );
+        context->ze_event_pool_factory.release( hEventPool );
 
         return result;
     }
@@ -2617,7 +2594,7 @@ namespace loader
         {
             // convert driver handle to loader handle
             *phEventPool = reinterpret_cast<ze_event_pool_handle_t>(
-                ze_event_pool_factory.getInstance( *phEventPool, dditable ) );
+                context->ze_event_pool_factory.getInstance( *phEventPool, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -2710,7 +2687,7 @@ namespace loader
         {
             // convert driver handle to loader handle
             *phContext = reinterpret_cast<ze_context_handle_t>(
-                ze_context_factory.getInstance( *phContext, dditable ) );
+                context->ze_context_factory.getInstance( *phContext, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -2776,7 +2753,7 @@ namespace loader
         {
             // convert driver handle to loader handle
             *phFence = reinterpret_cast<ze_fence_handle_t>(
-                ze_fence_factory.getInstance( *phFence, dditable ) );
+                context->ze_fence_factory.getInstance( *phFence, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -2811,7 +2788,7 @@ namespace loader
             return result;
 
         // release loader handle
-        ze_fence_factory.release( hFence );
+        context->ze_fence_factory.release( hFence );
 
         return result;
     }
@@ -2956,9 +2933,9 @@ namespace loader
             // convert driver handle to loader handle
             ze_image_handle_t internalHandlePtr = *phImage;
             *phImage = reinterpret_cast<ze_image_handle_t>(
-                ze_image_factory.getInstance( *phImage, dditable ) );
+                context->ze_image_factory.getInstance( *phImage, dditable ) );
             // convert loader handle to driver handle and store in map
-            image_handle_map.insert({ze_image_factory.getInstance( internalHandlePtr, dditable ), internalHandlePtr});
+            context->image_handle_map.insert({context->ze_image_factory.getInstance( internalHandlePtr, dditable ), internalHandlePtr});
         }
         catch( std::bad_alloc& )
         {
@@ -2984,7 +2961,7 @@ namespace loader
             return ZE_RESULT_ERROR_UNINITIALIZED;
 
         // remove the handle from the kernel arugment map
-        image_handle_map.erase(reinterpret_cast<ze_image_object_t*>(hImage));
+        context->image_handle_map.erase(reinterpret_cast<ze_image_object_t*>(hImage));
         // convert loader handle to driver handle
         hImage = reinterpret_cast<ze_image_object_t*>( hImage )->handle;
 
@@ -2995,7 +2972,7 @@ namespace loader
             return result;
 
         // release loader handle
-        ze_image_factory.release( hImage );
+        context->ze_image_factory.release( hImage );
 
         return result;
     }
@@ -3156,7 +3133,7 @@ namespace loader
             // convert driver handle to loader handle
             if( nullptr != phDevice )
                 *phDevice = reinterpret_cast<ze_device_handle_t>(
-                    ze_device_factory.getInstance( *phDevice, dditable ) );
+                    context->ze_device_factory.getInstance( *phDevice, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -3448,7 +3425,7 @@ namespace loader
         {
             // convert driver handle to loader handle
             *phModule = reinterpret_cast<ze_module_handle_t>(
-                ze_module_factory.getInstance( *phModule, dditable ) );
+                context->ze_module_factory.getInstance( *phModule, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -3463,7 +3440,7 @@ namespace loader
             // convert driver handle to loader handle
             if( nullptr != phBuildLog )
                 *phBuildLog = reinterpret_cast<ze_module_build_log_handle_t>(
-                    ze_module_build_log_factory.getInstance( *phBuildLog, dditable ) );
+                    context->ze_module_build_log_factory.getInstance( *phBuildLog, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -3498,7 +3475,7 @@ namespace loader
             return result;
 
         // release loader handle
-        ze_module_factory.release( hModule );
+        context->ze_module_factory.release( hModule );
 
         return result;
     }
@@ -3535,7 +3512,7 @@ namespace loader
             // convert driver handle to loader handle
             if( nullptr != phLinkLog )
                 *phLinkLog = reinterpret_cast<ze_module_build_log_handle_t>(
-                    ze_module_build_log_factory.getInstance( *phLinkLog, dditable ) );
+                    context->ze_module_build_log_factory.getInstance( *phLinkLog, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -3573,7 +3550,7 @@ namespace loader
             return result;
 
         // release loader handle
-        ze_module_build_log_factory.release( hModuleBuildLog );
+        context->ze_module_build_log_factory.release( hModuleBuildLog );
 
         return result;
     }
@@ -3744,7 +3721,7 @@ namespace loader
         {
             // convert driver handle to loader handle
             *phKernel = reinterpret_cast<ze_kernel_handle_t>(
-                ze_kernel_factory.getInstance( *phKernel, dditable ) );
+                context->ze_kernel_factory.getInstance( *phKernel, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -3779,7 +3756,7 @@ namespace loader
             return result;
 
         // release loader handle
-        ze_kernel_factory.release( hKernel );
+        context->ze_kernel_factory.release( hKernel );
 
         return result;
     }
@@ -3920,10 +3897,10 @@ namespace loader
             // check if the arg value is a translated handle
             ze_image_object_t **imageHandle = static_cast<ze_image_object_t **>(internalArgValue);
             ze_sampler_object_t **samplerHandle = static_cast<ze_sampler_object_t **>(internalArgValue);
-            if( image_handle_map.find(*imageHandle) != image_handle_map.end() ) {
-                internalArgValue = &image_handle_map[*imageHandle];
-            } else if( sampler_handle_map.find(*samplerHandle) != sampler_handle_map.end() ) {
-                internalArgValue = &sampler_handle_map[*samplerHandle];
+            if( context->image_handle_map.find(*imageHandle) != context->image_handle_map.end() ) {
+                internalArgValue = &context->image_handle_map[*imageHandle];
+            } else if( context->sampler_handle_map.find(*samplerHandle) != context->sampler_handle_map.end() ) {
+                internalArgValue = &context->sampler_handle_map[*samplerHandle];
             }
         }
         // forward to device-driver
@@ -4433,9 +4410,9 @@ namespace loader
             // convert driver handle to loader handle
             ze_sampler_handle_t internalHandlePtr = *phSampler;
             *phSampler = reinterpret_cast<ze_sampler_handle_t>(
-                ze_sampler_factory.getInstance( *phSampler, dditable ) );
+                context->ze_sampler_factory.getInstance( *phSampler, dditable ) );
             // convert loader handle to driver handle and store in map
-            sampler_handle_map.insert({ze_sampler_factory.getInstance( internalHandlePtr, dditable ), internalHandlePtr});
+            context->sampler_handle_map.insert({context->ze_sampler_factory.getInstance( internalHandlePtr, dditable ), internalHandlePtr});
         }
         catch( std::bad_alloc& )
         {
@@ -4461,7 +4438,7 @@ namespace loader
             return ZE_RESULT_ERROR_UNINITIALIZED;
 
         // remove the handle from the kernel arugment map
-        sampler_handle_map.erase(reinterpret_cast<ze_sampler_object_t*>(hSampler));
+        context->sampler_handle_map.erase(reinterpret_cast<ze_sampler_object_t*>(hSampler));
         // convert loader handle to driver handle
         hSampler = reinterpret_cast<ze_sampler_object_t*>( hSampler )->handle;
 
@@ -4472,7 +4449,7 @@ namespace loader
             return result;
 
         // release loader handle
-        ze_sampler_factory.release( hSampler );
+        context->ze_sampler_factory.release( hSampler );
 
         return result;
     }
@@ -4596,7 +4573,7 @@ namespace loader
         {
             // convert driver handle to loader handle
             *phPhysicalMemory = reinterpret_cast<ze_physical_mem_handle_t>(
-                ze_physical_mem_factory.getInstance( *phPhysicalMemory, dditable ) );
+                context->ze_physical_mem_factory.getInstance( *phPhysicalMemory, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -4635,7 +4612,7 @@ namespace loader
             return result;
 
         // release loader handle
-        ze_physical_mem_factory.release( hPhysicalMemory );
+        context->ze_physical_mem_factory.release( hPhysicalMemory );
 
         return result;
     }
@@ -4940,7 +4917,7 @@ namespace loader
         {
             // convert driver handle to loader handle
             *phImageView = reinterpret_cast<ze_image_handle_t>(
-                ze_image_factory.getInstance( *phImageView, dditable ) );
+                context->ze_image_factory.getInstance( *phImageView, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -4989,9 +4966,9 @@ namespace loader
             // convert driver handle to loader handle
             ze_image_handle_t internalHandlePtr = *phImageView;
             *phImageView = reinterpret_cast<ze_image_handle_t>(
-                ze_image_factory.getInstance( *phImageView, dditable ) );
+                context->ze_image_factory.getInstance( *phImageView, dditable ) );
             // convert loader handle to driver handle and store in map
-            image_handle_map.insert({ze_image_factory.getInstance( internalHandlePtr, dditable ), internalHandlePtr});
+            context->image_handle_map.insert({context->ze_image_factory.getInstance( internalHandlePtr, dditable ), internalHandlePtr});
         }
         catch( std::bad_alloc& )
         {
@@ -5212,7 +5189,7 @@ namespace loader
         {
             // convert driver handle to loader handle
             *phLog = reinterpret_cast<ze_module_build_log_handle_t>(
-                ze_module_build_log_factory.getInstance( *phLog, dditable ) );
+                context->ze_module_build_log_factory.getInstance( *phLog, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -5286,7 +5263,7 @@ namespace loader
             // convert driver handles to loader handles
             for( size_t i = 0; ( nullptr != phVertices ) && ( i < *pCount ); ++i )
                 phVertices[ i ] = reinterpret_cast<ze_fabric_vertex_handle_t>(
-                    ze_fabric_vertex_factory.getInstance( phVertices[ i ], dditable ) );
+                    context->ze_fabric_vertex_factory.getInstance( phVertices[ i ], dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -5334,7 +5311,7 @@ namespace loader
             // convert driver handles to loader handles
             for( size_t i = 0; ( nullptr != phSubvertices ) && ( i < *pCount ); ++i )
                 phSubvertices[ i ] = reinterpret_cast<ze_fabric_vertex_handle_t>(
-                    ze_fabric_vertex_factory.getInstance( phSubvertices[ i ], dditable ) );
+                    context->ze_fabric_vertex_factory.getInstance( phSubvertices[ i ], dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -5398,7 +5375,7 @@ namespace loader
         {
             // convert driver handle to loader handle
             *phDevice = reinterpret_cast<ze_device_handle_t>(
-                ze_device_factory.getInstance( *phDevice, dditable ) );
+                context->ze_device_factory.getInstance( *phDevice, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -5437,7 +5414,7 @@ namespace loader
         {
             // convert driver handle to loader handle
             *phVertex = reinterpret_cast<ze_fabric_vertex_handle_t>(
-                ze_fabric_vertex_factory.getInstance( *phVertex, dditable ) );
+                context->ze_fabric_vertex_factory.getInstance( *phVertex, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -5489,7 +5466,7 @@ namespace loader
             // convert driver handles to loader handles
             for( size_t i = 0; ( nullptr != phEdges ) && ( i < *pCount ); ++i )
                 phEdges[ i ] = reinterpret_cast<ze_fabric_edge_handle_t>(
-                    ze_fabric_edge_factory.getInstance( phEdges[ i ], dditable ) );
+                    context->ze_fabric_edge_factory.getInstance( phEdges[ i ], dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -5529,7 +5506,7 @@ namespace loader
         {
             // convert driver handle to loader handle
             *phVertexA = reinterpret_cast<ze_fabric_vertex_handle_t>(
-                ze_fabric_vertex_factory.getInstance( *phVertexA, dditable ) );
+                context->ze_fabric_vertex_factory.getInstance( *phVertexA, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -5540,7 +5517,7 @@ namespace loader
         {
             // convert driver handle to loader handle
             *phVertexB = reinterpret_cast<ze_fabric_vertex_handle_t>(
-                ze_fabric_vertex_factory.getInstance( *phVertexB, dditable ) );
+                context->ze_fabric_vertex_factory.getInstance( *phVertexB, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -5648,7 +5625,7 @@ namespace loader
         {
             // convert driver handle to loader handle
             *phBuilder = reinterpret_cast<ze_rtas_builder_exp_handle_t>(
-                ze_rtas_builder_exp_factory.getInstance( *phBuilder, dditable ) );
+                context->ze_rtas_builder_exp_factory.getInstance( *phBuilder, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -5774,7 +5751,7 @@ namespace loader
             return result;
 
         // release loader handle
-        ze_rtas_builder_exp_factory.release( hBuilder );
+        context->ze_rtas_builder_exp_factory.release( hBuilder );
 
         return result;
     }
@@ -5808,7 +5785,7 @@ namespace loader
         {
             // convert driver handle to loader handle
             *phParallelOperation = reinterpret_cast<ze_rtas_parallel_operation_exp_handle_t>(
-                ze_rtas_parallel_operation_exp_factory.getInstance( *phParallelOperation, dditable ) );
+                context->ze_rtas_parallel_operation_exp_factory.getInstance( *phParallelOperation, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -5892,7 +5869,7 @@ namespace loader
             return result;
 
         // release loader handle
-        ze_rtas_parallel_operation_exp_factory.release( hParallelOperation );
+        context->ze_rtas_parallel_operation_exp_factory.release( hParallelOperation );
 
         return result;
     }
@@ -5983,7 +5960,7 @@ namespace loader
         {
             // convert driver handle to loader handle
             *phClonedCommandList = reinterpret_cast<ze_command_list_handle_t>(
-                ze_command_list_factory.getInstance( *phClonedCommandList, dditable ) );
+                context->ze_command_list_factory.getInstance( *phClonedCommandList, dditable ) );
         }
         catch( std::bad_alloc& )
         {

--- a/source/loader/ze_loader.cpp
+++ b/source/loader/ze_loader.cpp
@@ -211,6 +211,10 @@ namespace loader
 
         // Use the previously init ddi table pointer to zeInit to allow for intercept of the zeInit calls
         ze_result_t res = globalInitStored->pfnInit(flags);
+        // Verify that this driver successfully init in the call above.
+        if (driver.initStatus != ZE_RESULT_SUCCESS) {
+            res = driver.initStatus;
+        }
         if (debugTraceEnabled) {
             std::string message = "init driver " + driver.name + " zeInit(" + loader::to_string(flags) + ") returning ";
             debug_trace_message(message, loader::to_string(res));

--- a/source/loader/ze_loader.cpp
+++ b/source/loader/ze_loader.cpp
@@ -124,7 +124,7 @@ namespace loader
         }
     }
 
-    ze_result_t context_t::check_drivers(ze_init_flags_t flags, ze_global_dditable_t *globalInitStored) {
+    ze_result_t context_t::check_drivers(ze_init_flags_t flags, ze_global_dditable_t *globalInitStored, bool *requireDdiReinit) {
         if (debugTraceEnabled) {
             std::string message = "check_drivers(" + std::string("flags=") + loader::to_string(flags) + ")";
             debug_trace_message(message, "");
@@ -156,6 +156,7 @@ namespace loader
                     debug_trace_message(errorMessage, loader::to_string(result));
                 }
                 it = drivers.erase(it);
+                *requireDdiReinit = true;
                 if(return_first_driver_result)
                     return result;
             }

--- a/source/loader/ze_loader.cpp
+++ b/source/loader/ze_loader.cpp
@@ -156,7 +156,10 @@ namespace loader
                     debug_trace_message(errorMessage, loader::to_string(result));
                 }
                 it = drivers.erase(it);
-                *requireDdiReinit = true;
+                // If the number of drivers is now ==1, then we need to reinit the ddi tables to pass through.
+                if (drivers.size() == 1) {
+                    *requireDdiReinit = true;
+                }
                 if(return_first_driver_result)
                     return result;
             }

--- a/source/loader/ze_loader_api.cpp
+++ b/source/loader/ze_loader_api.cpp
@@ -33,9 +33,9 @@ zeLoaderInit()
 ///     - ::ZE_RESULT_SUCCESS
 ///     - ::ZE_RESULT_ERROR_UNINITIALIZED
 ZE_DLLEXPORT ze_result_t ZE_APICALL
-zelLoaderDriverCheck(ze_init_flags_t flags, ze_global_dditable_t *globalInitStored)
+zelLoaderDriverCheck(ze_init_flags_t flags, ze_global_dditable_t *globalInitStored, bool *requireDdiReinit)
 {
-    return loader::context->check_drivers(flags, globalInitStored);
+    return loader::context->check_drivers(flags, globalInitStored, requireDdiReinit);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/source/loader/ze_loader_api.h
+++ b/source/loader/ze_loader_api.h
@@ -33,7 +33,7 @@ zeLoaderInit();
 ///     - ::ZE_RESULT_SUCCESS
 ///     - ::ZE_RESULT_ERROR_UNINITIALIZED
 ZE_DLLEXPORT ze_result_t ZE_APICALL
-zelLoaderDriverCheck(ze_init_flags_t flags, ze_global_dditable_t *globalInitStored);
+zelLoaderDriverCheck(ze_init_flags_t flags, ze_global_dditable_t *globalInitStored, bool *requireDdiReinit);
 
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/source/loader/ze_loader_internal.h
+++ b/source/loader/ze_loader_internal.h
@@ -41,6 +41,63 @@ namespace loader
     class context_t
     {
     public:
+        ///////////////////////////////////////////////////////////////////////////////
+        ze_driver_factory_t                 ze_driver_factory;
+        ze_device_factory_t                 ze_device_factory;
+        ze_context_factory_t                ze_context_factory;
+        ze_command_queue_factory_t          ze_command_queue_factory;
+        ze_command_list_factory_t           ze_command_list_factory;
+        ze_fence_factory_t                  ze_fence_factory;
+        ze_event_pool_factory_t             ze_event_pool_factory;
+        ze_event_factory_t                  ze_event_factory;
+        ze_image_factory_t                  ze_image_factory;
+        ze_module_factory_t                 ze_module_factory;
+        ze_module_build_log_factory_t       ze_module_build_log_factory;
+        ze_kernel_factory_t                 ze_kernel_factory;
+        ze_sampler_factory_t                ze_sampler_factory;
+        ze_physical_mem_factory_t           ze_physical_mem_factory;
+        ze_fabric_vertex_factory_t          ze_fabric_vertex_factory;
+        ze_fabric_edge_factory_t            ze_fabric_edge_factory;
+        ze_rtas_builder_exp_factory_t       ze_rtas_builder_exp_factory;
+        ze_rtas_parallel_operation_exp_factory_t    ze_rtas_parallel_operation_exp_factory;
+        ///////////////////////////////////////////////////////////////////////////////
+        zes_driver_factory_t                zes_driver_factory;
+        zes_device_factory_t                zes_device_factory;
+        zes_sched_factory_t                 zes_sched_factory;
+        zes_perf_factory_t                  zes_perf_factory;
+        zes_pwr_factory_t                   zes_pwr_factory;
+        zes_freq_factory_t                  zes_freq_factory;
+        zes_engine_factory_t                zes_engine_factory;
+        zes_standby_factory_t               zes_standby_factory;
+        zes_firmware_factory_t              zes_firmware_factory;
+        zes_mem_factory_t                   zes_mem_factory;
+        zes_fabric_port_factory_t           zes_fabric_port_factory;
+        zes_temp_factory_t                  zes_temp_factory;
+        zes_psu_factory_t                   zes_psu_factory;
+        zes_fan_factory_t                   zes_fan_factory;
+        zes_led_factory_t                   zes_led_factory;
+        zes_ras_factory_t                   zes_ras_factory;
+        zes_diag_factory_t                  zes_diag_factory;
+        zes_overclock_factory_t             zes_overclock_factory;
+        zes_vf_factory_t                    zes_vf_factory;
+        ///////////////////////////////////////////////////////////////////////////////
+        zet_driver_factory_t                zet_driver_factory;
+        zet_device_factory_t                zet_device_factory;
+        zet_context_factory_t               zet_context_factory;
+        zet_command_list_factory_t          zet_command_list_factory;
+        zet_module_factory_t                zet_module_factory;
+        zet_kernel_factory_t                zet_kernel_factory;
+        zet_metric_group_factory_t          zet_metric_group_factory;
+        zet_metric_factory_t                zet_metric_factory;
+        zet_metric_streamer_factory_t       zet_metric_streamer_factory;
+        zet_metric_query_pool_factory_t     zet_metric_query_pool_factory;
+        zet_metric_query_factory_t          zet_metric_query_factory;
+        zet_tracer_exp_factory_t            zet_tracer_exp_factory;
+        zet_debug_session_factory_t         zet_debug_session_factory;
+        zet_metric_programmable_exp_factory_t   zet_metric_programmable_exp_factory;
+        ///////////////////////////////////////////////////////////////////////////////
+        std::unordered_map<ze_image_object_t *, ze_image_handle_t>            image_handle_map;
+        std::unordered_map<ze_sampler_object_t *, ze_sampler_handle_t>        sampler_handle_map;
         ze_api_version_t version = ZE_API_VERSION_CURRENT;
 
         driver_vector_t drivers;
@@ -67,5 +124,4 @@ namespace loader
     };
 
     extern context_t *context;
-    extern ze_event_factory_t ze_event_factory;
 }

--- a/source/loader/ze_loader_internal.h
+++ b/source/loader/ze_loader_internal.h
@@ -110,7 +110,7 @@ namespace loader
         std::vector<zel_component_version_t> compVersions;
         const char *LOADER_COMP_NAME = "loader";
 
-        ze_result_t check_drivers(ze_init_flags_t flags, ze_global_dditable_t *globalInitStored);
+        ze_result_t check_drivers(ze_init_flags_t flags, ze_global_dditable_t *globalInitStored, bool *requireDdiReinit);
         void debug_trace_message(std::string errorMessage, std::string errorValue);
         ze_result_t init();
         ze_result_t init_driver(driver_t driver, ze_init_flags_t flags, ze_global_dditable_t *globalInitStored);

--- a/source/loader/ze_object.h
+++ b/source/loader/ze_object.h
@@ -20,7 +20,7 @@ struct dditable_t
 
 //////////////////////////////////////////////////////////////////////////
 template<typename _handle_t>
-class __zedlllocal object_t
+class object_t
 {
 public:
     using handle_t = _handle_t;

--- a/source/loader/zes_ldrddi.cpp
+++ b/source/loader/zes_ldrddi.cpp
@@ -12,27 +12,6 @@
 namespace loader
 {
     ///////////////////////////////////////////////////////////////////////////////
-    zes_driver_factory_t                zes_driver_factory;
-    zes_device_factory_t                zes_device_factory;
-    zes_sched_factory_t                 zes_sched_factory;
-    zes_perf_factory_t                  zes_perf_factory;
-    zes_pwr_factory_t                   zes_pwr_factory;
-    zes_freq_factory_t                  zes_freq_factory;
-    zes_engine_factory_t                zes_engine_factory;
-    zes_standby_factory_t               zes_standby_factory;
-    zes_firmware_factory_t              zes_firmware_factory;
-    zes_mem_factory_t                   zes_mem_factory;
-    zes_fabric_port_factory_t           zes_fabric_port_factory;
-    zes_temp_factory_t                  zes_temp_factory;
-    zes_psu_factory_t                   zes_psu_factory;
-    zes_fan_factory_t                   zes_fan_factory;
-    zes_led_factory_t                   zes_led_factory;
-    zes_ras_factory_t                   zes_ras_factory;
-    zes_diag_factory_t                  zes_diag_factory;
-    zes_overclock_factory_t             zes_overclock_factory;
-    zes_vf_factory_t                    zes_vf_factory;
-
-    ///////////////////////////////////////////////////////////////////////////////
     /// @brief Intercept function for zesInit
     __zedlllocal ze_result_t ZE_APICALL
     zesInit(
@@ -109,7 +88,7 @@ namespace loader
                     for( uint32_t i = 0; i < library_driver_handle_count; ++i ) {
                         uint32_t driver_index = total_driver_handle_count + i;
                         phDrivers[ driver_index ] = reinterpret_cast<zes_driver_handle_t>(
-                            zes_driver_factory.getInstance( phDrivers[ driver_index ], &drv.dditable ) );
+                            context->zes_driver_factory.getInstance( phDrivers[ driver_index ], &drv.dditable ) );
                     }
                 }
                 catch( std::bad_alloc& )
@@ -229,7 +208,7 @@ namespace loader
             // convert driver handles to loader handles
             for( size_t i = 0; ( nullptr != phDevices ) && ( i < *pCount ); ++i )
                 phDevices[ i ] = reinterpret_cast<zes_device_handle_t>(
-                    zes_device_factory.getInstance( phDevices[ i ], dditable ) );
+                    context->zes_device_factory.getInstance( phDevices[ i ], dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -657,7 +636,7 @@ namespace loader
             // convert driver handles to loader handles
             for( size_t i = 0; ( nullptr != phDomainHandle ) && ( i < *pCount ); ++i )
                 phDomainHandle[ i ] = reinterpret_cast<zes_overclock_handle_t>(
-                    zes_overclock_factory.getInstance( phDomainHandle[ i ], dditable ) );
+                    context->zes_overclock_factory.getInstance( phDomainHandle[ i ], dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -948,7 +927,7 @@ namespace loader
             // convert driver handles to loader handles
             for( size_t i = 0; ( nullptr != phDiagnostics ) && ( i < *pCount ); ++i )
                 phDiagnostics[ i ] = reinterpret_cast<zes_diag_handle_t>(
-                    zes_diag_factory.getInstance( phDiagnostics[ i ], dditable ) );
+                    context->zes_diag_factory.getInstance( phDiagnostics[ i ], dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -1187,7 +1166,7 @@ namespace loader
             // convert driver handles to loader handles
             for( size_t i = 0; ( nullptr != phEngine ) && ( i < *pCount ); ++i )
                 phEngine[ i ] = reinterpret_cast<zes_engine_handle_t>(
-                    zes_engine_factory.getInstance( phEngine[ i ], dditable ) );
+                    context->zes_engine_factory.getInstance( phEngine[ i ], dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -1407,7 +1386,7 @@ namespace loader
             // convert driver handles to loader handles
             for( size_t i = 0; ( nullptr != phPort ) && ( i < *pCount ); ++i )
                 phPort[ i ] = reinterpret_cast<zes_fabric_port_handle_t>(
-                    zes_fabric_port_factory.getInstance( phPort[ i ], dditable ) );
+                    context->zes_fabric_port_factory.getInstance( phPort[ i ], dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -1668,7 +1647,7 @@ namespace loader
             // convert driver handles to loader handles
             for( size_t i = 0; ( nullptr != phFan ) && ( i < *pCount ); ++i )
                 phFan[ i ] = reinterpret_cast<zes_fan_handle_t>(
-                    zes_fan_factory.getInstance( phFan[ i ], dditable ) );
+                    context->zes_fan_factory.getInstance( phFan[ i ], dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -1870,7 +1849,7 @@ namespace loader
             // convert driver handles to loader handles
             for( size_t i = 0; ( nullptr != phFirmware ) && ( i < *pCount ); ++i )
                 phFirmware[ i ] = reinterpret_cast<zes_firmware_handle_t>(
-                    zes_firmware_factory.getInstance( phFirmware[ i ], dditable ) );
+                    context->zes_firmware_factory.getInstance( phFirmware[ i ], dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -2023,7 +2002,7 @@ namespace loader
             // convert driver handles to loader handles
             for( size_t i = 0; ( nullptr != phFrequency ) && ( i < *pCount ); ++i )
                 phFrequency[ i ] = reinterpret_cast<zes_freq_handle_t>(
-                    zes_freq_factory.getInstance( phFrequency[ i ], dditable ) );
+                    context->zes_freq_factory.getInstance( phFrequency[ i ], dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -2527,7 +2506,7 @@ namespace loader
             // convert driver handles to loader handles
             for( size_t i = 0; ( nullptr != phLed ) && ( i < *pCount ); ++i )
                 phLed[ i ] = reinterpret_cast<zes_led_handle_t>(
-                    zes_led_factory.getInstance( phLed[ i ], dditable ) );
+                    context->zes_led_factory.getInstance( phLed[ i ], dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -2677,7 +2656,7 @@ namespace loader
             // convert driver handles to loader handles
             for( size_t i = 0; ( nullptr != phMemory ) && ( i < *pCount ); ++i )
                 phMemory[ i ] = reinterpret_cast<zes_mem_handle_t>(
-                    zes_mem_factory.getInstance( phMemory[ i ], dditable ) );
+                    context->zes_mem_factory.getInstance( phMemory[ i ], dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -2803,7 +2782,7 @@ namespace loader
             // convert driver handles to loader handles
             for( size_t i = 0; ( nullptr != phPerf ) && ( i < *pCount ); ++i )
                 phPerf[ i ] = reinterpret_cast<zes_perf_handle_t>(
-                    zes_perf_factory.getInstance( phPerf[ i ], dditable ) );
+                    context->zes_perf_factory.getInstance( phPerf[ i ], dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -2930,7 +2909,7 @@ namespace loader
             // convert driver handles to loader handles
             for( size_t i = 0; ( nullptr != phPower ) && ( i < *pCount ); ++i )
                 phPower[ i ] = reinterpret_cast<zes_pwr_handle_t>(
-                    zes_pwr_factory.getInstance( phPower[ i ], dditable ) );
+                    context->zes_pwr_factory.getInstance( phPower[ i ], dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -2969,7 +2948,7 @@ namespace loader
         {
             // convert driver handle to loader handle
             *phPower = reinterpret_cast<zes_pwr_handle_t>(
-                zes_pwr_factory.getInstance( *phPower, dditable ) );
+                context->zes_pwr_factory.getInstance( *phPower, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -3181,7 +3160,7 @@ namespace loader
             // convert driver handles to loader handles
             for( size_t i = 0; ( nullptr != phPsu ) && ( i < *pCount ); ++i )
                 phPsu[ i ] = reinterpret_cast<zes_psu_handle_t>(
-                    zes_psu_factory.getInstance( phPsu[ i ], dditable ) );
+                    context->zes_psu_factory.getInstance( phPsu[ i ], dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -3281,7 +3260,7 @@ namespace loader
             // convert driver handles to loader handles
             for( size_t i = 0; ( nullptr != phRas ) && ( i < *pCount ); ++i )
                 phRas[ i ] = reinterpret_cast<zes_ras_handle_t>(
-                    zes_ras_factory.getInstance( phRas[ i ], dditable ) );
+                    context->zes_ras_factory.getInstance( phRas[ i ], dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -3433,7 +3412,7 @@ namespace loader
             // convert driver handles to loader handles
             for( size_t i = 0; ( nullptr != phScheduler ) && ( i < *pCount ); ++i )
                 phScheduler[ i ] = reinterpret_cast<zes_sched_handle_t>(
-                    zes_sched_factory.getInstance( phScheduler[ i ], dditable ) );
+                    context->zes_sched_factory.getInstance( phScheduler[ i ], dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -3693,7 +3672,7 @@ namespace loader
             // convert driver handles to loader handles
             for( size_t i = 0; ( nullptr != phStandby ) && ( i < *pCount ); ++i )
                 phStandby[ i ] = reinterpret_cast<zes_standby_handle_t>(
-                    zes_standby_factory.getInstance( phStandby[ i ], dditable ) );
+                    context->zes_standby_factory.getInstance( phStandby[ i ], dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -3818,7 +3797,7 @@ namespace loader
             // convert driver handles to loader handles
             for( size_t i = 0; ( nullptr != phTemperature ) && ( i < *pCount ); ++i )
                 phTemperature[ i ] = reinterpret_cast<zes_temp_handle_t>(
-                    zes_temp_factory.getInstance( phTemperature[ i ], dditable ) );
+                    context->zes_temp_factory.getInstance( phTemperature[ i ], dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -4200,7 +4179,7 @@ namespace loader
         {
             // convert driver handle to loader handle
             *phDevice = reinterpret_cast<zes_device_handle_t>(
-                zes_device_factory.getInstance( *phDevice, dditable ) );
+                context->zes_device_factory.getInstance( *phDevice, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -4250,7 +4229,7 @@ namespace loader
             // convert driver handles to loader handles
             for( size_t i = 0; ( nullptr != phVFhandle ) && ( i < *pCount ); ++i )
                 phVFhandle[ i ] = reinterpret_cast<zes_vf_handle_t>(
-                    zes_vf_factory.getInstance( phVFhandle[ i ], dditable ) );
+                    context->zes_vf_factory.getInstance( phVFhandle[ i ], dditable ) );
         }
         catch( std::bad_alloc& )
         {

--- a/source/loader/zet_ldrddi.cpp
+++ b/source/loader/zet_ldrddi.cpp
@@ -12,22 +12,6 @@
 namespace loader
 {
     ///////////////////////////////////////////////////////////////////////////////
-    zet_driver_factory_t                zet_driver_factory;
-    zet_device_factory_t                zet_device_factory;
-    zet_context_factory_t               zet_context_factory;
-    zet_command_list_factory_t          zet_command_list_factory;
-    zet_module_factory_t                zet_module_factory;
-    zet_kernel_factory_t                zet_kernel_factory;
-    zet_metric_group_factory_t          zet_metric_group_factory;
-    zet_metric_factory_t                zet_metric_factory;
-    zet_metric_streamer_factory_t       zet_metric_streamer_factory;
-    zet_metric_query_pool_factory_t     zet_metric_query_pool_factory;
-    zet_metric_query_factory_t          zet_metric_query_factory;
-    zet_tracer_exp_factory_t            zet_tracer_exp_factory;
-    zet_debug_session_factory_t         zet_debug_session_factory;
-    zet_metric_programmable_exp_factory_t   zet_metric_programmable_exp_factory;
-
-    ///////////////////////////////////////////////////////////////////////////////
     /// @brief Intercept function for zetModuleGetDebugInfo
     __zedlllocal ze_result_t ZE_APICALL
     zetModuleGetDebugInfo(
@@ -109,7 +93,7 @@ namespace loader
         {
             // convert driver handle to loader handle
             *phDebug = reinterpret_cast<zet_debug_session_handle_t>(
-                zet_debug_session_factory.getInstance( *phDebug, dditable ) );
+                context->zet_debug_session_factory.getInstance( *phDebug, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -144,7 +128,7 @@ namespace loader
             return result;
 
         // release loader handle
-        zet_debug_session_factory.release( hDebug );
+        context->zet_debug_session_factory.release( hDebug );
 
         return result;
     }
@@ -485,7 +469,7 @@ namespace loader
             // convert driver handles to loader handles
             for( size_t i = 0; ( nullptr != phMetricGroups ) && ( i < *pCount ); ++i )
                 phMetricGroups[ i ] = reinterpret_cast<zet_metric_group_handle_t>(
-                    zet_metric_group_factory.getInstance( phMetricGroups[ i ], dditable ) );
+                    context->zet_metric_group_factory.getInstance( phMetricGroups[ i ], dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -593,7 +577,7 @@ namespace loader
             // convert driver handles to loader handles
             for( size_t i = 0; ( nullptr != phMetrics ) && ( i < *pCount ); ++i )
                 phMetrics[ i ] = reinterpret_cast<zet_metric_handle_t>(
-                    zet_metric_factory.getInstance( phMetrics[ i ], dditable ) );
+                    context->zet_metric_factory.getInstance( phMetrics[ i ], dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -710,7 +694,7 @@ namespace loader
         {
             // convert driver handle to loader handle
             *phMetricStreamer = reinterpret_cast<zet_metric_streamer_handle_t>(
-                zet_metric_streamer_factory.getInstance( *phMetricStreamer, dditable ) );
+                context->zet_metric_streamer_factory.getInstance( *phMetricStreamer, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -774,7 +758,7 @@ namespace loader
             return result;
 
         // release loader handle
-        zet_metric_streamer_factory.release( hMetricStreamer );
+        context->zet_metric_streamer_factory.release( hMetricStreamer );
 
         return result;
     }
@@ -852,7 +836,7 @@ namespace loader
         {
             // convert driver handle to loader handle
             *phMetricQueryPool = reinterpret_cast<zet_metric_query_pool_handle_t>(
-                zet_metric_query_pool_factory.getInstance( *phMetricQueryPool, dditable ) );
+                context->zet_metric_query_pool_factory.getInstance( *phMetricQueryPool, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -887,7 +871,7 @@ namespace loader
             return result;
 
         // release loader handle
-        zet_metric_query_pool_factory.release( hMetricQueryPool );
+        context->zet_metric_query_pool_factory.release( hMetricQueryPool );
 
         return result;
     }
@@ -922,7 +906,7 @@ namespace loader
         {
             // convert driver handle to loader handle
             *phMetricQuery = reinterpret_cast<zet_metric_query_handle_t>(
-                zet_metric_query_factory.getInstance( *phMetricQuery, dditable ) );
+                context->zet_metric_query_factory.getInstance( *phMetricQuery, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -957,7 +941,7 @@ namespace loader
             return result;
 
         // release loader handle
-        zet_metric_query_factory.release( hMetricQuery );
+        context->zet_metric_query_factory.release( hMetricQuery );
 
         return result;
     }
@@ -1160,7 +1144,7 @@ namespace loader
         {
             // convert driver handle to loader handle
             *phTracer = reinterpret_cast<zet_tracer_exp_handle_t>(
-                zet_tracer_exp_factory.getInstance( *phTracer, dditable ) );
+                context->zet_tracer_exp_factory.getInstance( *phTracer, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -1195,7 +1179,7 @@ namespace loader
             return result;
 
         // release loader handle
-        zet_tracer_exp_factory.release( hTracer );
+        context->zet_tracer_exp_factory.release( hTracer );
 
         return result;
     }
@@ -1465,7 +1449,7 @@ namespace loader
             // convert driver handles to loader handles
             for( size_t i = 0; ( nullptr != phMetricProgrammables ) && ( i < *pCount ); ++i )
                 phMetricProgrammables[ i ] = reinterpret_cast<zet_metric_programmable_exp_handle_t>(
-                    zet_metric_programmable_exp_factory.getInstance( phMetricProgrammables[ i ], dditable ) );
+                    context->zet_metric_programmable_exp_factory.getInstance( phMetricProgrammables[ i ], dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -1610,7 +1594,7 @@ namespace loader
             // convert driver handles to loader handles
             for( size_t i = 0; ( nullptr != phMetricHandles ) && ( i < *pMetricHandleCount ); ++i )
                 phMetricHandles[ i ] = reinterpret_cast<zet_metric_handle_t>(
-                    zet_metric_factory.getInstance( phMetricHandles[ i ], dditable ) );
+                    context->zet_metric_factory.getInstance( phMetricHandles[ i ], dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -1655,7 +1639,7 @@ namespace loader
         {
             // convert driver handle to loader handle
             *phMetricGroup = reinterpret_cast<zet_metric_group_handle_t>(
-                zet_metric_group_factory.getInstance( *phMetricGroup, dditable ) );
+                context->zet_metric_group_factory.getInstance( *phMetricGroup, dditable ) );
         }
         catch( std::bad_alloc& )
         {


### PR DESCRIPTION
- Moved all loader handle maps to within the loader context to ensure the maps are init and destroyed with library init/destroy vs at start of atexit.
- Check result of individual driver for zeInit during init_driver().