### PR TITLE
Split Ze and Zes Drivers and only release drivers at close

### DIFF
--- a/scripts/templates/ldrddi.cpp.mako
+++ b/scripts/templates/ldrddi.cpp.mako
@@ -40,7 +40,11 @@ namespace loader
 
         %if re.match(r"Init", obj['name']):
         bool atLeastOneDriverValid = false;
-        for( auto& drv : context->drivers )
+        %if namespace != "zes":
+        for( auto& drv : loader::context->zeDrivers )
+        %else:
+        for( auto& drv : *loader::context->sysmanInstanceDrivers )
+        %endif
         {
             if(drv.initStatus != ZE_RESULT_SUCCESS)
                 continue;
@@ -55,7 +59,11 @@ namespace loader
         %elif re.match(r"\w+DriverGet$", th.make_func_name(n, tags, obj)):
         uint32_t total_driver_handle_count = 0;
 
-        for( auto& drv : context->drivers )
+        %if namespace != "zes":
+        for( auto& drv : loader::context->zeDrivers )
+        %else:
+        for( auto& drv : *loader::context->sysmanInstanceDrivers )
+        %endif
         {
             if(drv.initStatus != ZE_RESULT_SUCCESS)
                 continue;
@@ -293,7 +301,12 @@ ${tbl['export']['name']}(
     %endfor
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    %if namespace != "zes":
+    if( loader::context->zeDrivers.size() < 1 )
+    %else:
+    if( loader::context->sysmanInstanceDrivers->size() < 1 )
+    %endif
+
         return ${X}_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -308,7 +321,11 @@ ${tbl['export']['name']}(
     bool atLeastOneDriverValid = false;
     %endif
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    %if namespace != "zes":
+    for( auto& drv : loader::context->zeDrivers )
+    %else:
+    for( auto& drv : *loader::context->sysmanInstanceDrivers )
+    %endif
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -344,7 +361,11 @@ ${tbl['export']['name']}(
 
     if( ${X}_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        %if namespace != "zes":
+        if( ( loader::context->zeDrivers.size() > 1 ) || loader::context->forceIntercept )
+        %else:
+        if( ( loader::context->sysmanInstanceDrivers->size() > 1 ) || loader::context->forceIntercept )
+        %endif
         {
             // return pointers to loader's DDIs
             %for obj in tbl['functions']:
@@ -362,7 +383,11 @@ ${tbl['export']['name']}(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.${n}.${tbl['name']};
+            %if namespace != "zes":
+            *pDdiTable = loader::context->zeDrivers.front().dditable.${n}.${tbl['name']};
+            %else:
+            *pDdiTable = loader::context->sysmanInstanceDrivers->front().dditable.${n}.${tbl['name']};
+            %endif
         }
     }
 

--- a/source/lib/ze_lib.h
+++ b/source/lib/ze_lib.h
@@ -36,7 +36,6 @@ namespace ze_lib
 
         std::once_flag initOnce;
         std::once_flag initOnceSysMan;
-        bool driverCheckCompleted = false;
 
         ze_result_t Init(ze_init_flags_t flags, bool sysmanOnly);
 

--- a/source/loader/ze_ldrddi.cpp
+++ b/source/loader/ze_ldrddi.cpp
@@ -22,7 +22,7 @@ namespace loader
         ze_result_t result = ZE_RESULT_SUCCESS;
 
         bool atLeastOneDriverValid = false;
-        for( auto& drv : context->drivers )
+        for( auto& drv : loader::context->zeDrivers )
         {
             if(drv.initStatus != ZE_RESULT_SUCCESS)
                 continue;
@@ -55,7 +55,7 @@ namespace loader
 
         uint32_t total_driver_handle_count = 0;
 
-        for( auto& drv : context->drivers )
+        for( auto& drv : loader::context->zeDrivers )
         {
             if(drv.initStatus != ZE_RESULT_SUCCESS)
                 continue;
@@ -6175,7 +6175,8 @@ zeGetGlobalProcAddrTable(
     ze_global_dditable_t* pDdiTable                 ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->zeDrivers.size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -6188,7 +6189,7 @@ zeGetGlobalProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : loader::context->zeDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -6210,7 +6211,7 @@ zeGetGlobalProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->zeDrivers.size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnInit                                     = loader::zeInit;
@@ -6218,7 +6219,7 @@ zeGetGlobalProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.ze.Global;
+            *pDdiTable = loader::context->zeDrivers.front().dditable.ze.Global;
         }
     }
 
@@ -6266,7 +6267,8 @@ zeGetRTASBuilderExpProcAddrTable(
     ze_rtas_builder_exp_dditable_t* pDdiTable       ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->zeDrivers.size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -6278,7 +6280,7 @@ zeGetRTASBuilderExpProcAddrTable(
     ze_result_t result = ZE_RESULT_SUCCESS;
 
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : loader::context->zeDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -6292,7 +6294,7 @@ zeGetRTASBuilderExpProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->zeDrivers.size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnCreateExp                                = loader::zeRTASBuilderCreateExp;
@@ -6303,7 +6305,7 @@ zeGetRTASBuilderExpProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.ze.RTASBuilderExp;
+            *pDdiTable = loader::context->zeDrivers.front().dditable.ze.RTASBuilderExp;
         }
     }
 
@@ -6351,7 +6353,8 @@ zeGetRTASParallelOperationExpProcAddrTable(
     ze_rtas_parallel_operation_exp_dditable_t* pDdiTable///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->zeDrivers.size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -6363,7 +6366,7 @@ zeGetRTASParallelOperationExpProcAddrTable(
     ze_result_t result = ZE_RESULT_SUCCESS;
 
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : loader::context->zeDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -6377,7 +6380,7 @@ zeGetRTASParallelOperationExpProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->zeDrivers.size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnCreateExp                                = loader::zeRTASParallelOperationCreateExp;
@@ -6388,7 +6391,7 @@ zeGetRTASParallelOperationExpProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.ze.RTASParallelOperationExp;
+            *pDdiTable = loader::context->zeDrivers.front().dditable.ze.RTASParallelOperationExp;
         }
     }
 
@@ -6436,7 +6439,8 @@ zeGetDriverProcAddrTable(
     ze_driver_dditable_t* pDdiTable                 ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->zeDrivers.size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -6449,7 +6453,7 @@ zeGetDriverProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : loader::context->zeDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -6471,7 +6475,7 @@ zeGetDriverProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->zeDrivers.size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnGet                                      = loader::zeDriverGet;
@@ -6485,7 +6489,7 @@ zeGetDriverProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.ze.Driver;
+            *pDdiTable = loader::context->zeDrivers.front().dditable.ze.Driver;
         }
     }
 
@@ -6533,7 +6537,8 @@ zeGetDriverExpProcAddrTable(
     ze_driver_exp_dditable_t* pDdiTable             ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->zeDrivers.size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -6545,7 +6550,7 @@ zeGetDriverExpProcAddrTable(
     ze_result_t result = ZE_RESULT_SUCCESS;
 
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : loader::context->zeDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -6559,7 +6564,7 @@ zeGetDriverExpProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->zeDrivers.size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnRTASFormatCompatibilityCheckExp          = loader::zeDriverRTASFormatCompatibilityCheckExp;
@@ -6567,7 +6572,7 @@ zeGetDriverExpProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.ze.DriverExp;
+            *pDdiTable = loader::context->zeDrivers.front().dditable.ze.DriverExp;
         }
     }
 
@@ -6615,7 +6620,8 @@ zeGetDeviceProcAddrTable(
     ze_device_dditable_t* pDdiTable                 ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->zeDrivers.size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -6628,7 +6634,7 @@ zeGetDeviceProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : loader::context->zeDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -6650,7 +6656,7 @@ zeGetDeviceProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->zeDrivers.size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnGet                                      = loader::zeDeviceGet;
@@ -6676,7 +6682,7 @@ zeGetDeviceProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.ze.Device;
+            *pDdiTable = loader::context->zeDrivers.front().dditable.ze.Device;
         }
     }
 
@@ -6724,7 +6730,8 @@ zeGetDeviceExpProcAddrTable(
     ze_device_exp_dditable_t* pDdiTable             ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->zeDrivers.size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -6736,7 +6743,7 @@ zeGetDeviceExpProcAddrTable(
     ze_result_t result = ZE_RESULT_SUCCESS;
 
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : loader::context->zeDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -6750,7 +6757,7 @@ zeGetDeviceExpProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->zeDrivers.size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnGetFabricVertexExp                       = loader::zeDeviceGetFabricVertexExp;
@@ -6758,7 +6765,7 @@ zeGetDeviceExpProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.ze.DeviceExp;
+            *pDdiTable = loader::context->zeDrivers.front().dditable.ze.DeviceExp;
         }
     }
 
@@ -6806,7 +6813,8 @@ zeGetContextProcAddrTable(
     ze_context_dditable_t* pDdiTable                ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->zeDrivers.size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -6819,7 +6827,7 @@ zeGetContextProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : loader::context->zeDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -6841,7 +6849,7 @@ zeGetContextProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->zeDrivers.size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnCreate                                   = loader::zeContextCreate;
@@ -6857,7 +6865,7 @@ zeGetContextProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.ze.Context;
+            *pDdiTable = loader::context->zeDrivers.front().dditable.ze.Context;
         }
     }
 
@@ -6905,7 +6913,8 @@ zeGetCommandQueueProcAddrTable(
     ze_command_queue_dditable_t* pDdiTable          ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->zeDrivers.size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -6918,7 +6927,7 @@ zeGetCommandQueueProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : loader::context->zeDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -6940,7 +6949,7 @@ zeGetCommandQueueProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->zeDrivers.size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnCreate                                   = loader::zeCommandQueueCreate;
@@ -6953,7 +6962,7 @@ zeGetCommandQueueProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.ze.CommandQueue;
+            *pDdiTable = loader::context->zeDrivers.front().dditable.ze.CommandQueue;
         }
     }
 
@@ -7001,7 +7010,8 @@ zeGetCommandListProcAddrTable(
     ze_command_list_dditable_t* pDdiTable           ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->zeDrivers.size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -7014,7 +7024,7 @@ zeGetCommandListProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : loader::context->zeDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -7036,7 +7046,7 @@ zeGetCommandListProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->zeDrivers.size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnCreate                                   = loader::zeCommandListCreate;
@@ -7077,7 +7087,7 @@ zeGetCommandListProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.ze.CommandList;
+            *pDdiTable = loader::context->zeDrivers.front().dditable.ze.CommandList;
         }
     }
 
@@ -7125,7 +7135,8 @@ zeGetCommandListExpProcAddrTable(
     ze_command_list_exp_dditable_t* pDdiTable       ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->zeDrivers.size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -7137,7 +7148,7 @@ zeGetCommandListExpProcAddrTable(
     ze_result_t result = ZE_RESULT_SUCCESS;
 
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : loader::context->zeDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -7151,7 +7162,7 @@ zeGetCommandListExpProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->zeDrivers.size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnCreateCloneExp                           = loader::zeCommandListCreateCloneExp;
@@ -7164,7 +7175,7 @@ zeGetCommandListExpProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.ze.CommandListExp;
+            *pDdiTable = loader::context->zeDrivers.front().dditable.ze.CommandListExp;
         }
     }
 
@@ -7212,7 +7223,8 @@ zeGetEventProcAddrTable(
     ze_event_dditable_t* pDdiTable                  ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->zeDrivers.size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -7225,7 +7237,7 @@ zeGetEventProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : loader::context->zeDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -7247,7 +7259,7 @@ zeGetEventProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->zeDrivers.size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnCreate                                   = loader::zeEventCreate;
@@ -7265,7 +7277,7 @@ zeGetEventProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.ze.Event;
+            *pDdiTable = loader::context->zeDrivers.front().dditable.ze.Event;
         }
     }
 
@@ -7313,7 +7325,8 @@ zeGetEventExpProcAddrTable(
     ze_event_exp_dditable_t* pDdiTable              ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->zeDrivers.size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -7325,7 +7338,7 @@ zeGetEventExpProcAddrTable(
     ze_result_t result = ZE_RESULT_SUCCESS;
 
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : loader::context->zeDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -7339,7 +7352,7 @@ zeGetEventExpProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->zeDrivers.size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnQueryTimestampsExp                       = loader::zeEventQueryTimestampsExp;
@@ -7347,7 +7360,7 @@ zeGetEventExpProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.ze.EventExp;
+            *pDdiTable = loader::context->zeDrivers.front().dditable.ze.EventExp;
         }
     }
 
@@ -7395,7 +7408,8 @@ zeGetEventPoolProcAddrTable(
     ze_event_pool_dditable_t* pDdiTable             ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->zeDrivers.size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -7408,7 +7422,7 @@ zeGetEventPoolProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : loader::context->zeDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -7430,7 +7444,7 @@ zeGetEventPoolProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->zeDrivers.size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnCreate                                   = loader::zeEventPoolCreate;
@@ -7445,7 +7459,7 @@ zeGetEventPoolProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.ze.EventPool;
+            *pDdiTable = loader::context->zeDrivers.front().dditable.ze.EventPool;
         }
     }
 
@@ -7493,7 +7507,8 @@ zeGetFenceProcAddrTable(
     ze_fence_dditable_t* pDdiTable                  ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->zeDrivers.size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -7506,7 +7521,7 @@ zeGetFenceProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : loader::context->zeDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -7528,7 +7543,7 @@ zeGetFenceProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->zeDrivers.size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnCreate                                   = loader::zeFenceCreate;
@@ -7540,7 +7555,7 @@ zeGetFenceProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.ze.Fence;
+            *pDdiTable = loader::context->zeDrivers.front().dditable.ze.Fence;
         }
     }
 
@@ -7588,7 +7603,8 @@ zeGetImageProcAddrTable(
     ze_image_dditable_t* pDdiTable                  ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->zeDrivers.size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -7601,7 +7617,7 @@ zeGetImageProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : loader::context->zeDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -7623,7 +7639,7 @@ zeGetImageProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->zeDrivers.size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnGetProperties                            = loader::zeImageGetProperties;
@@ -7635,7 +7651,7 @@ zeGetImageProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.ze.Image;
+            *pDdiTable = loader::context->zeDrivers.front().dditable.ze.Image;
         }
     }
 
@@ -7683,7 +7699,8 @@ zeGetImageExpProcAddrTable(
     ze_image_exp_dditable_t* pDdiTable              ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->zeDrivers.size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -7695,7 +7712,7 @@ zeGetImageExpProcAddrTable(
     ze_result_t result = ZE_RESULT_SUCCESS;
 
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : loader::context->zeDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -7709,7 +7726,7 @@ zeGetImageExpProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->zeDrivers.size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnGetMemoryPropertiesExp                   = loader::zeImageGetMemoryPropertiesExp;
@@ -7719,7 +7736,7 @@ zeGetImageExpProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.ze.ImageExp;
+            *pDdiTable = loader::context->zeDrivers.front().dditable.ze.ImageExp;
         }
     }
 
@@ -7767,7 +7784,8 @@ zeGetKernelProcAddrTable(
     ze_kernel_dditable_t* pDdiTable                 ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->zeDrivers.size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -7780,7 +7798,7 @@ zeGetKernelProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : loader::context->zeDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -7802,7 +7820,7 @@ zeGetKernelProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->zeDrivers.size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnCreate                                   = loader::zeKernelCreate;
@@ -7821,7 +7839,7 @@ zeGetKernelProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.ze.Kernel;
+            *pDdiTable = loader::context->zeDrivers.front().dditable.ze.Kernel;
         }
     }
 
@@ -7869,7 +7887,8 @@ zeGetKernelExpProcAddrTable(
     ze_kernel_exp_dditable_t* pDdiTable             ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->zeDrivers.size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -7881,7 +7900,7 @@ zeGetKernelExpProcAddrTable(
     ze_result_t result = ZE_RESULT_SUCCESS;
 
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : loader::context->zeDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -7895,7 +7914,7 @@ zeGetKernelExpProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->zeDrivers.size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnSetGlobalOffsetExp                       = loader::zeKernelSetGlobalOffsetExp;
@@ -7904,7 +7923,7 @@ zeGetKernelExpProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.ze.KernelExp;
+            *pDdiTable = loader::context->zeDrivers.front().dditable.ze.KernelExp;
         }
     }
 
@@ -7952,7 +7971,8 @@ zeGetMemProcAddrTable(
     ze_mem_dditable_t* pDdiTable                    ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->zeDrivers.size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -7965,7 +7985,7 @@ zeGetMemProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : loader::context->zeDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -7987,7 +8007,7 @@ zeGetMemProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->zeDrivers.size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnAllocShared                              = loader::zeMemAllocShared;
@@ -8006,7 +8026,7 @@ zeGetMemProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.ze.Mem;
+            *pDdiTable = loader::context->zeDrivers.front().dditable.ze.Mem;
         }
     }
 
@@ -8054,7 +8074,8 @@ zeGetMemExpProcAddrTable(
     ze_mem_exp_dditable_t* pDdiTable                ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->zeDrivers.size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -8066,7 +8087,7 @@ zeGetMemExpProcAddrTable(
     ze_result_t result = ZE_RESULT_SUCCESS;
 
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : loader::context->zeDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -8080,7 +8101,7 @@ zeGetMemExpProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->zeDrivers.size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnGetIpcHandleFromFileDescriptorExp        = loader::zeMemGetIpcHandleFromFileDescriptorExp;
@@ -8091,7 +8112,7 @@ zeGetMemExpProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.ze.MemExp;
+            *pDdiTable = loader::context->zeDrivers.front().dditable.ze.MemExp;
         }
     }
 
@@ -8139,7 +8160,8 @@ zeGetModuleProcAddrTable(
     ze_module_dditable_t* pDdiTable                 ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->zeDrivers.size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -8152,7 +8174,7 @@ zeGetModuleProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : loader::context->zeDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -8174,7 +8196,7 @@ zeGetModuleProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->zeDrivers.size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnCreate                                   = loader::zeModuleCreate;
@@ -8190,7 +8212,7 @@ zeGetModuleProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.ze.Module;
+            *pDdiTable = loader::context->zeDrivers.front().dditable.ze.Module;
         }
     }
 
@@ -8238,7 +8260,8 @@ zeGetModuleBuildLogProcAddrTable(
     ze_module_build_log_dditable_t* pDdiTable       ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->zeDrivers.size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -8251,7 +8274,7 @@ zeGetModuleBuildLogProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : loader::context->zeDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -8273,7 +8296,7 @@ zeGetModuleBuildLogProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->zeDrivers.size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnDestroy                                  = loader::zeModuleBuildLogDestroy;
@@ -8282,7 +8305,7 @@ zeGetModuleBuildLogProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.ze.ModuleBuildLog;
+            *pDdiTable = loader::context->zeDrivers.front().dditable.ze.ModuleBuildLog;
         }
     }
 
@@ -8330,7 +8353,8 @@ zeGetPhysicalMemProcAddrTable(
     ze_physical_mem_dditable_t* pDdiTable           ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->zeDrivers.size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -8343,7 +8367,7 @@ zeGetPhysicalMemProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : loader::context->zeDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -8365,7 +8389,7 @@ zeGetPhysicalMemProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->zeDrivers.size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnCreate                                   = loader::zePhysicalMemCreate;
@@ -8374,7 +8398,7 @@ zeGetPhysicalMemProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.ze.PhysicalMem;
+            *pDdiTable = loader::context->zeDrivers.front().dditable.ze.PhysicalMem;
         }
     }
 
@@ -8422,7 +8446,8 @@ zeGetSamplerProcAddrTable(
     ze_sampler_dditable_t* pDdiTable                ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->zeDrivers.size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -8435,7 +8460,7 @@ zeGetSamplerProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : loader::context->zeDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -8457,7 +8482,7 @@ zeGetSamplerProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->zeDrivers.size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnCreate                                   = loader::zeSamplerCreate;
@@ -8466,7 +8491,7 @@ zeGetSamplerProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.ze.Sampler;
+            *pDdiTable = loader::context->zeDrivers.front().dditable.ze.Sampler;
         }
     }
 
@@ -8514,7 +8539,8 @@ zeGetVirtualMemProcAddrTable(
     ze_virtual_mem_dditable_t* pDdiTable            ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->zeDrivers.size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -8527,7 +8553,7 @@ zeGetVirtualMemProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : loader::context->zeDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -8549,7 +8575,7 @@ zeGetVirtualMemProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->zeDrivers.size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnReserve                                  = loader::zeVirtualMemReserve;
@@ -8563,7 +8589,7 @@ zeGetVirtualMemProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.ze.VirtualMem;
+            *pDdiTable = loader::context->zeDrivers.front().dditable.ze.VirtualMem;
         }
     }
 
@@ -8611,7 +8637,8 @@ zeGetFabricEdgeExpProcAddrTable(
     ze_fabric_edge_exp_dditable_t* pDdiTable        ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->zeDrivers.size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -8623,7 +8650,7 @@ zeGetFabricEdgeExpProcAddrTable(
     ze_result_t result = ZE_RESULT_SUCCESS;
 
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : loader::context->zeDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -8637,7 +8664,7 @@ zeGetFabricEdgeExpProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->zeDrivers.size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnGetExp                                   = loader::zeFabricEdgeGetExp;
@@ -8647,7 +8674,7 @@ zeGetFabricEdgeExpProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.ze.FabricEdgeExp;
+            *pDdiTable = loader::context->zeDrivers.front().dditable.ze.FabricEdgeExp;
         }
     }
 
@@ -8695,7 +8722,8 @@ zeGetFabricVertexExpProcAddrTable(
     ze_fabric_vertex_exp_dditable_t* pDdiTable      ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->zeDrivers.size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -8707,7 +8735,7 @@ zeGetFabricVertexExpProcAddrTable(
     ze_result_t result = ZE_RESULT_SUCCESS;
 
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : loader::context->zeDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -8721,7 +8749,7 @@ zeGetFabricVertexExpProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->zeDrivers.size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnGetExp                                   = loader::zeFabricVertexGetExp;
@@ -8732,7 +8760,7 @@ zeGetFabricVertexExpProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.ze.FabricVertexExp;
+            *pDdiTable = loader::context->zeDrivers.front().dditable.ze.FabricVertexExp;
         }
     }
 

--- a/source/loader/ze_loader_internal.h
+++ b/source/loader/ze_loader_internal.h
@@ -102,7 +102,10 @@ namespace loader
         std::unordered_map<ze_sampler_object_t *, ze_sampler_handle_t>        sampler_handle_map;
         ze_api_version_t version = ZE_API_VERSION_CURRENT;
 
-        driver_vector_t drivers;
+        driver_vector_t allDrivers;
+        driver_vector_t zeDrivers;
+        driver_vector_t zesDrivers;
+        driver_vector_t *sysmanInstanceDrivers;
 
         HMODULE validationLayer = nullptr;
         HMODULE tracingLayer = nullptr;

--- a/source/loader/zel_tracing_ldrddi.cpp
+++ b/source/loader/zel_tracing_ldrddi.cpp
@@ -31,7 +31,7 @@ zelGetTracerApiProcAddrTable(
     zel_tracer_dditable_t* pDdiTable                ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->zeDrivers.size() < 1 )
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )

--- a/source/loader/zes_ldrddi.cpp
+++ b/source/loader/zes_ldrddi.cpp
@@ -22,7 +22,7 @@ namespace loader
         ze_result_t result = ZE_RESULT_SUCCESS;
 
         bool atLeastOneDriverValid = false;
-        for( auto& drv : context->drivers )
+        for( auto& drv : *loader::context->sysmanInstanceDrivers )
         {
             if(drv.initStatus != ZE_RESULT_SUCCESS)
                 continue;
@@ -56,7 +56,7 @@ namespace loader
 
         uint32_t total_driver_handle_count = 0;
 
-        for( auto& drv : context->drivers )
+        for( auto& drv : *loader::context->sysmanInstanceDrivers )
         {
             if(drv.initStatus != ZE_RESULT_SUCCESS)
                 continue;
@@ -4413,7 +4413,8 @@ zesGetGlobalProcAddrTable(
     zes_global_dditable_t* pDdiTable                ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->sysmanInstanceDrivers->size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -4426,7 +4427,7 @@ zesGetGlobalProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : *loader::context->sysmanInstanceDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -4452,7 +4453,7 @@ zesGetGlobalProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->sysmanInstanceDrivers->size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnInit                                     = loader::zesInit;
@@ -4460,7 +4461,7 @@ zesGetGlobalProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.zes.Global;
+            *pDdiTable = loader::context->sysmanInstanceDrivers->front().dditable.zes.Global;
         }
     }
 
@@ -4492,7 +4493,8 @@ zesGetDeviceProcAddrTable(
     zes_device_dditable_t* pDdiTable                ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->sysmanInstanceDrivers->size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -4505,7 +4507,7 @@ zesGetDeviceProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : *loader::context->sysmanInstanceDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -4527,7 +4529,7 @@ zesGetDeviceProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->sysmanInstanceDrivers->size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnGetProperties                            = loader::zesDeviceGetProperties;
@@ -4571,7 +4573,7 @@ zesGetDeviceProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.zes.Device;
+            *pDdiTable = loader::context->sysmanInstanceDrivers->front().dditable.zes.Device;
         }
     }
 
@@ -4603,7 +4605,8 @@ zesGetDeviceExpProcAddrTable(
     zes_device_exp_dditable_t* pDdiTable            ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->sysmanInstanceDrivers->size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -4615,7 +4618,7 @@ zesGetDeviceExpProcAddrTable(
     ze_result_t result = ZE_RESULT_SUCCESS;
 
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : *loader::context->sysmanInstanceDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -4629,7 +4632,7 @@ zesGetDeviceExpProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->sysmanInstanceDrivers->size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnGetSubDevicePropertiesExp                = loader::zesDeviceGetSubDevicePropertiesExp;
@@ -4638,7 +4641,7 @@ zesGetDeviceExpProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.zes.DeviceExp;
+            *pDdiTable = loader::context->sysmanInstanceDrivers->front().dditable.zes.DeviceExp;
         }
     }
 
@@ -4670,7 +4673,8 @@ zesGetDriverProcAddrTable(
     zes_driver_dditable_t* pDdiTable                ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->sysmanInstanceDrivers->size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -4683,7 +4687,7 @@ zesGetDriverProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : *loader::context->sysmanInstanceDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -4705,7 +4709,7 @@ zesGetDriverProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->sysmanInstanceDrivers->size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnEventListen                              = loader::zesDriverEventListen;
@@ -4717,7 +4721,7 @@ zesGetDriverProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.zes.Driver;
+            *pDdiTable = loader::context->sysmanInstanceDrivers->front().dditable.zes.Driver;
         }
     }
 
@@ -4749,7 +4753,8 @@ zesGetDriverExpProcAddrTable(
     zes_driver_exp_dditable_t* pDdiTable            ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->sysmanInstanceDrivers->size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -4761,7 +4766,7 @@ zesGetDriverExpProcAddrTable(
     ze_result_t result = ZE_RESULT_SUCCESS;
 
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : *loader::context->sysmanInstanceDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -4775,7 +4780,7 @@ zesGetDriverExpProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->sysmanInstanceDrivers->size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnGetDeviceByUuidExp                       = loader::zesDriverGetDeviceByUuidExp;
@@ -4783,7 +4788,7 @@ zesGetDriverExpProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.zes.DriverExp;
+            *pDdiTable = loader::context->sysmanInstanceDrivers->front().dditable.zes.DriverExp;
         }
     }
 
@@ -4815,7 +4820,8 @@ zesGetDiagnosticsProcAddrTable(
     zes_diagnostics_dditable_t* pDdiTable           ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->sysmanInstanceDrivers->size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -4828,7 +4834,7 @@ zesGetDiagnosticsProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : *loader::context->sysmanInstanceDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -4850,7 +4856,7 @@ zesGetDiagnosticsProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->sysmanInstanceDrivers->size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnGetProperties                            = loader::zesDiagnosticsGetProperties;
@@ -4860,7 +4866,7 @@ zesGetDiagnosticsProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.zes.Diagnostics;
+            *pDdiTable = loader::context->sysmanInstanceDrivers->front().dditable.zes.Diagnostics;
         }
     }
 
@@ -4892,7 +4898,8 @@ zesGetEngineProcAddrTable(
     zes_engine_dditable_t* pDdiTable                ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->sysmanInstanceDrivers->size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -4905,7 +4912,7 @@ zesGetEngineProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : *loader::context->sysmanInstanceDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -4927,7 +4934,7 @@ zesGetEngineProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->sysmanInstanceDrivers->size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnGetProperties                            = loader::zesEngineGetProperties;
@@ -4937,7 +4944,7 @@ zesGetEngineProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.zes.Engine;
+            *pDdiTable = loader::context->sysmanInstanceDrivers->front().dditable.zes.Engine;
         }
     }
 
@@ -4969,7 +4976,8 @@ zesGetFabricPortProcAddrTable(
     zes_fabric_port_dditable_t* pDdiTable           ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->sysmanInstanceDrivers->size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -4982,7 +4990,7 @@ zesGetFabricPortProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : *loader::context->sysmanInstanceDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -5004,7 +5012,7 @@ zesGetFabricPortProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->sysmanInstanceDrivers->size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnGetProperties                            = loader::zesFabricPortGetProperties;
@@ -5019,7 +5027,7 @@ zesGetFabricPortProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.zes.FabricPort;
+            *pDdiTable = loader::context->sysmanInstanceDrivers->front().dditable.zes.FabricPort;
         }
     }
 
@@ -5051,7 +5059,8 @@ zesGetFanProcAddrTable(
     zes_fan_dditable_t* pDdiTable                   ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->sysmanInstanceDrivers->size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -5064,7 +5073,7 @@ zesGetFanProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : *loader::context->sysmanInstanceDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -5086,7 +5095,7 @@ zesGetFanProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->sysmanInstanceDrivers->size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnGetProperties                            = loader::zesFanGetProperties;
@@ -5099,7 +5108,7 @@ zesGetFanProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.zes.Fan;
+            *pDdiTable = loader::context->sysmanInstanceDrivers->front().dditable.zes.Fan;
         }
     }
 
@@ -5131,7 +5140,8 @@ zesGetFirmwareProcAddrTable(
     zes_firmware_dditable_t* pDdiTable              ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->sysmanInstanceDrivers->size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -5144,7 +5154,7 @@ zesGetFirmwareProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : *loader::context->sysmanInstanceDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -5166,7 +5176,7 @@ zesGetFirmwareProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->sysmanInstanceDrivers->size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnGetProperties                            = loader::zesFirmwareGetProperties;
@@ -5177,7 +5187,7 @@ zesGetFirmwareProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.zes.Firmware;
+            *pDdiTable = loader::context->sysmanInstanceDrivers->front().dditable.zes.Firmware;
         }
     }
 
@@ -5209,7 +5219,8 @@ zesGetFirmwareExpProcAddrTable(
     zes_firmware_exp_dditable_t* pDdiTable          ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->sysmanInstanceDrivers->size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -5221,7 +5232,7 @@ zesGetFirmwareExpProcAddrTable(
     ze_result_t result = ZE_RESULT_SUCCESS;
 
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : *loader::context->sysmanInstanceDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -5235,7 +5246,7 @@ zesGetFirmwareExpProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->sysmanInstanceDrivers->size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnGetSecurityVersionExp                    = loader::zesFirmwareGetSecurityVersionExp;
@@ -5244,7 +5255,7 @@ zesGetFirmwareExpProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.zes.FirmwareExp;
+            *pDdiTable = loader::context->sysmanInstanceDrivers->front().dditable.zes.FirmwareExp;
         }
     }
 
@@ -5276,7 +5287,8 @@ zesGetFrequencyProcAddrTable(
     zes_frequency_dditable_t* pDdiTable             ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->sysmanInstanceDrivers->size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -5289,7 +5301,7 @@ zesGetFrequencyProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : *loader::context->sysmanInstanceDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -5311,7 +5323,7 @@ zesGetFrequencyProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->sysmanInstanceDrivers->size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnGetProperties                            = loader::zesFrequencyGetProperties;
@@ -5335,7 +5347,7 @@ zesGetFrequencyProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.zes.Frequency;
+            *pDdiTable = loader::context->sysmanInstanceDrivers->front().dditable.zes.Frequency;
         }
     }
 
@@ -5367,7 +5379,8 @@ zesGetLedProcAddrTable(
     zes_led_dditable_t* pDdiTable                   ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->sysmanInstanceDrivers->size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -5380,7 +5393,7 @@ zesGetLedProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : *loader::context->sysmanInstanceDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -5402,7 +5415,7 @@ zesGetLedProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->sysmanInstanceDrivers->size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnGetProperties                            = loader::zesLedGetProperties;
@@ -5413,7 +5426,7 @@ zesGetLedProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.zes.Led;
+            *pDdiTable = loader::context->sysmanInstanceDrivers->front().dditable.zes.Led;
         }
     }
 
@@ -5445,7 +5458,8 @@ zesGetMemoryProcAddrTable(
     zes_memory_dditable_t* pDdiTable                ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->sysmanInstanceDrivers->size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -5458,7 +5472,7 @@ zesGetMemoryProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : *loader::context->sysmanInstanceDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -5480,7 +5494,7 @@ zesGetMemoryProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->sysmanInstanceDrivers->size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnGetProperties                            = loader::zesMemoryGetProperties;
@@ -5490,7 +5504,7 @@ zesGetMemoryProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.zes.Memory;
+            *pDdiTable = loader::context->sysmanInstanceDrivers->front().dditable.zes.Memory;
         }
     }
 
@@ -5522,7 +5536,8 @@ zesGetOverclockProcAddrTable(
     zes_overclock_dditable_t* pDdiTable             ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->sysmanInstanceDrivers->size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -5535,7 +5550,7 @@ zesGetOverclockProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : *loader::context->sysmanInstanceDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -5561,7 +5576,7 @@ zesGetOverclockProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->sysmanInstanceDrivers->size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnGetDomainProperties                      = loader::zesOverclockGetDomainProperties;
@@ -5577,7 +5592,7 @@ zesGetOverclockProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.zes.Overclock;
+            *pDdiTable = loader::context->sysmanInstanceDrivers->front().dditable.zes.Overclock;
         }
     }
 
@@ -5609,7 +5624,8 @@ zesGetPerformanceFactorProcAddrTable(
     zes_performance_factor_dditable_t* pDdiTable    ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->sysmanInstanceDrivers->size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -5622,7 +5638,7 @@ zesGetPerformanceFactorProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : *loader::context->sysmanInstanceDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -5644,7 +5660,7 @@ zesGetPerformanceFactorProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->sysmanInstanceDrivers->size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnGetProperties                            = loader::zesPerformanceFactorGetProperties;
@@ -5654,7 +5670,7 @@ zesGetPerformanceFactorProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.zes.PerformanceFactor;
+            *pDdiTable = loader::context->sysmanInstanceDrivers->front().dditable.zes.PerformanceFactor;
         }
     }
 
@@ -5686,7 +5702,8 @@ zesGetPowerProcAddrTable(
     zes_power_dditable_t* pDdiTable                 ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->sysmanInstanceDrivers->size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -5699,7 +5716,7 @@ zesGetPowerProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : *loader::context->sysmanInstanceDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -5721,7 +5738,7 @@ zesGetPowerProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->sysmanInstanceDrivers->size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnGetProperties                            = loader::zesPowerGetProperties;
@@ -5736,7 +5753,7 @@ zesGetPowerProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.zes.Power;
+            *pDdiTable = loader::context->sysmanInstanceDrivers->front().dditable.zes.Power;
         }
     }
 
@@ -5768,7 +5785,8 @@ zesGetPsuProcAddrTable(
     zes_psu_dditable_t* pDdiTable                   ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->sysmanInstanceDrivers->size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -5781,7 +5799,7 @@ zesGetPsuProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : *loader::context->sysmanInstanceDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -5803,7 +5821,7 @@ zesGetPsuProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->sysmanInstanceDrivers->size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnGetProperties                            = loader::zesPsuGetProperties;
@@ -5812,7 +5830,7 @@ zesGetPsuProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.zes.Psu;
+            *pDdiTable = loader::context->sysmanInstanceDrivers->front().dditable.zes.Psu;
         }
     }
 
@@ -5844,7 +5862,8 @@ zesGetRasProcAddrTable(
     zes_ras_dditable_t* pDdiTable                   ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->sysmanInstanceDrivers->size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -5857,7 +5876,7 @@ zesGetRasProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : *loader::context->sysmanInstanceDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -5879,7 +5898,7 @@ zesGetRasProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->sysmanInstanceDrivers->size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnGetProperties                            = loader::zesRasGetProperties;
@@ -5890,7 +5909,7 @@ zesGetRasProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.zes.Ras;
+            *pDdiTable = loader::context->sysmanInstanceDrivers->front().dditable.zes.Ras;
         }
     }
 
@@ -5922,7 +5941,8 @@ zesGetRasExpProcAddrTable(
     zes_ras_exp_dditable_t* pDdiTable               ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->sysmanInstanceDrivers->size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -5934,7 +5954,7 @@ zesGetRasExpProcAddrTable(
     ze_result_t result = ZE_RESULT_SUCCESS;
 
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : *loader::context->sysmanInstanceDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -5948,7 +5968,7 @@ zesGetRasExpProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->sysmanInstanceDrivers->size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnGetStateExp                              = loader::zesRasGetStateExp;
@@ -5957,7 +5977,7 @@ zesGetRasExpProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.zes.RasExp;
+            *pDdiTable = loader::context->sysmanInstanceDrivers->front().dditable.zes.RasExp;
         }
     }
 
@@ -5989,7 +6009,8 @@ zesGetSchedulerProcAddrTable(
     zes_scheduler_dditable_t* pDdiTable             ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->sysmanInstanceDrivers->size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -6002,7 +6023,7 @@ zesGetSchedulerProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : *loader::context->sysmanInstanceDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -6024,7 +6045,7 @@ zesGetSchedulerProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->sysmanInstanceDrivers->size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnGetProperties                            = loader::zesSchedulerGetProperties;
@@ -6039,7 +6060,7 @@ zesGetSchedulerProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.zes.Scheduler;
+            *pDdiTable = loader::context->sysmanInstanceDrivers->front().dditable.zes.Scheduler;
         }
     }
 
@@ -6071,7 +6092,8 @@ zesGetStandbyProcAddrTable(
     zes_standby_dditable_t* pDdiTable               ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->sysmanInstanceDrivers->size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -6084,7 +6106,7 @@ zesGetStandbyProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : *loader::context->sysmanInstanceDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -6106,7 +6128,7 @@ zesGetStandbyProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->sysmanInstanceDrivers->size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnGetProperties                            = loader::zesStandbyGetProperties;
@@ -6116,7 +6138,7 @@ zesGetStandbyProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.zes.Standby;
+            *pDdiTable = loader::context->sysmanInstanceDrivers->front().dditable.zes.Standby;
         }
     }
 
@@ -6148,7 +6170,8 @@ zesGetTemperatureProcAddrTable(
     zes_temperature_dditable_t* pDdiTable           ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->sysmanInstanceDrivers->size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -6161,7 +6184,7 @@ zesGetTemperatureProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : *loader::context->sysmanInstanceDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -6183,7 +6206,7 @@ zesGetTemperatureProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->sysmanInstanceDrivers->size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnGetProperties                            = loader::zesTemperatureGetProperties;
@@ -6194,7 +6217,7 @@ zesGetTemperatureProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.zes.Temperature;
+            *pDdiTable = loader::context->sysmanInstanceDrivers->front().dditable.zes.Temperature;
         }
     }
 
@@ -6226,7 +6249,8 @@ zesGetVFManagementExpProcAddrTable(
     zes_vf_management_exp_dditable_t* pDdiTable     ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->sysmanInstanceDrivers->size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -6238,7 +6262,7 @@ zesGetVFManagementExpProcAddrTable(
     ze_result_t result = ZE_RESULT_SUCCESS;
 
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : *loader::context->sysmanInstanceDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -6252,7 +6276,7 @@ zesGetVFManagementExpProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->sysmanInstanceDrivers->size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnGetVFPropertiesExp                       = loader::zesVFManagementGetVFPropertiesExp;
@@ -6264,7 +6288,7 @@ zesGetVFManagementExpProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.zes.VFManagementExp;
+            *pDdiTable = loader::context->sysmanInstanceDrivers->front().dditable.zes.VFManagementExp;
         }
     }
 

--- a/source/loader/zet_ldrddi.cpp
+++ b/source/loader/zet_ldrddi.cpp
@@ -1811,7 +1811,8 @@ zetGetMetricProgrammableExpProcAddrTable(
     zet_metric_programmable_exp_dditable_t* pDdiTable   ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->zeDrivers.size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -1823,7 +1824,7 @@ zetGetMetricProgrammableExpProcAddrTable(
     ze_result_t result = ZE_RESULT_SUCCESS;
 
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : loader::context->zeDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -1837,7 +1838,7 @@ zetGetMetricProgrammableExpProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->zeDrivers.size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnGetExp                                   = loader::zetMetricProgrammableGetExp;
@@ -1848,7 +1849,7 @@ zetGetMetricProgrammableExpProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.zet.MetricProgrammableExp;
+            *pDdiTable = loader::context->zeDrivers.front().dditable.zet.MetricProgrammableExp;
         }
     }
 
@@ -1880,7 +1881,8 @@ zetGetDeviceProcAddrTable(
     zet_device_dditable_t* pDdiTable                ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->zeDrivers.size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -1893,7 +1895,7 @@ zetGetDeviceProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : loader::context->zeDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -1915,7 +1917,7 @@ zetGetDeviceProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->zeDrivers.size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnGetDebugProperties                       = loader::zetDeviceGetDebugProperties;
@@ -1923,7 +1925,7 @@ zetGetDeviceProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.zet.Device;
+            *pDdiTable = loader::context->zeDrivers.front().dditable.zet.Device;
         }
     }
 
@@ -1955,7 +1957,8 @@ zetGetContextProcAddrTable(
     zet_context_dditable_t* pDdiTable               ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->zeDrivers.size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -1968,7 +1971,7 @@ zetGetContextProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : loader::context->zeDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -1990,7 +1993,7 @@ zetGetContextProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->zeDrivers.size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnActivateMetricGroups                     = loader::zetContextActivateMetricGroups;
@@ -1998,7 +2001,7 @@ zetGetContextProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.zet.Context;
+            *pDdiTable = loader::context->zeDrivers.front().dditable.zet.Context;
         }
     }
 
@@ -2030,7 +2033,8 @@ zetGetCommandListProcAddrTable(
     zet_command_list_dditable_t* pDdiTable          ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->zeDrivers.size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -2043,7 +2047,7 @@ zetGetCommandListProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : loader::context->zeDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -2065,7 +2069,7 @@ zetGetCommandListProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->zeDrivers.size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnAppendMetricStreamerMarker               = loader::zetCommandListAppendMetricStreamerMarker;
@@ -2076,7 +2080,7 @@ zetGetCommandListProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.zet.CommandList;
+            *pDdiTable = loader::context->zeDrivers.front().dditable.zet.CommandList;
         }
     }
 
@@ -2108,7 +2112,8 @@ zetGetKernelProcAddrTable(
     zet_kernel_dditable_t* pDdiTable                ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->zeDrivers.size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -2121,7 +2126,7 @@ zetGetKernelProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : loader::context->zeDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -2143,7 +2148,7 @@ zetGetKernelProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->zeDrivers.size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnGetProfileInfo                           = loader::zetKernelGetProfileInfo;
@@ -2151,7 +2156,7 @@ zetGetKernelProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.zet.Kernel;
+            *pDdiTable = loader::context->zeDrivers.front().dditable.zet.Kernel;
         }
     }
 
@@ -2183,7 +2188,8 @@ zetGetModuleProcAddrTable(
     zet_module_dditable_t* pDdiTable                ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->zeDrivers.size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -2196,7 +2202,7 @@ zetGetModuleProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : loader::context->zeDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -2218,7 +2224,7 @@ zetGetModuleProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->zeDrivers.size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnGetDebugInfo                             = loader::zetModuleGetDebugInfo;
@@ -2226,7 +2232,7 @@ zetGetModuleProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.zet.Module;
+            *pDdiTable = loader::context->zeDrivers.front().dditable.zet.Module;
         }
     }
 
@@ -2258,7 +2264,8 @@ zetGetDebugProcAddrTable(
     zet_debug_dditable_t* pDdiTable                 ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->zeDrivers.size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -2271,7 +2278,7 @@ zetGetDebugProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : loader::context->zeDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -2293,7 +2300,7 @@ zetGetDebugProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->zeDrivers.size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnAttach                                   = loader::zetDebugAttach;
@@ -2312,7 +2319,7 @@ zetGetDebugProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.zet.Debug;
+            *pDdiTable = loader::context->zeDrivers.front().dditable.zet.Debug;
         }
     }
 
@@ -2344,7 +2351,8 @@ zetGetMetricProcAddrTable(
     zet_metric_dditable_t* pDdiTable                ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->zeDrivers.size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -2357,7 +2365,7 @@ zetGetMetricProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : loader::context->zeDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -2379,7 +2387,7 @@ zetGetMetricProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->zeDrivers.size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnGet                                      = loader::zetMetricGet;
@@ -2388,7 +2396,7 @@ zetGetMetricProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.zet.Metric;
+            *pDdiTable = loader::context->zeDrivers.front().dditable.zet.Metric;
         }
     }
 
@@ -2420,7 +2428,8 @@ zetGetMetricExpProcAddrTable(
     zet_metric_exp_dditable_t* pDdiTable            ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->zeDrivers.size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -2432,7 +2441,7 @@ zetGetMetricExpProcAddrTable(
     ze_result_t result = ZE_RESULT_SUCCESS;
 
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : loader::context->zeDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -2446,7 +2455,7 @@ zetGetMetricExpProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->zeDrivers.size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnCreateFromProgrammableExp                = loader::zetMetricCreateFromProgrammableExp;
@@ -2455,7 +2464,7 @@ zetGetMetricExpProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.zet.MetricExp;
+            *pDdiTable = loader::context->zeDrivers.front().dditable.zet.MetricExp;
         }
     }
 
@@ -2487,7 +2496,8 @@ zetGetMetricGroupProcAddrTable(
     zet_metric_group_dditable_t* pDdiTable          ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->zeDrivers.size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -2500,7 +2510,7 @@ zetGetMetricGroupProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : loader::context->zeDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -2522,7 +2532,7 @@ zetGetMetricGroupProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->zeDrivers.size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnGet                                      = loader::zetMetricGroupGet;
@@ -2532,7 +2542,7 @@ zetGetMetricGroupProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.zet.MetricGroup;
+            *pDdiTable = loader::context->zeDrivers.front().dditable.zet.MetricGroup;
         }
     }
 
@@ -2564,7 +2574,8 @@ zetGetMetricGroupExpProcAddrTable(
     zet_metric_group_exp_dditable_t* pDdiTable      ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->zeDrivers.size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -2576,7 +2587,7 @@ zetGetMetricGroupExpProcAddrTable(
     ze_result_t result = ZE_RESULT_SUCCESS;
 
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : loader::context->zeDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -2590,7 +2601,7 @@ zetGetMetricGroupExpProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->zeDrivers.size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnCalculateMultipleMetricValuesExp         = loader::zetMetricGroupCalculateMultipleMetricValuesExp;
@@ -2606,7 +2617,7 @@ zetGetMetricGroupExpProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.zet.MetricGroupExp;
+            *pDdiTable = loader::context->zeDrivers.front().dditable.zet.MetricGroupExp;
         }
     }
 
@@ -2638,7 +2649,8 @@ zetGetMetricQueryProcAddrTable(
     zet_metric_query_dditable_t* pDdiTable          ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->zeDrivers.size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -2651,7 +2663,7 @@ zetGetMetricQueryProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : loader::context->zeDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -2673,7 +2685,7 @@ zetGetMetricQueryProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->zeDrivers.size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnCreate                                   = loader::zetMetricQueryCreate;
@@ -2684,7 +2696,7 @@ zetGetMetricQueryProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.zet.MetricQuery;
+            *pDdiTable = loader::context->zeDrivers.front().dditable.zet.MetricQuery;
         }
     }
 
@@ -2716,7 +2728,8 @@ zetGetMetricQueryPoolProcAddrTable(
     zet_metric_query_pool_dditable_t* pDdiTable     ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->zeDrivers.size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -2729,7 +2742,7 @@ zetGetMetricQueryPoolProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : loader::context->zeDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -2751,7 +2764,7 @@ zetGetMetricQueryPoolProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->zeDrivers.size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnCreate                                   = loader::zetMetricQueryPoolCreate;
@@ -2760,7 +2773,7 @@ zetGetMetricQueryPoolProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.zet.MetricQueryPool;
+            *pDdiTable = loader::context->zeDrivers.front().dditable.zet.MetricQueryPool;
         }
     }
 
@@ -2792,7 +2805,8 @@ zetGetMetricStreamerProcAddrTable(
     zet_metric_streamer_dditable_t* pDdiTable       ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->zeDrivers.size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -2805,7 +2819,7 @@ zetGetMetricStreamerProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : loader::context->zeDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -2827,7 +2841,7 @@ zetGetMetricStreamerProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->zeDrivers.size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnOpen                                     = loader::zetMetricStreamerOpen;
@@ -2837,7 +2851,7 @@ zetGetMetricStreamerProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.zet.MetricStreamer;
+            *pDdiTable = loader::context->zeDrivers.front().dditable.zet.MetricStreamer;
         }
     }
 
@@ -2869,7 +2883,8 @@ zetGetTracerExpProcAddrTable(
     zet_tracer_exp_dditable_t* pDdiTable            ///< [in,out] pointer to table of DDI function pointers
     )
 {
-    if( loader::context->drivers.size() < 1 )
+    if( loader::context->zeDrivers.size() < 1 )
+
         return ZE_RESULT_ERROR_UNINITIALIZED;
 
     if( nullptr == pDdiTable )
@@ -2882,7 +2897,7 @@ zetGetTracerExpProcAddrTable(
 
     bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
-    for( auto& drv : loader::context->drivers )
+    for( auto& drv : loader::context->zeDrivers )
     {
         if(drv.initStatus != ZE_RESULT_SUCCESS)
             continue;
@@ -2904,7 +2919,7 @@ zetGetTracerExpProcAddrTable(
 
     if( ZE_RESULT_SUCCESS == result )
     {
-        if( ( loader::context->drivers.size() > 1 ) || loader::context->forceIntercept )
+        if( ( loader::context->zeDrivers.size() > 1 ) || loader::context->forceIntercept )
         {
             // return pointers to loader's DDIs
             pDdiTable->pfnCreate                                   = loader::zetTracerExpCreate;
@@ -2916,7 +2931,7 @@ zetGetTracerExpProcAddrTable(
         else
         {
             // return pointers directly to driver's DDIs
-            *pDdiTable = loader::context->drivers.front().dditable.zet.TracerExp;
+            *pDdiTable = loader::context->zeDrivers.front().dditable.zet.TracerExp;
         }
     }
 


### PR DESCRIPTION
- to allow for different sets of drivers supporting sysman vs core we now have two sets of drivers tracked in the instance allowing for sysman to access different sets of drivers than core and vice versa.