### PR TITLE
Prevent reinit when zes/ze handles have already been retrieved

### DIFF
--- a/scripts/templates/libapi.cpp.mako
+++ b/scripts/templates/libapi.cpp.mako
@@ -127,6 +127,9 @@ ${th.make_func_name(n, tags, obj)}(
         else
             return ${X}_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
+%if re.match(r"\w+DriverGet$", th.make_func_name(n, tags, obj)):
+    ze_lib::context->${n}Inuse = true;
+%endif
 
     return ${th.make_pfn_name(n, tags, obj)}( ${", ".join(th.make_param_lines(n, tags, obj, format=["name"]))} );
 }

--- a/source/lib/ze_lib.h
+++ b/source/lib/ze_lib.h
@@ -59,6 +59,8 @@ namespace ze_lib
         HMODULE tracing_lib = nullptr;
         bool isInitialized = false;
         bool inTeardown = false;
+        bool zesInuse = false;
+        bool zeInuse = false;
     };
 
     extern context_t *context;

--- a/source/lib/ze_libapi.cpp
+++ b/source/lib/ze_libapi.cpp
@@ -125,6 +125,7 @@ zeDriverGet(
         else
             return ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
+    ze_lib::context->zeInuse = true;
 
     return pfnGet( pCount, phDrivers );
 }

--- a/source/lib/zes_libapi.cpp
+++ b/source/lib/zes_libapi.cpp
@@ -120,6 +120,7 @@ zesDriverGet(
         else
             return ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
+    ze_lib::context->zesInuse = true;
 
     return pfnGet( pCount, phDrivers );
 }


### PR DESCRIPTION
- Given ze or zes driver get has been called, then one cannot allow for the ddi table to be reinit to avoid breaking the user's existing handles.