### PR TITLE
Update CHANGELOG.md for v1.17.43

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Level zero loader changelog
 
+## v1.17.43
+* Switch to monotonically increasing patch numbers
+* Fix warning by updating min cmake version to 3.5
+* Add missing guards around debug messages
 ## v1.17.42
 * Fix SysMan driver pointers given no sysman env and no zesInit (#193)
 * Prevent reinit when zes/ze handles have already been retrieved (#192)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,53 +10,12 @@ if(MSVC AND (MSVC_VERSION LESS 1900))
 message(FATAL_ERROR "Visual Studio Compiler Version >= 1900 Required to build.")
 endif()
 
-# This project follows semantic versioning (https://semver.org/). Only set the
-# major and minor version here - patch version is determined dynamically.
-project(level-zero VERSION 1.17)
+# This project follows semantic versioning (https://semver.org/)
+project(level-zero VERSION 1.17.43)
 
 include(GNUInstallDirs)
 
-# Patch version corresponds to # of commits on master since last version
-# major/minor tag (e.g., v1.0). If not building in a git repository, then get
-# the patch version from a VERSION_PATCH file that would be shipped with a
-# source distribution. Otherwise, use 0.
-set(PROJECT_VERSION_PATCH 0)
 find_package(Git)
-if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/VERSION_PATCH")
-	file(READ "${CMAKE_CURRENT_SOURCE_DIR}/VERSION_PATCH" VERSION_PATCH)
-	string(STRIP "${VERSION_PATCH}" PROJECT_VERSION_PATCH)
-	message(STATUS "Using patch version from VERSION_PATCH file in source tree: ${PROJECT_VERSION_PATCH}")
-elseif(Git_FOUND)
-	if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
-		message(WARNING "Cannot determine patch version - VERSION_PATCH file is not in source tree and source tree does not appear to be a git repository. Using 0 as patch version.")
-		set(PROJECT_VERSION_PATCH 0)
-	else()
-		set(GIT_TAG "v${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}")
-		if(MSVC)
-			set(grep_string \\[CI\\] )
-			execute_process(
-				COMMAND CMD /c ${GIT_EXECUTABLE} rev-list ${GIT_TAG}..HEAD --grep=${grep_string} --invert-grep --count
-				OUTPUT_VARIABLE VERSION_PATCH
-				WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-			)
-		else()
-			set(grep_string "\\[CI\\] ")
-			execute_process(
-				COMMAND ${GIT_EXECUTABLE} rev-list ${GIT_TAG}..HEAD --grep=${grep_string} --invert-grep --count
-				OUTPUT_VARIABLE VERSION_PATCH
-				WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-			)
-		endif()
-		string(STRIP "${VERSION_PATCH}" PROJECT_VERSION_PATCH)
-		if(PROJECT_VERSION_PATCH STREQUAL "")
-			message(WARNING "Cannot determine patch version - couldn't find ${GIT_TAG} tag in repository. Using 0 as patch version.")
-			set(PROJECT_VERSION_PATCH 0)
-		else()
-			message(STATUS "Using patch version from commit count in git repository: ${PROJECT_VERSION_PATCH}")
-		endif()
-	endif()
-endif()
-
 if(Git_FOUND)
 	if(MSVC)
 		execute_process(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: MIT
 
-cmake_minimum_required(VERSION 3.2.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5.0 FATAL_ERROR)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)

--- a/os_release_info.cmake
+++ b/os_release_info.cmake
@@ -12,7 +12,7 @@ set(_os_release_info TRUE)
 # of the local cmake environment.
 
 # Set cmake policies for at least this level:
-cmake_minimum_required(VERSION 3.2.0)
+cmake_minimum_required(VERSION 3.5.0)
 
 
 # Function get_os_release_info - Determine and return OS name and version


### PR DESCRIPTION
- Fixes a cmake warning about the minimum supported version
- Switches patch increments to monotonic rather than commit count