### PR TITLE
Fix zeInit Compatibility when zeInitDrivers is undefined

### DIFF
--- a/scripts/templates/libapi.cpp.mako
+++ b/scripts/templates/libapi.cpp.mako
@@ -86,6 +86,10 @@ ${th.make_func_name(n, tags, obj)}(
         return result;
     });
 
+    if (result != ${X}_RESULT_SUCCESS) {
+        return result;
+    }
+
     if(ze_lib::context->inTeardown) {
         return ${X}_RESULT_ERROR_UNINITIALIZED;
     }

--- a/scripts/templates/nullddi.cpp.mako
+++ b/scripts/templates/nullddi.cpp.mako
@@ -130,6 +130,16 @@ ${tbl['export']['name']}(
 
     ${x}_result_t result = ${X}_RESULT_SUCCESS;
 
+% if tbl['name'] == 'Global' and n == 'ze':
+    pDdiTable->pfnInit                                   = driver::zeInit;
+
+    auto missing_api = getenv_string( "ZEL_TEST_MISSING_API" );
+    if (std::strcmp(missing_api.c_str(), "zeInitDrivers") == 0) {
+        pDdiTable->pfnInitDrivers                            = nullptr;
+    } else {
+        pDdiTable->pfnInitDrivers                            = driver::zeInitDrivers;
+    }
+%else:
     %for obj in tbl['functions']:
     %if 'condition' in obj:
 #if ${th.subt(n, tags, obj['condition'])}
@@ -142,6 +152,7 @@ ${tbl['export']['name']}(
     %endif
 
     %endfor
+%endif
     return result;
 }
 

--- a/source/drivers/null/ze_nullddi.cpp
+++ b/source/drivers/null/ze_nullddi.cpp
@@ -5142,8 +5142,12 @@ zeGetGlobalProcAddrTable(
 
     pDdiTable->pfnInit                                   = driver::zeInit;
 
-    pDdiTable->pfnInitDrivers                            = driver::zeInitDrivers;
-
+    auto missing_api = getenv_string( "ZEL_TEST_MISSING_API" );
+    if (std::strcmp(missing_api.c_str(), "zeInitDrivers") == 0) {
+        pDdiTable->pfnInitDrivers                            = nullptr;
+    } else {
+        pDdiTable->pfnInitDrivers                            = driver::zeInitDrivers;
+    }
     return result;
 }
 

--- a/source/lib/ze_libapi.cpp
+++ b/source/lib/ze_libapi.cpp
@@ -197,6 +197,10 @@ zeInitDrivers(
         return result;
     });
 
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+
     if(ze_lib::context->inTeardown) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }

--- a/source/loader/ze_loader.cpp
+++ b/source/loader/ze_loader.cpp
@@ -145,6 +145,14 @@ namespace loader
                 debug_trace_message(message, "");
             }
         }
+        // If zeInitDrivers is not supported by this driver, but zeInitDrivers is called first, then return uninitialized.
+        if (desc && !loader::context->initDriversSupport) {
+            std::string message = "zeInitDrivers called first, but not supported by driver, returning uninitialized.";
+            debug_trace_message(message, "");
+            return ZE_RESULT_ERROR_UNINITIALIZED;
+        }
+
+
         bool return_first_driver_result=false;
         std::string initName = "zeInit";
         driver_vector_t *drivers = &zeDrivers;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -38,3 +38,5 @@ add_test(NAME tests_both_gpu COMMAND tests --gtest_filter=*GivenLevelZeroLoaderP
 set_property(TEST tests_both_gpu PROPERTY ENVIRONMENT "ZE_ENABLE_NULL_DRIVER=1")
 add_test(NAME tests_both_npu COMMAND tests --gtest_filter=*GivenLevelZeroLoaderPresentWhenCallingzeInitThenZeInitDriversThenBothCallsSucceedWithNPUTypes*)
 set_property(TEST tests_both_npu PROPERTY ENVIRONMENT "ZE_ENABLE_NULL_DRIVER=1")
+add_test(NAME tests_missing_api COMMAND tests --gtest_filter=*GivenLevelZeroLoaderPresentWhenCallingZeInitDriversThenzeInitWithzeInitDriversUnsupportedOnTheDriverThenzeInitSucceeds*)
+set_property(TEST tests_missing_api PROPERTY ENVIRONMENT "ZE_ENABLE_NULL_DRIVER=1")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -38,5 +38,5 @@ add_test(NAME tests_both_gpu COMMAND tests --gtest_filter=*GivenLevelZeroLoaderP
 set_property(TEST tests_both_gpu PROPERTY ENVIRONMENT "ZE_ENABLE_NULL_DRIVER=1")
 add_test(NAME tests_both_npu COMMAND tests --gtest_filter=*GivenLevelZeroLoaderPresentWhenCallingzeInitThenZeInitDriversThenBothCallsSucceedWithNPUTypes*)
 set_property(TEST tests_both_npu PROPERTY ENVIRONMENT "ZE_ENABLE_NULL_DRIVER=1")
-add_test(NAME tests_missing_api COMMAND tests --gtest_filter=*GivenLevelZeroLoaderPresentWhenCallingZeInitDriversThenzeInitWithzeInitDriversUnsupportedOnTheDriverThenzeInitSucceeds*)
+add_test(NAME tests_missing_api COMMAND tests --gtest_filter=*GivenZeInitDriversUnsupportedOnTheDriverWhenCallingZeInitDriversThenUninitializedReturned*)
 set_property(TEST tests_missing_api PROPERTY ENVIRONMENT "ZE_ENABLE_NULL_DRIVER=1")

--- a/test/loader_api.cpp
+++ b/test/loader_api.cpp
@@ -145,7 +145,7 @@ TEST(
 
 TEST(
     LoaderInit,
-    GivenLevelZeroLoaderPresentWhenCallingZeInitDriversThenzeInitWithzeInitDriversUnsupportedOnTheDriverThenzeInitSucceeds) {
+    GivenZeInitDriversUnsupportedOnTheDriverWhenCallingZeInitDriversThenUninitializedReturned) {
 
   uint32_t pCount = 0;
   ze_init_driver_type_desc_t desc = {ZE_STRUCTURE_TYPE_INIT_DRIVER_TYPE_DESC};

--- a/test/loader_api.cpp
+++ b/test/loader_api.cpp
@@ -145,6 +145,19 @@ TEST(
 
 TEST(
     LoaderInit,
+    GivenLevelZeroLoaderPresentWhenCallingZeInitDriversThenzeInitWithzeInitDriversUnsupportedOnTheDriverThenzeInitSucceeds) {
+
+  uint32_t pCount = 0;
+  ze_init_driver_type_desc_t desc = {ZE_STRUCTURE_TYPE_INIT_DRIVER_TYPE_DESC};
+  desc.flags = UINT32_MAX;
+  desc.pNext = nullptr;
+  putenv_safe( const_cast<char *>( "ZEL_TEST_MISSING_API=zeInitDrivers" ) );
+  EXPECT_EQ(ZE_RESULT_ERROR_UNINITIALIZED, zeInitDrivers(&pCount, nullptr, &desc));
+  EXPECT_EQ(ZE_RESULT_SUCCESS, zeInit(0));
+}
+
+TEST(
+    LoaderInit,
     GivenLevelZeroLoaderPresentWhenCallingZeInitDriversThenzeInitThenBothCallsSucceedWithNPUTypes) {
 
   uint32_t pCount = 0;


### PR DESCRIPTION
- Handle when zeinitDrivers is called first and the driver does not support the api yet. Included a unit test to cover these types of cases going forward.