### PR TITLE
Fix backwards compatibility usage of Get*ProcAddrTable

### DIFF
--- a/source/lib/ze_libddi.cpp
+++ b/source/lib/ze_libddi.cpp
@@ -30,16 +30,18 @@ namespace ze_lib
 
         if( ZE_RESULT_SUCCESS == result )
         {
+            // Optional
             auto getTable = reinterpret_cast<ze_pfnGetRTASBuilderExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetRTASBuilderExpProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.RTASBuilderExp );
+            getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.RTASBuilderExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
+            // Optional
             auto getTable = reinterpret_cast<ze_pfnGetRTASParallelOperationExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetRTASParallelOperationExpProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.RTASParallelOperationExp );
+            getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.RTASParallelOperationExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -51,9 +53,10 @@ namespace ze_lib
 
         if( ZE_RESULT_SUCCESS == result )
         {
+            // Optional
             auto getTable = reinterpret_cast<ze_pfnGetDriverExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetDriverExpProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.DriverExp );
+            getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.DriverExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -65,9 +68,10 @@ namespace ze_lib
 
         if( ZE_RESULT_SUCCESS == result )
         {
+            // Optional
             auto getTable = reinterpret_cast<ze_pfnGetDeviceExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetDeviceExpProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.DeviceExp );
+            getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.DeviceExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -93,9 +97,10 @@ namespace ze_lib
 
         if( ZE_RESULT_SUCCESS == result )
         {
+            // Optional
             auto getTable = reinterpret_cast<ze_pfnGetCommandListExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetCommandListExpProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.CommandListExp );
+            getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.CommandListExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -107,9 +112,10 @@ namespace ze_lib
 
         if( ZE_RESULT_SUCCESS == result )
         {
+            // Optional
             auto getTable = reinterpret_cast<ze_pfnGetEventExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetEventExpProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.EventExp );
+            getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.EventExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -135,9 +141,10 @@ namespace ze_lib
 
         if( ZE_RESULT_SUCCESS == result )
         {
+            // Optional
             auto getTable = reinterpret_cast<ze_pfnGetImageExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetImageExpProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.ImageExp );
+            getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.ImageExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -149,9 +156,10 @@ namespace ze_lib
 
         if( ZE_RESULT_SUCCESS == result )
         {
+            // Optional
             auto getTable = reinterpret_cast<ze_pfnGetKernelExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetKernelExpProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.KernelExp );
+            getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.KernelExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -163,9 +171,10 @@ namespace ze_lib
 
         if( ZE_RESULT_SUCCESS == result )
         {
+            // Optional
             auto getTable = reinterpret_cast<ze_pfnGetMemExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetMemExpProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.MemExp );
+            getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.MemExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -205,16 +214,18 @@ namespace ze_lib
 
         if( ZE_RESULT_SUCCESS == result )
         {
+            // Optional
             auto getTable = reinterpret_cast<ze_pfnGetFabricEdgeExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetFabricEdgeExpProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.FabricEdgeExp );
+            getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.FabricEdgeExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
+            // Optional
             auto getTable = reinterpret_cast<ze_pfnGetFabricVertexExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetFabricVertexExpProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.FabricVertexExp );
+            getTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.FabricVertexExp );
         }
 
         return result;
@@ -231,12 +242,14 @@ namespace ze_lib
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zeGetRTASBuilderExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.RTASBuilderExp );
+            // Optional
+            zeGetRTASBuilderExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.RTASBuilderExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zeGetRTASParallelOperationExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.RTASParallelOperationExp );
+            // Optional
+            zeGetRTASParallelOperationExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.RTASParallelOperationExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -246,7 +259,8 @@ namespace ze_lib
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zeGetDriverExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.DriverExp );
+            // Optional
+            zeGetDriverExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.DriverExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -256,7 +270,8 @@ namespace ze_lib
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zeGetDeviceExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.DeviceExp );
+            // Optional
+            zeGetDeviceExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.DeviceExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -276,7 +291,8 @@ namespace ze_lib
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zeGetCommandListExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.CommandListExp );
+            // Optional
+            zeGetCommandListExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.CommandListExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -286,7 +302,8 @@ namespace ze_lib
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zeGetEventExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.EventExp );
+            // Optional
+            zeGetEventExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.EventExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -306,7 +323,8 @@ namespace ze_lib
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zeGetImageExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.ImageExp );
+            // Optional
+            zeGetImageExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.ImageExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -316,7 +334,8 @@ namespace ze_lib
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zeGetKernelExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.KernelExp );
+            // Optional
+            zeGetKernelExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.KernelExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -326,7 +345,8 @@ namespace ze_lib
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zeGetMemExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.MemExp );
+            // Optional
+            zeGetMemExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.MemExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -356,12 +376,14 @@ namespace ze_lib
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zeGetFabricEdgeExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.FabricEdgeExp );
+            // Optional
+            zeGetFabricEdgeExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.FabricEdgeExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zeGetFabricVertexExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.FabricVertexExp );
+            // Optional
+            zeGetFabricVertexExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzeDdiTable.FabricVertexExp );
         }
 
         return result;

--- a/source/lib/zes_libddi.cpp
+++ b/source/lib/zes_libddi.cpp
@@ -23,9 +23,10 @@ namespace ze_lib
 
         if( ZE_RESULT_SUCCESS == result )
         {
+            // Optional
             auto getTable = reinterpret_cast<zes_pfnGetGlobalProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetGlobalProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.Global );
+            getTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.Global );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -37,9 +38,10 @@ namespace ze_lib
 
         if( ZE_RESULT_SUCCESS == result )
         {
+            // Optional
             auto getTable = reinterpret_cast<zes_pfnGetDeviceExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetDeviceExpProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.DeviceExp );
+            getTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.DeviceExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -51,9 +53,10 @@ namespace ze_lib
 
         if( ZE_RESULT_SUCCESS == result )
         {
+            // Optional
             auto getTable = reinterpret_cast<zes_pfnGetDriverExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetDriverExpProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.DriverExp );
+            getTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.DriverExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -93,9 +96,10 @@ namespace ze_lib
 
         if( ZE_RESULT_SUCCESS == result )
         {
+            // Optional
             auto getTable = reinterpret_cast<zes_pfnGetFirmwareExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetFirmwareExpProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.FirmwareExp );
+            getTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.FirmwareExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -121,9 +125,10 @@ namespace ze_lib
 
         if( ZE_RESULT_SUCCESS == result )
         {
+            // Optional
             auto getTable = reinterpret_cast<zes_pfnGetOverclockProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetOverclockProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.Overclock );
+            getTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.Overclock );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -156,9 +161,10 @@ namespace ze_lib
 
         if( ZE_RESULT_SUCCESS == result )
         {
+            // Optional
             auto getTable = reinterpret_cast<zes_pfnGetRasExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetRasExpProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.RasExp );
+            getTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.RasExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -184,9 +190,10 @@ namespace ze_lib
 
         if( ZE_RESULT_SUCCESS == result )
         {
+            // Optional
             auto getTable = reinterpret_cast<zes_pfnGetVFManagementExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetVFManagementExpProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.VFManagementExp );
+            getTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.VFManagementExp );
         }
 
         return result;
@@ -198,7 +205,8 @@ namespace ze_lib
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zesGetGlobalProcAddrTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.Global );
+            // Optional
+            zesGetGlobalProcAddrTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.Global );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -208,7 +216,8 @@ namespace ze_lib
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zesGetDeviceExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.DeviceExp );
+            // Optional
+            zesGetDeviceExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.DeviceExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -218,7 +227,8 @@ namespace ze_lib
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zesGetDriverExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.DriverExp );
+            // Optional
+            zesGetDriverExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.DriverExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -248,7 +258,8 @@ namespace ze_lib
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zesGetFirmwareExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.FirmwareExp );
+            // Optional
+            zesGetFirmwareExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.FirmwareExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -268,7 +279,8 @@ namespace ze_lib
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zesGetOverclockProcAddrTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.Overclock );
+            // Optional
+            zesGetOverclockProcAddrTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.Overclock );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -293,7 +305,8 @@ namespace ze_lib
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zesGetRasExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.RasExp );
+            // Optional
+            zesGetRasExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.RasExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -313,7 +326,8 @@ namespace ze_lib
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zesGetVFManagementExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.VFManagementExp );
+            // Optional
+            zesGetVFManagementExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzesDdiTable.VFManagementExp );
         }
 
         return result;

--- a/source/lib/zet_libddi.cpp
+++ b/source/lib/zet_libddi.cpp
@@ -23,23 +23,26 @@ namespace ze_lib
 
         if( ZE_RESULT_SUCCESS == result )
         {
+            // Optional
             auto getTable = reinterpret_cast<zet_pfnGetMetricDecoderExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zetGetMetricDecoderExpProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.MetricDecoderExp );
+            getTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.MetricDecoderExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
+            // Optional
             auto getTable = reinterpret_cast<zet_pfnGetMetricProgrammableExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zetGetMetricProgrammableExpProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.MetricProgrammableExp );
+            getTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.MetricProgrammableExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
+            // Optional
             auto getTable = reinterpret_cast<zet_pfnGetMetricTracerExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zetGetMetricTracerExpProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.MetricTracerExp );
+            getTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.MetricTracerExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -51,9 +54,10 @@ namespace ze_lib
 
         if( ZE_RESULT_SUCCESS == result )
         {
+            // Optional
             auto getTable = reinterpret_cast<zet_pfnGetDeviceExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zetGetDeviceExpProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.DeviceExp );
+            getTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.DeviceExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -100,9 +104,10 @@ namespace ze_lib
 
         if( ZE_RESULT_SUCCESS == result )
         {
+            // Optional
             auto getTable = reinterpret_cast<zet_pfnGetMetricExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zetGetMetricExpProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.MetricExp );
+            getTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.MetricExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -114,9 +119,10 @@ namespace ze_lib
 
         if( ZE_RESULT_SUCCESS == result )
         {
+            // Optional
             auto getTable = reinterpret_cast<zet_pfnGetMetricGroupExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zetGetMetricGroupExpProcAddrTable") );
-            result = getTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.MetricGroupExp );
+            getTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.MetricGroupExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -156,17 +162,20 @@ namespace ze_lib
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zetGetMetricDecoderExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.MetricDecoderExp );
+            // Optional
+            zetGetMetricDecoderExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.MetricDecoderExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zetGetMetricProgrammableExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.MetricProgrammableExp );
+            // Optional
+            zetGetMetricProgrammableExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.MetricProgrammableExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zetGetMetricTracerExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.MetricTracerExp );
+            // Optional
+            zetGetMetricTracerExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.MetricTracerExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -176,7 +185,8 @@ namespace ze_lib
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zetGetDeviceExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.DeviceExp );
+            // Optional
+            zetGetDeviceExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.DeviceExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -211,7 +221,8 @@ namespace ze_lib
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zetGetMetricExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.MetricExp );
+            // Optional
+            zetGetMetricExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.MetricExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -221,7 +232,8 @@ namespace ze_lib
 
         if( ZE_RESULT_SUCCESS == result )
         {
-            result = zetGetMetricGroupExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.MetricGroupExp );
+            // Optional
+            zetGetMetricGroupExpProcAddrTable( ZE_API_VERSION_CURRENT, &initialzetDdiTable.MetricGroupExp );
         }
 
         if( ZE_RESULT_SUCCESS == result )


### PR DESCRIPTION
Make the results of certain Get*ProcAddrTable calls in ze_libddi.cpp ignored as not all drivers will implement these functions. These functions populate different sections of DDI tables in the lib component.

Fixes #196
Relates to VLCLJ-2339