### PR TITLE
Bump minimal required CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: MIT
 
-cmake_minimum_required(VERSION 3.5.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.12.0 FATAL_ERROR)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)


### PR DESCRIPTION
Currently, it doesn't configure properly on cmake-3.5.0 with 2 errors:

````
-- Detecting CXX compile features - done
-- Found Git: /usr/bin/git (found version "2.43.0")
CMake Error at CMakeLists.txt:51 (include):
  include could not find load file:

    FetchContent

-- Performing Test COMPILER_SUPPORTS_CXX14
-- Performing Test COMPILER_SUPPORTS_CXX14 - Success
CMake Error at source/layers/validation/CMakeLists.txt:39 (install):
  install TARGETS given unknown argument "NAMELINK_COMPONENT".

CMake Error at source/layers/tracing/CMakeLists.txt:51 (install):
  install TARGETS given unknown argument "NAMELINK_COMPONENT".

-- Looking for pthread.h
-- Looking for pthread.h - found
-- Looking for pthread_create
-- Looking for pthread_create - found
-- Found Threads: TRUE
CMake Error at source/CMakeLists.txt:51 (install):
  install TARGETS given unknown argument "NAMELINK_COMPONENT".

-- Configuring incomplete, errors occurred!
````

The minimal version required for failing features are:
- 3.11 for https://cmake.org/cmake/help/latest/module/FetchContent.html
- 3.12 for https://cmake.org/cmake/help/latest/command/install.html (`NAMELINK_COMPONENT `)

\
I also double-checked this with a tool: https://github.com/nlohmann/cmake_min_version :
```
@luke   venv  ~/repos/cmake_min_version: python cmake_min_version.py ~/repos/luke/level-zero/
Found 9 CMake binaries from directory tools in 0.27 seconds

[  0%] CMake 3.9.0  ✘ error
       CMakeLists.txt:51 (include)
[ 25%] CMake 3.11.0 ✘ error
       source/layers/validation/CMakeLists.txt:39 (install)
[ 50%] CMake 3.12.0 ✔ works
[100%] Minimal working version: CMake 3.12.0

cmake_minimum_required(VERSION 3.12.0)
```