### PR TITLE
Fix reading updated state of the driver_t for checking initStatus

### DIFF
--- a/source/loader/ze_loader.cpp
+++ b/source/loader/ze_loader.cpp
@@ -170,7 +170,7 @@ namespace loader
         return ZE_RESULT_SUCCESS;
     }
 
-    ze_result_t context_t::init_driver(driver_t driver, ze_init_flags_t flags, ze_global_dditable_t *globalInitStored, zes_global_dditable_t *sysmanGlobalInitStored, bool sysmanOnly) {
+    ze_result_t context_t::init_driver(driver_t &driver, ze_init_flags_t flags, ze_global_dditable_t *globalInitStored, zes_global_dditable_t *sysmanGlobalInitStored, bool sysmanOnly) {
 
         if (sysmanOnly) {
             auto getTable = reinterpret_cast<zes_pfnGetGlobalProcAddrTable_t>(

--- a/source/loader/ze_loader_internal.h
+++ b/source/loader/ze_loader_internal.h
@@ -118,7 +118,7 @@ namespace loader
         ze_result_t check_drivers(ze_init_flags_t flags, ze_global_dditable_t *globalInitStored, zes_global_dditable_t *sysmanGlobalInitStored, bool *requireDdiReinit, bool sysmanOnly);
         void debug_trace_message(std::string errorMessage, std::string errorValue);
         ze_result_t init();
-        ze_result_t init_driver(driver_t driver, ze_init_flags_t flags, ze_global_dditable_t *globalInitStored, zes_global_dditable_t *sysmanGlobalInitStored, bool sysmanOnly);
+        ze_result_t init_driver(driver_t &driver, ze_init_flags_t flags, ze_global_dditable_t *globalInitStored, zes_global_dditable_t *sysmanGlobalInitStored, bool sysmanOnly);
         void add_loader_version();
         ~context_t();
         bool intercept_enabled = false;


### PR DESCRIPTION
- Fixed init_drivers call to correctly get the updated state of the driver_t entry for reliably checking the driver initStatus after call to pfnInit.