### PR TITLE
Static L0 Loader Support

### DIFF
--- a/.github/workflows/build-multi-static.yml
+++ b/.github/workflows/build-multi-static.yml
@@ -1,0 +1,159 @@
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+permissions: read-all
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  config:
+    if: github.repository_owner == 'oneapi-src'
+    runs-on: ubuntu-latest
+    outputs:
+      short-sha: ${{ steps.const.outputs.short-sha }}
+      ref-slug: ${{ steps.const.outputs.ref-slug }}
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        clean: true
+        ref: ${{ github.event.pull_request.head.sha }}
+    - name: Set constants
+      id: const
+      run: |
+        cat >> ${GITHUB_OUTPUT} <<EOF
+        short-sha=$(git rev-parse --short=7 ${GITHUB_SHA})
+        ref-slug=$(echo ${{ github.ref_name }} | tr '/_' '-')
+        EOF
+
+  build:
+    # Notes on formatting:
+    #
+    # GitHub Actions expressions ${{ ... }} are used wherever possible so the
+    # evaluation results are plainly visible in the web console.
+    #
+    # Note the mixed spaces and tabs in the heredocs, see the bash man page
+    # entry for <<- in the Here Documents section. This allows generated code to
+    # be indented for readability in the workflow output.
+    if: github.repository_owner == 'oneapi-src'
+    needs: [config]
+    runs-on: ${{ matrix.os.name == 'windows' && 'windows-latest' || 'ubuntu-latest' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [
+          {name: ubuntu, vmaj: 20, vmin: '04'},
+          {name: ubuntu, vmaj: 22, vmin: '04'},
+          {name: ubuntu, vmaj: 24, vmin: '04'},
+          {name: ubuntu, vmaj: 24, vmin: '10'},
+          {name: sles, vmaj: 15, vmin: 2},
+          {name: sles, vmaj: 15, vmin: 3},
+          {name: sles, vmaj: 15, vmin: 4},
+          {name: rhel, vmaj: 8, vmin: 6},
+          {name: windows}
+        ]
+        target: [install, package]
+        arch: ['']
+        include: [
+          {os: {name: ubuntu, vmaj: 20, vmin: '04'}, target: install, arch: arm64},
+          {os: {name: ubuntu, vmaj: 20, vmin: '04'}, target: package, arch: arm64}
+        ]
+    env:
+      MSYS_NO_PATHCONV: 1
+      MOUNT_TARGET:  ${{ matrix.os.name == 'windows' && 'C:/project' || '/project' }}
+      # -j breaks the Visual Studio configuration selection
+      PARALLEL: ${{ ! (matrix.os.name == 'windows') && '-j' || '' }}
+      ARCH_SUFFIX: ${{ matrix.arch != '' && format('_{0}', matrix.arch) || '' }}
+    steps:
+    - name: Set constants
+      id: const
+      env:
+        OS_STRING: >-
+          ${{ matrix.os.name == 'windows' && 'windows' ||
+              format('{0}-{1}.{2}',
+                matrix.os.name,
+                matrix.os.vmaj,
+                matrix.os.vmin
+              )
+          }}
+        CCACHE_DIR: ${{ github.workspace }}/ccache
+      run: |
+        cat >> ${GITHUB_OUTPUT} <<EOF
+        os-string=${OS_STRING}
+        image-name=ghcr.io/${{ github.repository }}/${OS_STRING}
+        ccache-dir=${CCACHE_DIR}
+        EOF
+    - uses: actions/checkout@v4
+      with:
+        clean: true
+        fetch-depth: 0
+        ref: ${{ github.event.pull_request.head.sha }}
+    - name: Create Ccache directory
+      run: mkdir -p '${{ steps.const.outputs.ccache-dir }}'
+    - name: Ccache
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.const.outputs.ccache-dir }}
+        key: ccache-${{ github.job }}-${{ steps.const.outputs.os-string }}${{ env.ARCH_SUFFIX }}-${{ matrix.target }}-${{ github.sha }}
+        restore-keys: ccache-${{ github.job }}-${{ steps.const.outputs.os-string }}${{ env.ARCH_SUFFIX }}-${{ matrix.target }}-
+    - name: Compute image name
+      run: echo "DOCKER_IMAGE=localhost/${{ github.repository }}/${{ steps.const.outputs.os-string }}" >> ${GITHUB_ENV}
+    - name: "Registry login: ghcr.io"
+      run: |
+        echo ${{ secrets.GITHUB_TOKEN }} |
+        docker login -u sys-lzdev --password-stdin ghcr.io
+    - name: Build image
+      run: |
+        docker info
+        docker build \
+        ${{ runner.os == 'Windows' && '  \
+          --memory 16G ' || '  '
+        }}\
+        ${{ matrix.os.vmaj != '' && format('  \
+          --build-arg VMAJ={0} \
+          --build-arg VMIN={1} ', matrix.os.vmaj, matrix.os.vmin) || '  '
+        }}\
+          --pull \
+          --tag ${DOCKER_IMAGE}:${{ needs.config.outputs.ref-slug }} \
+          - < .github/docker/${{ matrix.os.name }}.Dockerfile
+    - name: Build
+      id: build
+      run: |
+        mkdir build
+        docker run \
+          --rm \
+          --interactive \
+          -v '${{ github.workspace }}':${MOUNT_TARGET} \
+          -w ${MOUNT_TARGET}/build \
+          -e CCACHE_BASEDIR=${MOUNT_TARGET} \
+          -e CCACHE_DIR=${MOUNT_TARGET}/ccache \
+          -v '${{ steps.const.outputs.ccache-dir }}':${MOUNT_TARGET}/ccache \
+          ${DOCKER_IMAGE}:${{ needs.config.outputs.ref-slug }} \
+          bash -e -x <<-EOF
+
+        	cmake \
+        ${{ matrix.os.name != 'windows' && '	  \
+        	  -G Ninja ' || '	  '
+        }}\
+        ${{ matrix.arch == 'arm64' && '	  \
+        	  -D CMAKE_C_COMPILER=aarch64-linux-gnu-gcc \
+        	  -D CMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ \
+        	  -D CMAKE_SYSTEM_PROCESSOR=aarch64 ' || '	  '
+        }}\
+        	  -D CMAKE_C_COMPILER_LAUNCHER=ccache \
+        	  -D CMAKE_CXX_COMPILER_LAUNCHER=ccache \
+        	  -D CMAKE_BUILD_TYPE=Release \
+        	  -D CMAKE_INSTALL_PREFIX=${{ matrix.target == 'install' && '../level-zero-install' || matrix.target == 'package' && '/usr' || '' }} \
+        	  -D CPACK_OUTPUT_FILE_PREFIX=${MOUNT_TARGET}/level-zero-package \
+        	  ..
+        	
+        	cmake --build . ${PARALLEL} --target ${{ matrix.target }} ${{ matrix.os.name == 'windows' && '--config Release' || '' }}
+        	
+        	ccache --show-stats
+        	
+        	EOF

--- a/.github/workflows/build-multi-static.yml
+++ b/.github/workflows/build-multi-static.yml
@@ -148,6 +148,7 @@ jobs:
         	  -D CMAKE_C_COMPILER_LAUNCHER=ccache \
         	  -D CMAKE_CXX_COMPILER_LAUNCHER=ccache \
         	  -D CMAKE_BUILD_TYPE=Release \
+        	  -D BUILD_STATIC=1 \
         	  -D CMAKE_INSTALL_PREFIX=${{ matrix.target == 'install' && '../level-zero-install' || matrix.target == 'package' && '/usr' || '' }} \
         	  -D CPACK_OUTPUT_FILE_PREFIX=${MOUNT_TARGET}/level-zero-package \
         	  ..

--- a/.github/workflows/build-quick-static.yml
+++ b/.github/workflows/build-quick-static.yml
@@ -1,0 +1,49 @@
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  build-linux:
+    if: github.repository_owner == 'oneapi-src'
+    runs-on: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: hendrikmuhs/ccache-action@v1
+      - name: Build Loader on Latest Ubuntu
+        run: |
+          mkdir build
+          cd build
+          cmake \
+            -D CMAKE_C_COMPILER_LAUNCHER=ccache \
+            -D CMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -D CMAKE_BUILD_TYPE=Release \
+            -D BUILD_L0_LOADER_TESTS=1 \
+            ..
+          make -j$(nproc)
+      - env:
+          ZE_ENABLE_LOADER_DEBUG_TRACE: '1'
+          ZEL_LIBRARY_PATH: '${{ github.workspace }}/build/lib'
+        working-directory: build
+        run: ctest -V
+
+  build-windows:
+    if: github.repository_owner == 'oneapi-src'
+    runs-on: [windows-latest]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build Loader on Latest Windows
+        run: |
+          mkdir build
+          cd build
+          cmake -D BUILD_L0_LOADER_TESTS=1 -D BUILD_STATIC=1 ..
+          cmake --build . --config Release
+      - env:
+          ZE_ENABLE_LOADER_DEBUG_TRACE: '1'
+          ZEL_LIBRARY_PATH: '${{ github.workspace }}/build/bin/Release'
+        working-directory: build
+        run: ctest -C Release -V

--- a/.github/workflows/build-quick-static.yml
+++ b/.github/workflows/build-quick-static.yml
@@ -39,8 +39,9 @@ jobs:
               -D BUILD_STATIC=1 \
               ..
             make -j$(nproc)
+            cp lib/*.so* ../build/lib
       - env:
-          ZEL_LIBRARY_PATH: '${{ github.workspace }}/dynamic_build/lib'
+          ZEL_LIBRARY_PATH: '${{ github.workspace }}/build/lib'
         working-directory: build
         run: ZE_ENABLE_LOADER_DEBUG_TRACE=1 ctest -V
 

--- a/.github/workflows/build-quick-static.yml
+++ b/.github/workflows/build-quick-static.yml
@@ -36,14 +36,13 @@ jobs:
               -D CMAKE_CXX_COMPILER_LAUNCHER=ccache \
               -D CMAKE_BUILD_TYPE=Release \
               -D BUILD_L0_LOADER_TESTS=1 \
-              -D BUILD_STATIC=1 \
+              -D BUILD_STATIC=0 \
               ..
             make -j$(nproc)
-            cp lib/*.so* ../build/lib
       - env:
-          ZEL_LIBRARY_PATH: '${{ github.workspace }}/build/lib'
+          ZEL_LIBRARY_PATH: '${{ github.workspace }}/dynamic_build/lib'
         working-directory: build
-        run: ZE_ENABLE_LOADER_DEBUG_TRACE=1 ctest -V
+        run: ls $ZEL_LIBRARY_PATH;ZE_ENABLE_LOADER_DEBUG_TRACE=1 ctest -V
 
   build-windows:
     if: github.repository_owner == 'oneapi-src'

--- a/.github/workflows/build-quick-static.yml
+++ b/.github/workflows/build-quick-static.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: hendrikmuhs/ccache-action@v1
-      - name: Build Loader on Latest Ubuntu
+      - name: Build Static Loader on Latest Ubuntu
         run: |
           mkdir build
           cd build
@@ -23,13 +23,26 @@ jobs:
             -D CMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -D CMAKE_BUILD_TYPE=Release \
             -D BUILD_L0_LOADER_TESTS=1 \
+            -D BUILD_STATIC=1 \
             ..
           make -j$(nproc)
+      - name: Build Dynamic Loader on Latest Ubuntu
+        run: |
+            cd ${{ github.workspace }}
+            mkdir dynamic_build
+            cd dynamic_build
+            cmake \
+              -D CMAKE_C_COMPILER_LAUNCHER=ccache \
+              -D CMAKE_CXX_COMPILER_LAUNCHER=ccache \
+              -D CMAKE_BUILD_TYPE=Release \
+              -D BUILD_L0_LOADER_TESTS=1 \
+              -D BUILD_STATIC=1 \
+              ..
+            make -j$(nproc)
       - env:
-          ZE_ENABLE_LOADER_DEBUG_TRACE: '1'
-          ZEL_LIBRARY_PATH: '${{ github.workspace }}/build/lib'
+          ZEL_LIBRARY_PATH: '${{ github.workspace }}/dynamic_build/lib'
         working-directory: build
-        run: ctest -V
+        run: ZE_ENABLE_LOADER_DEBUG_TRACE=1 ctest -V
 
   build-windows:
     if: github.repository_owner == 'oneapi-src'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Level zero loader changelog
 
+## v1.21.0
+* Add Support for building the L0 Loader statically
 ## v1.20.6
 * Add in missing header for ze_handle_t definition for DDI extension
 ## v1.20.5

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,13 +53,22 @@ endif()
 include(FetchContent)
 
 if(BUILD_L0_LOADER_TESTS)
-	FetchContent_Declare(
-		googletest
-		URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.zip
-	)
+    FetchContent_Declare(
+        googletest
+        GIT_REPOSITORY https://github.com/google/googletest.git
+        GIT_TAG        v1.14.0
+    )
+    add_library(GTest::GTest INTERFACE IMPORTED)
+    target_link_libraries(GTest::GTest INTERFACE gtest_main)
 
 	# For Windows: Prevent overriding the parent project's compiler/linker settings
-	set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+    if(MSVC)
+        if (BUILD_STATIC)
+            set(gtest_force_shared_crt OFF CACHE BOOL "" FORCE)
+        else()
+            set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+        endif()
+    endif()
 
 	FetchContent_MakeAvailable(googletest)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,11 +63,7 @@ if(BUILD_L0_LOADER_TESTS AND (NOT MSVC OR (MSVC AND NOT BUILD_STATIC)))
 
 	# For Windows: Prevent overriding the parent project's compiler/linker settings
     if(MSVC)
-        if (BUILD_STATIC)
-            set(gtest_force_shared_crt OFF CACHE BOOL "" FORCE)
-        else()
-            set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-        endif()
+        set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
     endif()
 
 	FetchContent_MakeAvailable(googletest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ endif()
 
 include(FetchContent)
 
-if(BUILD_L0_LOADER_TESTS)
+if(BUILD_L0_LOADER_TESTS AND (NOT MSVC OR (MSVC AND NOT BUILD_STATIC)))
     FetchContent_Declare(
         googletest
         GIT_REPOSITORY https://github.com/google/googletest.git
@@ -191,7 +191,7 @@ set(TARGET_LOADER_NAME ze_loader)
 add_subdirectory(source)
 add_subdirectory(samples)
 
-if(BUILD_L0_LOADER_TESTS)
+if(BUILD_L0_LOADER_TESTS AND (NOT MSVC OR (MSVC AND NOT BUILD_STATIC)))
     include(CTest)
     add_subdirectory(test)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if(MSVC AND (MSVC_VERSION LESS 1900))
 endif()
 
 # This project follows semantic versioning (https://semver.org/)
-project(level-zero VERSION 1.20.6)
+project(level-zero VERSION 1.21.0)
 
 include(GNUInstallDirs)
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,19 @@ cmake --build . --target package
 cmake --build . --target install
 ```
 
+# Static Loader
+To build the Loader statically one must set `-DBUILD_STATIC=1` during the cmake configuration step.
+
+The build of the static loader creates a ze_loader.a/.lib which will link the source/lib source code into your application or library.
+
+This enables for inclusion of all L0 symbols into your application/library allowing for backwards compatability with older versions of the Loader.
+
+The static loader "shim" dynamically loads the ze_loader.so/.dll on the system enabling plugin like behavior where the init will fail gracefully given a usable loader or L0 driver is not found.
+
+When the `-DBUILD_STATIC=1` is executed, the dynamic loader and layers are not built to avoid conflicts during local test execution which requires the dynamic loader and layers to all be the same version for compatability.
+
+Testing with the static loader requires a build of the dynamic loader or an installation of the dynamic loader to exist in the library path.
+
 # Debug Trace
 The Level Zero Loader has the ability to print warnings and errors which occur within the internals of the Level Zero Loader itself.
 

--- a/scripts/templates/libddi.cpp.mako
+++ b/scripts/templates/libddi.cpp.mako
@@ -26,7 +26,7 @@ namespace ${x}_lib
     ///////////////////////////////////////////////////////////////////////////////
 
 #ifdef DYNAMIC_LOAD_LOADER
-    __zedlllocal ${x}_result_t context_t::${n}DdiTableInit()
+    __zedlllocal ${x}_result_t context_t::${n}DdiTableInit(ze_api_version_t version)
     {
         ${x}_result_t result = ${X}_RESULT_SUCCESS;
 
@@ -37,11 +37,11 @@ namespace ${x}_lib
             // Optional
             auto getTable = reinterpret_cast<${tbl['pfn']}>(
                 GET_FUNCTION_PTR(loader, "${tbl['export']['name']}") );
-            getTable( ${X}_API_VERSION_CURRENT, &initial${n}DdiTable.${tbl['name']} );
+            getTableWithCheck(getTable, version, &initial${n}DdiTable.${tbl['name']} );
     %else:
             auto getTable = reinterpret_cast<${tbl['pfn']}>(
                 GET_FUNCTION_PTR(loader, "${tbl['export']['name']}") );
-            result = getTable( ${X}_API_VERSION_CURRENT, &initial${n}DdiTable.${tbl['name']} );
+            result = getTableWithCheck(getTable, version, &initial${n}DdiTable.${tbl['name']} );
     %endif
         }
 
@@ -49,7 +49,7 @@ namespace ${x}_lib
         return result;
     }
 #else
-    __zedlllocal ${x}_result_t context_t::${n}DdiTableInit()
+    __zedlllocal ${x}_result_t context_t::${n}DdiTableInit(ze_api_version_t version)
     {
         ${x}_result_t result = ${X}_RESULT_SUCCESS;
 
@@ -58,9 +58,9 @@ namespace ${x}_lib
         {
             %if tbl['optional'] == True:
             // Optional
-            ${tbl['export']['name']}( ${X}_API_VERSION_CURRENT, &initial${n}DdiTable.${tbl['name']} );
+            ${tbl['export']['name']}( version, &initial${n}DdiTable.${tbl['name']} );
             %else:
-            result = ${tbl['export']['name']}( ${X}_API_VERSION_CURRENT, &initial${n}DdiTable.${tbl['name']} );
+            result = ${tbl['export']['name']}( version, &initial${n}DdiTable.${tbl['name']} );
             %endif
         }
 

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -12,11 +12,22 @@ configure_file(
     @ONLY)
 
 include(GNUInstallDirs)
-add_library(${TARGET_LOADER_NAME}
-    SHARED
-    ""
-    ${CMAKE_CURRENT_BINARY_DIR}/ZeLoaderVersion.rc
-)
+if (DYNAMIC_LOAD_LOADER)
+    message(STATUS "Building loader as static library")
+    add_library(${TARGET_LOADER_NAME}
+        STATIC
+        ""
+        ${CMAKE_CURRENT_BINARY_DIR}/ZeLoaderVersion.rc
+    )
+    add_definitions(-DDYNAMIC_LOAD_LOADER="1")
+else()
+    message(STATUS "Building loader as dynamic library")
+    add_library(${TARGET_LOADER_NAME}
+        SHARED
+        ""
+        ${CMAKE_CURRENT_BINARY_DIR}/ZeLoaderVersion.rc
+    )
+endif()
 
 add_subdirectory(lib)
 add_subdirectory(loader)

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -12,7 +12,7 @@ configure_file(
     @ONLY)
 
 include(GNUInstallDirs)
-if (DYNAMIC_LOAD_LOADER)
+if (BUILD_STATIC)
     message(STATUS "Building loader as static library")
     add_library(${TARGET_LOADER_NAME}
         STATIC

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -30,8 +30,10 @@ else()
 endif()
 
 add_subdirectory(lib)
-add_subdirectory(loader)
-add_subdirectory(layers)
+if (NOT BUILD_STATIC)
+    add_subdirectory(loader)
+    add_subdirectory(layers)
+endif()
 add_subdirectory(drivers)
 add_subdirectory(utils)
 

--- a/source/lib/linux/lib_init.cpp
+++ b/source/lib/linux/lib_init.cpp
@@ -12,11 +12,9 @@ namespace ze_lib
 {
 #ifndef DYNAMIC_LOAD_LOADER
     void __attribute__((constructor)) createLibContext() {
-        printf("Context created context lib dynamic\n");
         context = new context_t;
     }
 void __attribute__((destructor)) deleteLibContext() {
-        printf("Context destroyed context lib dynamic\n");
     delete context;
 } 
 #endif

--- a/source/lib/linux/lib_init.cpp
+++ b/source/lib/linux/lib_init.cpp
@@ -10,13 +10,15 @@
 
 namespace ze_lib
 {
-
+#ifndef DYNAMIC_LOAD_LOADER
     void __attribute__((constructor)) createLibContext() {
+        printf("Context created context lib dynamic\n");
         context = new context_t;
-    } 
-
-    void __attribute__((destructor)) deleteLibContext() {
-        delete context;
-    } 
+    }
+void __attribute__((destructor)) deleteLibContext() {
+        printf("Context destroyed context lib dynamic\n");
+    delete context;
+} 
+#endif
 
 }

--- a/source/lib/windows/lib_init.cpp
+++ b/source/lib/windows/lib_init.cpp
@@ -13,16 +13,7 @@
 
 namespace ze_lib
 {
-#ifdef DYNAMIC_LOAD_LOADER
-    export "C" BOOL APIENTRY DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved) {
-        if (fdwReason == DLL_PROCESS_DETACH) {
-            delete context;
-        } else if (fdwReason == DLL_PROCESS_ATTACH) {
-            context = new context_t;
-        }
-        return TRUE;
-    }       
-#else
+#ifndef DYNAMIC_LOAD_LOADER
     extern "C" BOOL APIENTRY DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved) {
         if (fdwReason == DLL_PROCESS_DETACH) {
             delete context;

--- a/source/lib/ze_lib.cpp
+++ b/source/lib/ze_lib.cpp
@@ -46,9 +46,15 @@ namespace ze_lib
         ze_api_version_t version = ZE_API_VERSION_CURRENT;
 #ifdef DYNAMIC_LOAD_LOADER
         std::string loaderLibraryPath;
-#ifdef _WIN32
-        loaderLibraryPath = readLevelZeroLoaderLibraryPath();
-#endif
+        auto loaderLibraryPathEnv = getenv_string("ZEL_LIBRARY_PATH");
+        if (!loaderLibraryPathEnv.empty()) {
+            loaderLibraryPath = loaderLibraryPathEnv;
+        }
+        #ifdef _WIN32
+        else {
+            loaderLibraryPath = readLevelZeroLoaderLibraryPath();
+        }
+        #endif
         std::string loaderFullLibraryPath = create_library_path(MAKE_LIBRARY_NAME( "ze_loader", L0_LOADER_VERSION), loaderLibraryPath.c_str());
         loader = LOAD_DRIVER_LIBRARY(loaderFullLibraryPath.c_str());
 

--- a/source/lib/ze_lib.cpp
+++ b/source/lib/ze_lib.cpp
@@ -76,34 +76,6 @@ namespace ze_lib
             return result;
         }
 
-        // Init Dynamic Loader's Lib Context:
-        auto initDriversLoader = reinterpret_cast<ze_pfnInitDrivers_t>(
-            GET_FUNCTION_PTR(loader, "zeInitDrivers") );
-        auto initLoader = reinterpret_cast<ze_pfnInit_t>(
-            GET_FUNCTION_PTR(loader, "zeInit") );
-        if (initDriversLoader == nullptr && initLoader == nullptr) {
-            std::string message = "ze_lib Context Init() zeInitDrivers and zeInit missing, returning ";
-            debug_trace_message(message, to_string(ZE_RESULT_ERROR_UNINITIALIZED));
-            return ZE_RESULT_ERROR_UNINITIALIZED;
-        }
-        if (!desc) {
-            result = initLoader(flags);
-        } else if (initDriversLoader != nullptr) {
-            uint32_t pInitDriversCount = 0;
-            result = initDriversLoader(&pInitDriversCount, nullptr, desc);
-        } else {
-            ze_init_flags_t init_flags = flags;
-            if (desc) {
-                if(desc->flags & ZE_INIT_DRIVER_TYPE_FLAG_GPU) {
-                    init_flags = ZE_INIT_FLAG_GPU_ONLY;
-                } else if(desc->flags & ZE_INIT_DRIVER_TYPE_FLAG_NPU) {
-                    init_flags = ZE_INIT_FLAG_VPU_ONLY;
-                } else {
-                    init_flags = 0;
-                }
-            }
-            result = initLoader(init_flags);
-        }
         if (result != ZE_RESULT_SUCCESS) {
             std::string message = "ze_lib Context Init() zeInitDrivers or zeInit failed with ";
             debug_trace_message(message, to_string(result));
@@ -316,6 +288,36 @@ namespace ze_lib
 
         if( ZE_RESULT_SUCCESS == result )
         {
+#ifdef DYNAMIC_LOAD_LOADER
+            // Init Dynamic Loader's Lib Context:
+            auto initDriversLoader = reinterpret_cast<ze_pfnInitDrivers_t>(
+                GET_FUNCTION_PTR(loader, "zeInitDrivers") );
+            auto initLoader = reinterpret_cast<ze_pfnInit_t>(
+                GET_FUNCTION_PTR(loader, "zeInit") );
+            if (initDriversLoader == nullptr && initLoader == nullptr) {
+                std::string message = "ze_lib Context Init() zeInitDrivers and zeInit missing, returning ";
+                debug_trace_message(message, to_string(ZE_RESULT_ERROR_UNINITIALIZED));
+                return ZE_RESULT_ERROR_UNINITIALIZED;
+            }
+            if (!desc) {
+                result = initLoader(flags);
+            } else if (initDriversLoader != nullptr) {
+                uint32_t pInitDriversCount = 0;
+                result = initDriversLoader(&pInitDriversCount, nullptr, desc);
+            } else {
+                ze_init_flags_t init_flags = flags;
+                if (desc) {
+                    if(desc->flags & ZE_INIT_DRIVER_TYPE_FLAG_GPU) {
+                        init_flags = ZE_INIT_FLAG_GPU_ONLY;
+                    } else if(desc->flags & ZE_INIT_DRIVER_TYPE_FLAG_NPU) {
+                        init_flags = ZE_INIT_FLAG_VPU_ONLY;
+                    } else {
+                        init_flags = 0;
+                    }
+                }
+                result = initLoader(init_flags);
+            }
+#endif
             isInitialized = true;
         }
 

--- a/source/lib/ze_lib.cpp
+++ b/source/lib/ze_lib.cpp
@@ -12,17 +12,12 @@
 
 namespace ze_lib
 {
-    #ifdef DYNAMIC_LOAD_LOADER
-    context_t &init_context() {
-        static context_t loader_context;
-        return loader_context;
-    }
-    #endif
     ///////////////////////////////////////////////////////////////////////////////
     #ifndef DYNAMIC_LOAD_LOADER
     context_t *context;
     #else
-    context_t *context = &init_context();
+    context_t loader_context;
+    context_t *context = &loader_context;
     #endif
     bool destruction = false;
 

--- a/source/lib/ze_lib.cpp
+++ b/source/lib/ze_lib.cpp
@@ -305,7 +305,16 @@ zelLoaderTranslateHandle(
    void **handleOut)
 
 {
+#ifdef DYNAMIC_LOAD_LOADER
+    if(nullptr == ze_lib::context->loader)
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    typedef ze_result_t (ZE_APICALL *zelLoaderTranslateHandleInternal_t)(zel_handle_type_t handleType, void *handleIn, void **handleOut);
+    auto translateHandle = reinterpret_cast<zelLoaderTranslateHandleInternal_t>(
+            GET_FUNCTION_PTR(ze_lib::context->loader, "zelLoaderTranslateHandleInternal") );
+    return translateHandle(handleType, handleIn, handleOut);
+#else
     return zelLoaderTranslateHandleInternal(handleType, handleIn, handleOut);
+#endif
 }
 
 ze_result_t ZE_APICALL

--- a/source/lib/ze_lib.cpp
+++ b/source/lib/ze_lib.cpp
@@ -12,11 +12,17 @@
 
 namespace ze_lib
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    context_t &init_context() {
+        static context_t loader_context;
+        return loader_context;
+    }
+    #endif
     ///////////////////////////////////////////////////////////////////////////////
     #ifndef DYNAMIC_LOAD_LOADER
     context_t *context;
     #else
-    context_t *context = new context_t;
+    context_t *context = &init_context();
     #endif
     bool destruction = false;
 

--- a/source/lib/ze_lib.cpp
+++ b/source/lib/ze_lib.cpp
@@ -77,7 +77,9 @@ namespace ze_lib
             debug_trace_message(message, to_string(ZE_RESULT_ERROR_UNINITIALIZED));
             return ZE_RESULT_ERROR_UNINITIALIZED;
         }
-        if (initDriversLoader != nullptr) {
+        if (!desc) {
+            result = initLoader(flags);
+        } else if (initDriversLoader != nullptr) {
             uint32_t pInitDriversCount = 0;
             result = initDriversLoader(&pInitDriversCount, nullptr, desc);
         } else {

--- a/source/lib/ze_lib.cpp
+++ b/source/lib/ze_lib.cpp
@@ -55,6 +55,8 @@ namespace ze_lib
             loaderLibraryPath = readLevelZeroLoaderLibraryPath();
         }
 #endif
+        if (debugTraceEnabled)
+            debug_trace_message("Static Loader Using Loader Library Path: ", loaderLibraryPath);
         std::string loaderFullLibraryPath = create_library_path(MAKE_LIBRARY_NAME( "ze_loader", L0_LOADER_VERSION), loaderLibraryPath.c_str());
         loader = LOAD_DRIVER_LIBRARY(loaderFullLibraryPath.c_str());
 

--- a/source/lib/ze_lib.cpp
+++ b/source/lib/ze_lib.cpp
@@ -50,11 +50,11 @@ namespace ze_lib
         if (!loaderLibraryPathEnv.empty()) {
             loaderLibraryPath = loaderLibraryPathEnv;
         }
-        #ifdef _WIN32
+#ifdef _WIN32
         else {
             loaderLibraryPath = readLevelZeroLoaderLibraryPath();
         }
-        #endif
+#endif
         std::string loaderFullLibraryPath = create_library_path(MAKE_LIBRARY_NAME( "ze_loader", L0_LOADER_VERSION), loaderLibraryPath.c_str());
         loader = LOAD_DRIVER_LIBRARY(loaderFullLibraryPath.c_str());
 

--- a/source/lib/ze_lib.h
+++ b/source/lib/ze_lib.h
@@ -27,7 +27,7 @@
 namespace ze_lib
 {
     ///////////////////////////////////////////////////////////////////////////////
-    class context_t
+    class __zedlllocal context_t
     {
     public:
 #ifdef DYNAMIC_LOAD_LOADER
@@ -38,7 +38,7 @@ namespace ze_lib
         ~context_t();
 
     //////////////////////////////////////////////////////////////////////////
-    std::string to_string(const ze_result_t result) {
+    __zedlllocal std::string to_string(const ze_result_t result) {
         if (result == ZE_RESULT_SUCCESS) {
             return "ZE_RESULT_SUCCESS";
         } else if (result == ZE_RESULT_NOT_READY) {
@@ -121,7 +121,7 @@ namespace ze_lib
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void debug_trace_message(std::string message, std::string result) {
+    __zedlllocal void debug_trace_message(std::string message, std::string result) {
         if (debugTraceEnabled){
             std::string debugTracePrefix = "ZE_LOADER_DEBUG_TRACE:";
             std::cerr << debugTracePrefix << message << result << std::endl;
@@ -130,7 +130,7 @@ namespace ze_lib
 
     ///////////////////////////////////////////////////////////////////////////////
     template <typename T, typename TableType>
-    ze_result_t getTableWithCheck(T getTable, ze_api_version_t version, TableType* table) {
+    __zedlllocal ze_result_t getTableWithCheck(T getTable, ze_api_version_t version, TableType* table) {
         ze_result_t result = ZE_RESULT_ERROR_UNINITIALIZED;
         if (getTable == nullptr) {
             std::string message = "getTableWithCheck Failed for " + std::string(typeid(TableType).name()) + " with ";
@@ -175,10 +175,10 @@ namespace ze_lib
         bool debugTraceEnabled = false;
     };
 
-    extern context_t *context;
     extern bool destruction;
+    extern context_t *context;
     #ifdef DYNAMIC_LOAD_LOADER
-    extern context_t loader_context;
+    extern context_t loader_context_static;
     #endif
 
 } // namespace ze_lib

--- a/source/lib/ze_lib.h
+++ b/source/lib/ze_lib.h
@@ -21,6 +21,8 @@
 #include <vector>
 #include <mutex>
 #include <atomic>
+#include <typeinfo>
+#include <iostream>
 
 namespace ze_lib
 {
@@ -35,14 +37,113 @@ namespace ze_lib
         context_t();
         ~context_t();
 
-        ///////////////////////////////////////////////////////////////////////////////
-        template <typename T, typename TableType>
-        ze_result_t getTableWithCheck(T getTable, ze_api_version_t version, TableType* table) {
-            if (getTable == nullptr) {
-            return ZE_RESULT_ERROR_UNINITIALIZED;
-            }
-            return getTable(version, table);
+    //////////////////////////////////////////////////////////////////////////
+    std::string to_string(const ze_result_t result) {
+        if (result == ZE_RESULT_SUCCESS) {
+            return "ZE_RESULT_SUCCESS";
+        } else if (result == ZE_RESULT_NOT_READY) {
+            return "ZE_RESULT_NOT_READY";
+        } else if (result == ZE_RESULT_ERROR_UNINITIALIZED) {
+            return "ZE_RESULT_ERROR_UNINITIALIZED";
+        } else if (result == ZE_RESULT_ERROR_DEVICE_LOST) {
+            return "ZE_RESULT_ERROR_DEVICE_LOST";
+        } else if (result == ZE_RESULT_ERROR_INVALID_ARGUMENT) {
+            return "ZE_RESULT_ERROR_INVALID_ARGUMENT";
+        } else if (result == ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY) {
+            return "ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY";
+        } else if (result == ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY) {
+            return "ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY";
+        } else if (result == ZE_RESULT_ERROR_MODULE_BUILD_FAILURE) {
+            return "ZE_RESULT_ERROR_MODULE_BUILD_FAILURE";
+        } else if (result == ZE_RESULT_ERROR_MODULE_LINK_FAILURE) {
+            return "ZE_RESULT_ERROR_MODULE_LINK_FAILURE";
+        } else if (result == ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS) {
+            return "ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS";
+        } else if (result == ZE_RESULT_ERROR_NOT_AVAILABLE) {
+            return "ZE_RESULT_ERROR_NOT_AVAILABLE";
+        } else if (result == ZE_RESULT_ERROR_DEPENDENCY_UNAVAILABLE) {
+            return "ZE_RESULT_ERROR_DEPENDENCY_UNAVAILABLE";
+        } else if (result == ZE_RESULT_WARNING_DROPPED_DATA) {
+            return "ZE_RESULT_WARNING_DROPPED_DATA";
+        } else if (result == ZE_RESULT_ERROR_UNSUPPORTED_VERSION) {
+            return "ZE_RESULT_ERROR_UNSUPPORTED_VERSION";
+        } else if (result == ZE_RESULT_ERROR_UNSUPPORTED_FEATURE) {
+            return "ZE_RESULT_ERROR_UNSUPPORTED_FEATURE";
+        } else if (result == ZE_RESULT_ERROR_INVALID_NULL_HANDLE) {
+            return "ZE_RESULT_ERROR_INVALID_NULL_HANDLE";
+        } else if (result == ZE_RESULT_ERROR_HANDLE_OBJECT_IN_USE) {
+            return "ZE_RESULT_ERROR_HANDLE_OBJECT_IN_USE";
+        } else if (result == ZE_RESULT_ERROR_INVALID_NULL_POINTER) {
+            return "ZE_RESULT_ERROR_INVALID_NULL_POINTER";
+        } else if (result == ZE_RESULT_ERROR_INVALID_SIZE) {
+            return "ZE_RESULT_ERROR_INVALID_SIZE";
+        } else if (result == ZE_RESULT_ERROR_UNSUPPORTED_SIZE) {
+            return "ZE_RESULT_ERROR_UNSUPPORTED_SIZE";
+        } else if (result == ZE_RESULT_ERROR_UNSUPPORTED_ALIGNMENT) {
+            return "ZE_RESULT_ERROR_UNSUPPORTED_ALIGNMENT";
+        } else if (result == ZE_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT) {
+            return "ZE_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT";
+        } else if (result == ZE_RESULT_ERROR_INVALID_ENUMERATION) {
+            return "ZE_RESULT_ERROR_INVALID_ENUMERATION";
+        } else if (result == ZE_RESULT_ERROR_UNSUPPORTED_ENUMERATION) {
+            return "ZE_RESULT_ERROR_UNSUPPORTED_ENUMERATION";
+        } else if (result == ZE_RESULT_ERROR_UNSUPPORTED_IMAGE_FORMAT) {
+            return "ZE_RESULT_ERROR_UNSUPPORTED_IMAGE_FORMAT";
+        } else if (result == ZE_RESULT_ERROR_INVALID_NATIVE_BINARY) {
+            return "ZE_RESULT_ERROR_INVALID_NATIVE_BINARY";
+        } else if (result == ZE_RESULT_ERROR_INVALID_GLOBAL_NAME) {
+            return "ZE_RESULT_ERROR_INVALID_GLOBAL_NAME";
+        } else if (result == ZE_RESULT_ERROR_INVALID_KERNEL_NAME) {
+            return "ZE_RESULT_ERROR_INVALID_KERNEL_NAME";
+        } else if (result == ZE_RESULT_ERROR_INVALID_FUNCTION_NAME) {
+            return "ZE_RESULT_ERROR_INVALID_FUNCTION_NAME";
+        } else if (result == ZE_RESULT_ERROR_INVALID_GROUP_SIZE_DIMENSION) {
+            return "ZE_RESULT_ERROR_INVALID_GROUP_SIZE_DIMENSION";
+        } else if (result == ZE_RESULT_ERROR_INVALID_GLOBAL_WIDTH_DIMENSION) {
+            return "ZE_RESULT_ERROR_INVALID_GLOBAL_WIDTH_DIMENSION";
+        } else if (result == ZE_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX) {
+            return "ZE_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX";
+        } else if (result == ZE_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE) {
+            return "ZE_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE";
+        } else if (result == ZE_RESULT_ERROR_INVALID_KERNEL_ATTRIBUTE_VALUE) {
+            return "ZE_RESULT_ERROR_INVALID_KERNEL_ATTRIBUTE_VALUE";
+        } else if (result == ZE_RESULT_ERROR_INVALID_MODULE_UNLINKED) {
+            return "ZE_RESULT_ERROR_INVALID_MODULE_UNLINKED";
+        } else if (result == ZE_RESULT_ERROR_INVALID_COMMAND_LIST_TYPE) {
+            return "ZE_RESULT_ERROR_INVALID_COMMAND_LIST_TYPE";
+        } else if (result == ZE_RESULT_ERROR_OVERLAPPING_REGIONS) {
+            return "ZE_RESULT_ERROR_OVERLAPPING_REGIONS";
+        } else if (result == ZE_RESULT_ERROR_UNKNOWN) {
+            return "ZE_RESULT_ERROR_UNKNOWN";
+        } else {
+            return std::to_string(static_cast<int>(result));
         }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    void debug_trace_message(std::string message, std::string result) {
+        if (debugTraceEnabled){
+            std::string debugTracePrefix = "ZE_LOADER_DEBUG_TRACE:";
+            std::cerr << debugTracePrefix << message << result << std::endl;
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    template <typename T, typename TableType>
+    ze_result_t getTableWithCheck(T getTable, ze_api_version_t version, TableType* table) {
+        ze_result_t result = ZE_RESULT_ERROR_UNINITIALIZED;
+        if (getTable == nullptr) {
+            std::string message = "getTableWithCheck Failed for " + std::string(typeid(TableType).name()) + " with ";
+            debug_trace_message(message, to_string(result));
+            return result;
+        }
+        result = getTable(version, table);
+        if (result != ZE_RESULT_SUCCESS) {
+            std::string message = "getTableWithCheck Failed for " + std::string(typeid(TableType).name()) + " with ";
+            debug_trace_message(message, to_string(result));
+        }
+        return result;
+    }
 
         std::once_flag initOnce;
         std::once_flag initOnceDrivers;
@@ -71,6 +172,7 @@ namespace ze_lib
         bool isInitialized = false;
         bool zesInuse = false;
         bool zeInuse = false;
+        bool debugTraceEnabled = false;
     };
 
     extern context_t *context;

--- a/source/lib/ze_lib.h
+++ b/source/lib/ze_lib.h
@@ -177,5 +177,8 @@ namespace ze_lib
 
     extern context_t *context;
     extern bool destruction;
+    #ifdef DYNAMIC_LOAD_LOADER
+    extern context_t loader_context;
+    #endif
 
 } // namespace ze_lib

--- a/source/lib/ze_lib.h
+++ b/source/lib/ze_lib.h
@@ -35,22 +35,31 @@ namespace ze_lib
         context_t();
         ~context_t();
 
+        ///////////////////////////////////////////////////////////////////////////////
+        template <typename T, typename TableType>
+        ze_result_t getTableWithCheck(T getTable, ze_api_version_t version, TableType* table) {
+            if (getTable == nullptr) {
+            return ZE_RESULT_ERROR_UNINITIALIZED;
+            }
+            return getTable(version, table);
+        }
+
         std::once_flag initOnce;
         std::once_flag initOnceDrivers;
         std::once_flag initOnceSysMan;
 
         ze_result_t Init(ze_init_flags_t flags, bool sysmanOnly, ze_init_driver_type_desc_t* desc);
 
-        ze_result_t zeDdiTableInit();
+        ze_result_t zeDdiTableInit(ze_api_version_t version);
         std::atomic<ze_dditable_t *>  zeDdiTable = {nullptr};
 
-        ze_result_t zetDdiTableInit();
+        ze_result_t zetDdiTableInit(ze_api_version_t version);
         std::atomic<zet_dditable_t *> zetDdiTable = {nullptr};
 
-        ze_result_t zesDdiTableInit();
+        ze_result_t zesDdiTableInit(ze_api_version_t version);
         std::atomic<zes_dditable_t *> zesDdiTable = {nullptr};
 
-        ze_result_t zelTracingDdiTableInit();
+        ze_result_t zelTracingDdiTableInit(ze_api_version_t version);
         zel_tracing_dditable_t  zelTracingDdiTable = {};
         std::atomic<ze_dditable_t *> pTracingZeDdiTable = {nullptr};
         ze_dditable_t initialzeDdiTable;

--- a/source/lib/ze_libddi.cpp
+++ b/source/lib/ze_libddi.cpp
@@ -17,15 +17,14 @@ namespace ze_lib
     ///////////////////////////////////////////////////////////////////////////////
 
 #ifdef DYNAMIC_LOAD_LOADER
-    __zedlllocal ze_result_t context_t::zeDdiTableInit()
+    __zedlllocal ze_result_t context_t::zeDdiTableInit(ze_api_version_t version)
     {
         ze_result_t result = ZE_RESULT_SUCCESS;
-        printf("calling static loader ddi init\n");
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<ze_pfnGetGlobalProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetGlobalProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.Global );
+            result = getTableWithCheck(getTable, version, &initialzeDdiTable.Global );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -33,7 +32,7 @@ namespace ze_lib
             // Optional
             auto getTable = reinterpret_cast<ze_pfnGetRTASBuilderExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetRTASBuilderExpProcAddrTable") );
-            getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.RTASBuilderExp );
+            getTableWithCheck(getTable, version, &initialzeDdiTable.RTASBuilderExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -41,14 +40,14 @@ namespace ze_lib
             // Optional
             auto getTable = reinterpret_cast<ze_pfnGetRTASParallelOperationExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetRTASParallelOperationExpProcAddrTable") );
-            getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.RTASParallelOperationExp );
+            getTableWithCheck(getTable, version, &initialzeDdiTable.RTASParallelOperationExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<ze_pfnGetDriverProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetDriverProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.Driver );
+            result = getTableWithCheck(getTable, version, &initialzeDdiTable.Driver );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -56,14 +55,14 @@ namespace ze_lib
             // Optional
             auto getTable = reinterpret_cast<ze_pfnGetDriverExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetDriverExpProcAddrTable") );
-            getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.DriverExp );
+            getTableWithCheck(getTable, version, &initialzeDdiTable.DriverExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<ze_pfnGetDeviceProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetDeviceProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.Device );
+            result = getTableWithCheck(getTable, version, &initialzeDdiTable.Device );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -71,28 +70,28 @@ namespace ze_lib
             // Optional
             auto getTable = reinterpret_cast<ze_pfnGetDeviceExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetDeviceExpProcAddrTable") );
-            getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.DeviceExp );
+            getTableWithCheck(getTable, version, &initialzeDdiTable.DeviceExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<ze_pfnGetContextProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetContextProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.Context );
+            result = getTableWithCheck(getTable, version, &initialzeDdiTable.Context );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<ze_pfnGetCommandQueueProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetCommandQueueProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.CommandQueue );
+            result = getTableWithCheck(getTable, version, &initialzeDdiTable.CommandQueue );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<ze_pfnGetCommandListProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetCommandListProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.CommandList );
+            result = getTableWithCheck(getTable, version, &initialzeDdiTable.CommandList );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -100,14 +99,14 @@ namespace ze_lib
             // Optional
             auto getTable = reinterpret_cast<ze_pfnGetCommandListExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetCommandListExpProcAddrTable") );
-            getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.CommandListExp );
+            getTableWithCheck(getTable, version, &initialzeDdiTable.CommandListExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<ze_pfnGetEventProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetEventProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.Event );
+            result = getTableWithCheck(getTable, version, &initialzeDdiTable.Event );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -115,28 +114,28 @@ namespace ze_lib
             // Optional
             auto getTable = reinterpret_cast<ze_pfnGetEventExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetEventExpProcAddrTable") );
-            getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.EventExp );
+            getTableWithCheck(getTable, version, &initialzeDdiTable.EventExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<ze_pfnGetEventPoolProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetEventPoolProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.EventPool );
+            result = getTableWithCheck(getTable, version, &initialzeDdiTable.EventPool );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<ze_pfnGetFenceProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetFenceProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.Fence );
+            result = getTableWithCheck(getTable, version, &initialzeDdiTable.Fence );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<ze_pfnGetImageProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetImageProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.Image );
+            result = getTableWithCheck(getTable, version, &initialzeDdiTable.Image );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -144,14 +143,14 @@ namespace ze_lib
             // Optional
             auto getTable = reinterpret_cast<ze_pfnGetImageExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetImageExpProcAddrTable") );
-            getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.ImageExp );
+            getTableWithCheck(getTable, version, &initialzeDdiTable.ImageExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<ze_pfnGetKernelProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetKernelProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.Kernel );
+            result = getTableWithCheck(getTable, version, &initialzeDdiTable.Kernel );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -159,14 +158,14 @@ namespace ze_lib
             // Optional
             auto getTable = reinterpret_cast<ze_pfnGetKernelExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetKernelExpProcAddrTable") );
-            getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.KernelExp );
+            getTableWithCheck(getTable, version, &initialzeDdiTable.KernelExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<ze_pfnGetMemProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetMemProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.Mem );
+            result = getTableWithCheck(getTable, version, &initialzeDdiTable.Mem );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -174,42 +173,42 @@ namespace ze_lib
             // Optional
             auto getTable = reinterpret_cast<ze_pfnGetMemExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetMemExpProcAddrTable") );
-            getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.MemExp );
+            getTableWithCheck(getTable, version, &initialzeDdiTable.MemExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<ze_pfnGetModuleProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetModuleProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.Module );
+            result = getTableWithCheck(getTable, version, &initialzeDdiTable.Module );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<ze_pfnGetModuleBuildLogProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetModuleBuildLogProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.ModuleBuildLog );
+            result = getTableWithCheck(getTable, version, &initialzeDdiTable.ModuleBuildLog );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<ze_pfnGetPhysicalMemProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetPhysicalMemProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.PhysicalMem );
+            result = getTableWithCheck(getTable, version, &initialzeDdiTable.PhysicalMem );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<ze_pfnGetSamplerProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetSamplerProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.Sampler );
+            result = getTableWithCheck(getTable, version, &initialzeDdiTable.Sampler );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<ze_pfnGetVirtualMemProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetVirtualMemProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.VirtualMem );
+            result = getTableWithCheck(getTable, version, &initialzeDdiTable.VirtualMem );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -217,7 +216,7 @@ namespace ze_lib
             // Optional
             auto getTable = reinterpret_cast<ze_pfnGetFabricEdgeExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetFabricEdgeExpProcAddrTable") );
-            getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.FabricEdgeExp );
+            getTableWithCheck(getTable, version, &initialzeDdiTable.FabricEdgeExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -225,13 +224,13 @@ namespace ze_lib
             // Optional
             auto getTable = reinterpret_cast<ze_pfnGetFabricVertexExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetFabricVertexExpProcAddrTable") );
-            getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.FabricVertexExp );
+            getTableWithCheck(getTable, version, &initialzeDdiTable.FabricVertexExp );
         }
 
         return result;
     }
 #else
-    __zedlllocal ze_result_t context_t::zeDdiTableInit()
+    __zedlllocal ze_result_t context_t::zeDdiTableInit(ze_api_version_t version)
     {
         ze_result_t result = ZE_RESULT_SUCCESS;
 

--- a/source/lib/ze_libddi.cpp
+++ b/source/lib/ze_libddi.cpp
@@ -20,7 +20,7 @@ namespace ze_lib
     __zedlllocal ze_result_t context_t::zeDdiTableInit()
     {
         ze_result_t result = ZE_RESULT_SUCCESS;
-
+        printf("calling static loader ddi init\n");
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<ze_pfnGetGlobalProcAddrTable_t>(

--- a/source/lib/ze_libddi.cpp
+++ b/source/lib/ze_libddi.cpp
@@ -20,6 +20,7 @@ namespace ze_lib
     __zedlllocal ze_result_t context_t::zeDdiTableInit(ze_api_version_t version)
     {
         ze_result_t result = ZE_RESULT_SUCCESS;
+
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<ze_pfnGetGlobalProcAddrTable_t>(
@@ -236,153 +237,153 @@ namespace ze_lib
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zeGetGlobalProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.Global );
+            result = zeGetGlobalProcAddrTable( version, &initialzeDdiTable.Global );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             // Optional
-            zeGetRTASBuilderExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.RTASBuilderExp );
+            zeGetRTASBuilderExpProcAddrTable( version, &initialzeDdiTable.RTASBuilderExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             // Optional
-            zeGetRTASParallelOperationExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.RTASParallelOperationExp );
+            zeGetRTASParallelOperationExpProcAddrTable( version, &initialzeDdiTable.RTASParallelOperationExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zeGetDriverProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.Driver );
-        }
-
-        if( ZE_RESULT_SUCCESS == result )
-        {
-            // Optional
-            zeGetDriverExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.DriverExp );
-        }
-
-        if( ZE_RESULT_SUCCESS == result )
-        {
-            result = zeGetDeviceProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.Device );
+            result = zeGetDriverProcAddrTable( version, &initialzeDdiTable.Driver );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             // Optional
-            zeGetDeviceExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.DeviceExp );
+            zeGetDriverExpProcAddrTable( version, &initialzeDdiTable.DriverExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zeGetContextProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.Context );
-        }
-
-        if( ZE_RESULT_SUCCESS == result )
-        {
-            result = zeGetCommandQueueProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.CommandQueue );
-        }
-
-        if( ZE_RESULT_SUCCESS == result )
-        {
-            result = zeGetCommandListProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.CommandList );
+            result = zeGetDeviceProcAddrTable( version, &initialzeDdiTable.Device );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             // Optional
-            zeGetCommandListExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.CommandListExp );
+            zeGetDeviceExpProcAddrTable( version, &initialzeDdiTable.DeviceExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zeGetEventProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.Event );
+            result = zeGetContextProcAddrTable( version, &initialzeDdiTable.Context );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            // Optional
-            zeGetEventExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.EventExp );
+            result = zeGetCommandQueueProcAddrTable( version, &initialzeDdiTable.CommandQueue );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zeGetEventPoolProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.EventPool );
-        }
-
-        if( ZE_RESULT_SUCCESS == result )
-        {
-            result = zeGetFenceProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.Fence );
-        }
-
-        if( ZE_RESULT_SUCCESS == result )
-        {
-            result = zeGetImageProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.Image );
+            result = zeGetCommandListProcAddrTable( version, &initialzeDdiTable.CommandList );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             // Optional
-            zeGetImageExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.ImageExp );
+            zeGetCommandListExpProcAddrTable( version, &initialzeDdiTable.CommandListExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zeGetKernelProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.Kernel );
-        }
-
-        if( ZE_RESULT_SUCCESS == result )
-        {
-            // Optional
-            zeGetKernelExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.KernelExp );
-        }
-
-        if( ZE_RESULT_SUCCESS == result )
-        {
-            result = zeGetMemProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.Mem );
+            result = zeGetEventProcAddrTable( version, &initialzeDdiTable.Event );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             // Optional
-            zeGetMemExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.MemExp );
+            zeGetEventExpProcAddrTable( version, &initialzeDdiTable.EventExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zeGetModuleProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.Module );
+            result = zeGetEventPoolProcAddrTable( version, &initialzeDdiTable.EventPool );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zeGetModuleBuildLogProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.ModuleBuildLog );
+            result = zeGetFenceProcAddrTable( version, &initialzeDdiTable.Fence );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zeGetPhysicalMemProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.PhysicalMem );
-        }
-
-        if( ZE_RESULT_SUCCESS == result )
-        {
-            result = zeGetSamplerProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.Sampler );
-        }
-
-        if( ZE_RESULT_SUCCESS == result )
-        {
-            result = zeGetVirtualMemProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.VirtualMem );
+            result = zeGetImageProcAddrTable( version, &initialzeDdiTable.Image );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             // Optional
-            zeGetFabricEdgeExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.FabricEdgeExp );
+            zeGetImageExpProcAddrTable( version, &initialzeDdiTable.ImageExp );
+        }
+
+        if( ZE_RESULT_SUCCESS == result )
+        {
+            result = zeGetKernelProcAddrTable( version, &initialzeDdiTable.Kernel );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             // Optional
-            zeGetFabricVertexExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.FabricVertexExp );
+            zeGetKernelExpProcAddrTable( version, &initialzeDdiTable.KernelExp );
+        }
+
+        if( ZE_RESULT_SUCCESS == result )
+        {
+            result = zeGetMemProcAddrTable( version, &initialzeDdiTable.Mem );
+        }
+
+        if( ZE_RESULT_SUCCESS == result )
+        {
+            // Optional
+            zeGetMemExpProcAddrTable( version, &initialzeDdiTable.MemExp );
+        }
+
+        if( ZE_RESULT_SUCCESS == result )
+        {
+            result = zeGetModuleProcAddrTable( version, &initialzeDdiTable.Module );
+        }
+
+        if( ZE_RESULT_SUCCESS == result )
+        {
+            result = zeGetModuleBuildLogProcAddrTable( version, &initialzeDdiTable.ModuleBuildLog );
+        }
+
+        if( ZE_RESULT_SUCCESS == result )
+        {
+            result = zeGetPhysicalMemProcAddrTable( version, &initialzeDdiTable.PhysicalMem );
+        }
+
+        if( ZE_RESULT_SUCCESS == result )
+        {
+            result = zeGetSamplerProcAddrTable( version, &initialzeDdiTable.Sampler );
+        }
+
+        if( ZE_RESULT_SUCCESS == result )
+        {
+            result = zeGetVirtualMemProcAddrTable( version, &initialzeDdiTable.VirtualMem );
+        }
+
+        if( ZE_RESULT_SUCCESS == result )
+        {
+            // Optional
+            zeGetFabricEdgeExpProcAddrTable( version, &initialzeDdiTable.FabricEdgeExp );
+        }
+
+        if( ZE_RESULT_SUCCESS == result )
+        {
+            // Optional
+            zeGetFabricVertexExpProcAddrTable( version, &initialzeDdiTable.FabricVertexExp );
         }
 
         return result;

--- a/source/lib/zel_tracing_libddi.cpp
+++ b/source/lib/zel_tracing_libddi.cpp
@@ -15,7 +15,7 @@ namespace ze_lib
     ///////////////////////////////////////////////////////////////////////////////
 
 #ifdef DYNAMIC_LOAD_LOADER
-    __zedlllocal ze_result_t context_t::zelTracingDdiTableInit()
+    __zedlllocal ze_result_t context_t::zelTracingDdiTableInit(ze_api_version_t version)
     {
         ze_result_t result = ZE_RESULT_SUCCESS;
 
@@ -23,13 +23,13 @@ namespace ze_lib
         {
             auto getTable = reinterpret_cast<zel_pfnGetTracerApiProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zelGetTracerApiProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &zelTracingDdiTable.Tracer);
+            result = getTableWithCheck(getTable, version, &zelTracingDdiTable.Tracer);
         }
 
         return result;
     }
 #else
-    __zedlllocal ze_result_t context_t::zelTracingDdiTableInit()
+    __zedlllocal ze_result_t context_t::zelTracingDdiTableInit(ze_api_version_t version)
     {
         ze_result_t result;
         result = zelGetTracerApiProcAddrTable( ZE_API_VERSION_CURRENT, &zelTracingDdiTable.Tracer);

--- a/source/lib/zes_libddi.cpp
+++ b/source/lib/zes_libddi.cpp
@@ -17,7 +17,7 @@ namespace ze_lib
     ///////////////////////////////////////////////////////////////////////////////
 
 #ifdef DYNAMIC_LOAD_LOADER
-    __zedlllocal ze_result_t context_t::zesDdiTableInit()
+    __zedlllocal ze_result_t context_t::zesDdiTableInit(ze_api_version_t version)
     {
         ze_result_t result = ZE_RESULT_SUCCESS;
 
@@ -26,14 +26,14 @@ namespace ze_lib
             // Optional
             auto getTable = reinterpret_cast<zes_pfnGetGlobalProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetGlobalProcAddrTable") );
-            getTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.Global );
+            getTableWithCheck(getTable, version, &initialzesDdiTable.Global );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<zes_pfnGetDeviceProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetDeviceProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.Device );
+            result = getTableWithCheck(getTable, version, &initialzesDdiTable.Device );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -41,14 +41,14 @@ namespace ze_lib
             // Optional
             auto getTable = reinterpret_cast<zes_pfnGetDeviceExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetDeviceExpProcAddrTable") );
-            getTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.DeviceExp );
+            getTableWithCheck(getTable, version, &initialzesDdiTable.DeviceExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<zes_pfnGetDriverProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetDriverProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.Driver );
+            result = getTableWithCheck(getTable, version, &initialzesDdiTable.Driver );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -56,42 +56,42 @@ namespace ze_lib
             // Optional
             auto getTable = reinterpret_cast<zes_pfnGetDriverExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetDriverExpProcAddrTable") );
-            getTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.DriverExp );
+            getTableWithCheck(getTable, version, &initialzesDdiTable.DriverExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<zes_pfnGetDiagnosticsProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetDiagnosticsProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.Diagnostics );
+            result = getTableWithCheck(getTable, version, &initialzesDdiTable.Diagnostics );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<zes_pfnGetEngineProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetEngineProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.Engine );
+            result = getTableWithCheck(getTable, version, &initialzesDdiTable.Engine );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<zes_pfnGetFabricPortProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetFabricPortProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.FabricPort );
+            result = getTableWithCheck(getTable, version, &initialzesDdiTable.FabricPort );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<zes_pfnGetFanProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetFanProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.Fan );
+            result = getTableWithCheck(getTable, version, &initialzesDdiTable.Fan );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<zes_pfnGetFirmwareProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetFirmwareProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.Firmware );
+            result = getTableWithCheck(getTable, version, &initialzesDdiTable.Firmware );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -99,28 +99,28 @@ namespace ze_lib
             // Optional
             auto getTable = reinterpret_cast<zes_pfnGetFirmwareExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetFirmwareExpProcAddrTable") );
-            getTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.FirmwareExp );
+            getTableWithCheck(getTable, version, &initialzesDdiTable.FirmwareExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<zes_pfnGetFrequencyProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetFrequencyProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.Frequency );
+            result = getTableWithCheck(getTable, version, &initialzesDdiTable.Frequency );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<zes_pfnGetLedProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetLedProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.Led );
+            result = getTableWithCheck(getTable, version, &initialzesDdiTable.Led );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<zes_pfnGetMemoryProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetMemoryProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.Memory );
+            result = getTableWithCheck(getTable, version, &initialzesDdiTable.Memory );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -128,35 +128,35 @@ namespace ze_lib
             // Optional
             auto getTable = reinterpret_cast<zes_pfnGetOverclockProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetOverclockProcAddrTable") );
-            getTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.Overclock );
+            getTableWithCheck(getTable, version, &initialzesDdiTable.Overclock );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<zes_pfnGetPerformanceFactorProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetPerformanceFactorProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.PerformanceFactor );
+            result = getTableWithCheck(getTable, version, &initialzesDdiTable.PerformanceFactor );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<zes_pfnGetPowerProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetPowerProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.Power );
+            result = getTableWithCheck(getTable, version, &initialzesDdiTable.Power );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<zes_pfnGetPsuProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetPsuProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.Psu );
+            result = getTableWithCheck(getTable, version, &initialzesDdiTable.Psu );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<zes_pfnGetRasProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetRasProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.Ras );
+            result = getTableWithCheck(getTable, version, &initialzesDdiTable.Ras );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -164,28 +164,28 @@ namespace ze_lib
             // Optional
             auto getTable = reinterpret_cast<zes_pfnGetRasExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetRasExpProcAddrTable") );
-            getTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.RasExp );
+            getTableWithCheck(getTable, version, &initialzesDdiTable.RasExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<zes_pfnGetSchedulerProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetSchedulerProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.Scheduler );
+            result = getTableWithCheck(getTable, version, &initialzesDdiTable.Scheduler );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<zes_pfnGetStandbyProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetStandbyProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.Standby );
+            result = getTableWithCheck(getTable, version, &initialzesDdiTable.Standby );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<zes_pfnGetTemperatureProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetTemperatureProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.Temperature );
+            result = getTableWithCheck(getTable, version, &initialzesDdiTable.Temperature );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -193,13 +193,13 @@ namespace ze_lib
             // Optional
             auto getTable = reinterpret_cast<zes_pfnGetVFManagementExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetVFManagementExpProcAddrTable") );
-            getTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.VFManagementExp );
+            getTableWithCheck(getTable, version, &initialzesDdiTable.VFManagementExp );
         }
 
         return result;
     }
 #else
-    __zedlllocal ze_result_t context_t::zesDdiTableInit()
+    __zedlllocal ze_result_t context_t::zesDdiTableInit(ze_api_version_t version)
     {
         ze_result_t result = ZE_RESULT_SUCCESS;
 

--- a/source/lib/zes_libddi.cpp
+++ b/source/lib/zes_libddi.cpp
@@ -206,128 +206,128 @@ namespace ze_lib
         if( ZE_RESULT_SUCCESS == result )
         {
             // Optional
-            zesGetGlobalProcAddrTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.Global );
+            zesGetGlobalProcAddrTable( version, &initialzesDdiTable.Global );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zesGetDeviceProcAddrTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.Device );
-        }
-
-        if( ZE_RESULT_SUCCESS == result )
-        {
-            // Optional
-            zesGetDeviceExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.DeviceExp );
-        }
-
-        if( ZE_RESULT_SUCCESS == result )
-        {
-            result = zesGetDriverProcAddrTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.Driver );
+            result = zesGetDeviceProcAddrTable( version, &initialzesDdiTable.Device );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             // Optional
-            zesGetDriverExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.DriverExp );
+            zesGetDeviceExpProcAddrTable( version, &initialzesDdiTable.DeviceExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zesGetDiagnosticsProcAddrTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.Diagnostics );
-        }
-
-        if( ZE_RESULT_SUCCESS == result )
-        {
-            result = zesGetEngineProcAddrTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.Engine );
-        }
-
-        if( ZE_RESULT_SUCCESS == result )
-        {
-            result = zesGetFabricPortProcAddrTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.FabricPort );
-        }
-
-        if( ZE_RESULT_SUCCESS == result )
-        {
-            result = zesGetFanProcAddrTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.Fan );
-        }
-
-        if( ZE_RESULT_SUCCESS == result )
-        {
-            result = zesGetFirmwareProcAddrTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.Firmware );
+            result = zesGetDriverProcAddrTable( version, &initialzesDdiTable.Driver );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             // Optional
-            zesGetFirmwareExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.FirmwareExp );
+            zesGetDriverExpProcAddrTable( version, &initialzesDdiTable.DriverExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zesGetFrequencyProcAddrTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.Frequency );
+            result = zesGetDiagnosticsProcAddrTable( version, &initialzesDdiTable.Diagnostics );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zesGetLedProcAddrTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.Led );
+            result = zesGetEngineProcAddrTable( version, &initialzesDdiTable.Engine );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zesGetMemoryProcAddrTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.Memory );
+            result = zesGetFabricPortProcAddrTable( version, &initialzesDdiTable.FabricPort );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            // Optional
-            zesGetOverclockProcAddrTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.Overclock );
+            result = zesGetFanProcAddrTable( version, &initialzesDdiTable.Fan );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zesGetPerformanceFactorProcAddrTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.PerformanceFactor );
-        }
-
-        if( ZE_RESULT_SUCCESS == result )
-        {
-            result = zesGetPowerProcAddrTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.Power );
-        }
-
-        if( ZE_RESULT_SUCCESS == result )
-        {
-            result = zesGetPsuProcAddrTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.Psu );
-        }
-
-        if( ZE_RESULT_SUCCESS == result )
-        {
-            result = zesGetRasProcAddrTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.Ras );
+            result = zesGetFirmwareProcAddrTable( version, &initialzesDdiTable.Firmware );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             // Optional
-            zesGetRasExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.RasExp );
+            zesGetFirmwareExpProcAddrTable( version, &initialzesDdiTable.FirmwareExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zesGetSchedulerProcAddrTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.Scheduler );
+            result = zesGetFrequencyProcAddrTable( version, &initialzesDdiTable.Frequency );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zesGetStandbyProcAddrTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.Standby );
+            result = zesGetLedProcAddrTable( version, &initialzesDdiTable.Led );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zesGetTemperatureProcAddrTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.Temperature );
+            result = zesGetMemoryProcAddrTable( version, &initialzesDdiTable.Memory );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             // Optional
-            zesGetVFManagementExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.VFManagementExp );
+            zesGetOverclockProcAddrTable( version, &initialzesDdiTable.Overclock );
+        }
+
+        if( ZE_RESULT_SUCCESS == result )
+        {
+            result = zesGetPerformanceFactorProcAddrTable( version, &initialzesDdiTable.PerformanceFactor );
+        }
+
+        if( ZE_RESULT_SUCCESS == result )
+        {
+            result = zesGetPowerProcAddrTable( version, &initialzesDdiTable.Power );
+        }
+
+        if( ZE_RESULT_SUCCESS == result )
+        {
+            result = zesGetPsuProcAddrTable( version, &initialzesDdiTable.Psu );
+        }
+
+        if( ZE_RESULT_SUCCESS == result )
+        {
+            result = zesGetRasProcAddrTable( version, &initialzesDdiTable.Ras );
+        }
+
+        if( ZE_RESULT_SUCCESS == result )
+        {
+            // Optional
+            zesGetRasExpProcAddrTable( version, &initialzesDdiTable.RasExp );
+        }
+
+        if( ZE_RESULT_SUCCESS == result )
+        {
+            result = zesGetSchedulerProcAddrTable( version, &initialzesDdiTable.Scheduler );
+        }
+
+        if( ZE_RESULT_SUCCESS == result )
+        {
+            result = zesGetStandbyProcAddrTable( version, &initialzesDdiTable.Standby );
+        }
+
+        if( ZE_RESULT_SUCCESS == result )
+        {
+            result = zesGetTemperatureProcAddrTable( version, &initialzesDdiTable.Temperature );
+        }
+
+        if( ZE_RESULT_SUCCESS == result )
+        {
+            // Optional
+            zesGetVFManagementExpProcAddrTable( version, &initialzesDdiTable.VFManagementExp );
         }
 
         return result;

--- a/source/lib/zet_libddi.cpp
+++ b/source/lib/zet_libddi.cpp
@@ -14,10 +14,9 @@
 
 namespace ze_lib
 {
-    ///////////////////////////////////////////////////////////////////////////////
 
 #ifdef DYNAMIC_LOAD_LOADER
-    __zedlllocal ze_result_t context_t::zetDdiTableInit()
+    __zedlllocal ze_result_t context_t::zetDdiTableInit(ze_api_version_t version)
     {
         ze_result_t result = ZE_RESULT_SUCCESS;
 
@@ -26,7 +25,7 @@ namespace ze_lib
             // Optional
             auto getTable = reinterpret_cast<zet_pfnGetMetricDecoderExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zetGetMetricDecoderExpProcAddrTable") );
-            getTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.MetricDecoderExp );
+            getTableWithCheck(getTable, version, &initialzetDdiTable.MetricDecoderExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -34,7 +33,7 @@ namespace ze_lib
             // Optional
             auto getTable = reinterpret_cast<zet_pfnGetMetricProgrammableExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zetGetMetricProgrammableExpProcAddrTable") );
-            getTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.MetricProgrammableExp );
+            getTableWithCheck(getTable, version, &initialzetDdiTable.MetricProgrammableExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -42,14 +41,14 @@ namespace ze_lib
             // Optional
             auto getTable = reinterpret_cast<zet_pfnGetMetricTracerExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zetGetMetricTracerExpProcAddrTable") );
-            getTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.MetricTracerExp );
+            getTableWithCheck(getTable, version, &initialzetDdiTable.MetricTracerExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<zet_pfnGetDeviceProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zetGetDeviceProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.Device );
+            result = getTableWithCheck(getTable, version, &initialzetDdiTable.Device );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -57,49 +56,49 @@ namespace ze_lib
             // Optional
             auto getTable = reinterpret_cast<zet_pfnGetDeviceExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zetGetDeviceExpProcAddrTable") );
-            getTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.DeviceExp );
+            getTableWithCheck(getTable, version, &initialzetDdiTable.DeviceExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<zet_pfnGetContextProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zetGetContextProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.Context );
+            result = getTableWithCheck(getTable, version, &initialzetDdiTable.Context );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<zet_pfnGetCommandListProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zetGetCommandListProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.CommandList );
+            result = getTableWithCheck(getTable, version, &initialzetDdiTable.CommandList );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<zet_pfnGetKernelProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zetGetKernelProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.Kernel );
+            result = getTableWithCheck(getTable, version, &initialzetDdiTable.Kernel );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<zet_pfnGetModuleProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zetGetModuleProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.Module );
+            result = getTableWithCheck(getTable, version, &initialzetDdiTable.Module );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<zet_pfnGetDebugProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zetGetDebugProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.Debug );
+            result = getTableWithCheck(getTable, version, &initialzetDdiTable.Debug );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<zet_pfnGetMetricProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zetGetMetricProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.Metric );
+            result = getTableWithCheck(getTable, version, &initialzetDdiTable.Metric );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -107,14 +106,14 @@ namespace ze_lib
             // Optional
             auto getTable = reinterpret_cast<zet_pfnGetMetricExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zetGetMetricExpProcAddrTable") );
-            getTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.MetricExp );
+            getTableWithCheck(getTable, version, &initialzetDdiTable.MetricExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<zet_pfnGetMetricGroupProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zetGetMetricGroupProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.MetricGroup );
+            result = getTableWithCheck(getTable, version, &initialzetDdiTable.MetricGroup );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -122,41 +121,41 @@ namespace ze_lib
             // Optional
             auto getTable = reinterpret_cast<zet_pfnGetMetricGroupExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zetGetMetricGroupExpProcAddrTable") );
-            getTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.MetricGroupExp );
+            getTableWithCheck(getTable, version, &initialzetDdiTable.MetricGroupExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<zet_pfnGetMetricQueryProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zetGetMetricQueryProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.MetricQuery );
+            result = getTableWithCheck(getTable, version, &initialzetDdiTable.MetricQuery );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<zet_pfnGetMetricQueryPoolProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zetGetMetricQueryPoolProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.MetricQueryPool );
+            result = getTableWithCheck(getTable, version, &initialzetDdiTable.MetricQueryPool );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<zet_pfnGetMetricStreamerProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zetGetMetricStreamerProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.MetricStreamer );
+            result = getTableWithCheck(getTable, version, &initialzetDdiTable.MetricStreamer );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             auto getTable = reinterpret_cast<zet_pfnGetTracerExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zetGetTracerExpProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.TracerExp );
+            result = getTableWithCheck(getTable, version, &initialzetDdiTable.TracerExp );
         }
 
         return result;
     }
 #else
-    __zedlllocal ze_result_t context_t::zetDdiTableInit()
+    __zedlllocal ze_result_t context_t::zetDdiTableInit(ze_api_version_t version)
     {
         ze_result_t result = ZE_RESULT_SUCCESS;
 

--- a/source/lib/zet_libddi.cpp
+++ b/source/lib/zet_libddi.cpp
@@ -14,6 +14,7 @@
 
 namespace ze_lib
 {
+    ///////////////////////////////////////////////////////////////////////////////
 
 #ifdef DYNAMIC_LOAD_LOADER
     __zedlllocal ze_result_t context_t::zetDdiTableInit(ze_api_version_t version)
@@ -162,97 +163,97 @@ namespace ze_lib
         if( ZE_RESULT_SUCCESS == result )
         {
             // Optional
-            zetGetMetricDecoderExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.MetricDecoderExp );
+            zetGetMetricDecoderExpProcAddrTable( version, &initialzetDdiTable.MetricDecoderExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             // Optional
-            zetGetMetricProgrammableExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.MetricProgrammableExp );
+            zetGetMetricProgrammableExpProcAddrTable( version, &initialzetDdiTable.MetricProgrammableExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             // Optional
-            zetGetMetricTracerExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.MetricTracerExp );
+            zetGetMetricTracerExpProcAddrTable( version, &initialzetDdiTable.MetricTracerExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zetGetDeviceProcAddrTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.Device );
-        }
-
-        if( ZE_RESULT_SUCCESS == result )
-        {
-            // Optional
-            zetGetDeviceExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.DeviceExp );
-        }
-
-        if( ZE_RESULT_SUCCESS == result )
-        {
-            result = zetGetContextProcAddrTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.Context );
-        }
-
-        if( ZE_RESULT_SUCCESS == result )
-        {
-            result = zetGetCommandListProcAddrTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.CommandList );
-        }
-
-        if( ZE_RESULT_SUCCESS == result )
-        {
-            result = zetGetKernelProcAddrTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.Kernel );
-        }
-
-        if( ZE_RESULT_SUCCESS == result )
-        {
-            result = zetGetModuleProcAddrTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.Module );
-        }
-
-        if( ZE_RESULT_SUCCESS == result )
-        {
-            result = zetGetDebugProcAddrTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.Debug );
-        }
-
-        if( ZE_RESULT_SUCCESS == result )
-        {
-            result = zetGetMetricProcAddrTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.Metric );
+            result = zetGetDeviceProcAddrTable( version, &initialzetDdiTable.Device );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             // Optional
-            zetGetMetricExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.MetricExp );
+            zetGetDeviceExpProcAddrTable( version, &initialzetDdiTable.DeviceExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zetGetMetricGroupProcAddrTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.MetricGroup );
+            result = zetGetContextProcAddrTable( version, &initialzetDdiTable.Context );
+        }
+
+        if( ZE_RESULT_SUCCESS == result )
+        {
+            result = zetGetCommandListProcAddrTable( version, &initialzetDdiTable.CommandList );
+        }
+
+        if( ZE_RESULT_SUCCESS == result )
+        {
+            result = zetGetKernelProcAddrTable( version, &initialzetDdiTable.Kernel );
+        }
+
+        if( ZE_RESULT_SUCCESS == result )
+        {
+            result = zetGetModuleProcAddrTable( version, &initialzetDdiTable.Module );
+        }
+
+        if( ZE_RESULT_SUCCESS == result )
+        {
+            result = zetGetDebugProcAddrTable( version, &initialzetDdiTable.Debug );
+        }
+
+        if( ZE_RESULT_SUCCESS == result )
+        {
+            result = zetGetMetricProcAddrTable( version, &initialzetDdiTable.Metric );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
             // Optional
-            zetGetMetricGroupExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.MetricGroupExp );
+            zetGetMetricExpProcAddrTable( version, &initialzetDdiTable.MetricExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zetGetMetricQueryProcAddrTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.MetricQuery );
+            result = zetGetMetricGroupProcAddrTable( version, &initialzetDdiTable.MetricGroup );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zetGetMetricQueryPoolProcAddrTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.MetricQueryPool );
+            // Optional
+            zetGetMetricGroupExpProcAddrTable( version, &initialzetDdiTable.MetricGroupExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zetGetMetricStreamerProcAddrTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.MetricStreamer );
+            result = zetGetMetricQueryProcAddrTable( version, &initialzetDdiTable.MetricQuery );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zetGetTracerExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.TracerExp );
+            result = zetGetMetricQueryPoolProcAddrTable( version, &initialzetDdiTable.MetricQueryPool );
+        }
+
+        if( ZE_RESULT_SUCCESS == result )
+        {
+            result = zetGetMetricStreamerProcAddrTable( version, &initialzetDdiTable.MetricStreamer );
+        }
+
+        if( ZE_RESULT_SUCCESS == result )
+        {
+            result = zetGetTracerExpProcAddrTable( version, &initialzetDdiTable.TracerExp );
         }
 
         return result;

--- a/source/loader/linux/loader_init.cpp
+++ b/source/loader/linux/loader_init.cpp
@@ -12,12 +12,10 @@ namespace loader
 {
 #ifndef DYNAMIC_LOAD_LOADER
     void __attribute__((constructor)) createLoaderContext() {
-        printf("loader created context lib dynamic\n");
         context = new context_t;
     }
 
     void __attribute__((destructor)) deleteLoaderContext() {
-        printf("loader destroyed context lib dynamic\n");
         delete context;
     }
 #endif

--- a/source/loader/linux/loader_init.cpp
+++ b/source/loader/linux/loader_init.cpp
@@ -10,13 +10,15 @@
 
 namespace loader
 {
-
+#ifndef DYNAMIC_LOAD_LOADER
     void __attribute__((constructor)) createLoaderContext() {
+        printf("loader created context lib dynamic\n");
         context = new context_t;
     }
 
     void __attribute__((destructor)) deleteLoaderContext() {
+        printf("loader destroyed context lib dynamic\n");
         delete context;
     }
-
+#endif
 }

--- a/source/loader/ze_loader_api.cpp
+++ b/source/loader/ze_loader_api.cpp
@@ -56,7 +56,6 @@ zeLoaderGetTracingHandle()
 ///     - ::Pointer to the Loader's Context
 ZE_DLLEXPORT loader::context_t *ZE_APICALL
 zelLoaderGetContext() {
-    printf("zelLoaderGetContext\n");
     return loader::context;
 }
 

--- a/source/loader/ze_loader_api.cpp
+++ b/source/loader/ze_loader_api.cpp
@@ -50,6 +50,17 @@ zeLoaderGetTracingHandle()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Get pointer to Loader Context
+///
+/// @returns
+///     - ::Pointer to the Loader's Context
+ZE_DLLEXPORT loader::context_t *ZE_APICALL
+zelLoaderGetContext() {
+    printf("zelLoaderGetContext\n");
+    return loader::context;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Internal function for Setting the ddi table for the Tracing Layer.
 ///
 ZE_DLLEXPORT ze_result_t ZE_APICALL

--- a/source/loader/ze_loader_api.h
+++ b/source/loader/ze_loader_api.h
@@ -51,6 +51,14 @@ zelLoaderTracingLayerInit(std::atomic<ze_dditable_t *> &zeDdiTable);
 ZE_DLLEXPORT HMODULE ZE_APICALL
 zeLoaderGetTracingHandle();
 
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get pointer to Loader Context
+///
+/// @returns
+///     - ::handle to tracing library
+ZE_DLLEXPORT loader::context_t *ZE_APICALL
+zelLoaderGetContext();
+
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Exported function for getting version

--- a/source/loader/ze_loader_internal.h
+++ b/source/loader/ze_loader_internal.h
@@ -150,7 +150,6 @@ namespace loader
         bool tracingLayerEnabled = false;
         dditable_t tracing_dditable = {};
         std::shared_ptr<Logger> zel_logger;
-        uint32_t init_counter = 0;
     };
 
     extern context_t *context;

--- a/source/loader/ze_loader_internal.h
+++ b/source/loader/ze_loader_internal.h
@@ -150,6 +150,7 @@ namespace loader
         bool tracingLayerEnabled = false;
         dditable_t tracing_dditable = {};
         std::shared_ptr<Logger> zel_logger;
+        uint32_t init_counter = 0;
     };
 
     extern context_t *context;

--- a/source/loader/ze_loader_internal.h
+++ b/source/loader/ze_loader_internal.h
@@ -22,7 +22,7 @@
 #include "zes_ldrddi.h"
 
 #include "loader/ze_loader.h"
-#include "logging.h"
+#include "../utils/logging.h"
 #include "spdlog/spdlog.h"
 namespace loader
 {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,7 +16,11 @@ target_link_libraries(
 # For some reason the MSVC runtime libraries used by googletest and test
 # binaries don't match, so force the test binary to use the dynamic runtime.
 if(MSVC)
+  if (BUILD_STATIC)
+    target_compile_options(tests PRIVATE "/MT$<$<CONFIG:Debug>:d>")
+  else()
     target_compile_options(tests PRIVATE "/MD$<$<CONFIG:Debug>:d>")
+  endif()
 endif()
 
 add_test(NAME tests_api COMMAND tests --gtest_filter=*GivenLevelZeroLoaderPresentWhenCallingzeGetLoaderVersionsAPIThenValidVersionIsReturned*)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,11 +16,7 @@ target_link_libraries(
 # For some reason the MSVC runtime libraries used by googletest and test
 # binaries don't match, so force the test binary to use the dynamic runtime.
 if(MSVC)
-  if (BUILD_STATIC)
-    target_compile_options(tests PRIVATE "/MT$<$<CONFIG:Debug>:d>")
-  else()
-    target_compile_options(tests PRIVATE "/MD$<$<CONFIG:Debug>:d>")
-  endif()
+  target_compile_options(tests PRIVATE "/MD$<$<CONFIG:Debug>:d>")
 endif()
 
 add_test(NAME tests_api COMMAND tests --gtest_filter=*GivenLevelZeroLoaderPresentWhenCallingzeGetLoaderVersionsAPIThenValidVersionIsReturned*)


### PR DESCRIPTION
Static Loader Support.

This support has a few conditions:

1. zes/ze driver split is not supported without this version of the loader so backwards compatibility for different lists of drivers for ze/zes init is not supported if using the static lib due to needing to modify the loader's context. zes/ze driver list will be the same.
2. As of this version of the loader, all symbols read between the static loader and the dynamic loader must remain ABI compatible ie all apis exported in source/loader/ze_loader_api.h now must be abi compatible.
3. The oldest dynamic loader supported is v1.15.17
