### PR TITLE
logging full path of loaded library in traces

### DIFF
--- a/source/inc/ze_util.h
+++ b/source/inc/ze_util.h
@@ -39,6 +39,7 @@ inline void getLastErrorString(std::string &errorValue) {
 #  define GET_FUNCTION_PTR(LIB, FUNC_NAME) GetProcAddress(LIB, FUNC_NAME)
 #  define string_copy_s strncpy_s
 #else
+#  include <link.h>
 #  include <dlfcn.h>
 #  define HMODULE void*
 #  define MAKE_LIBRARY_NAME(NAME, VERSION)    "lib" NAME ".so." VERSION

--- a/source/loader/ze_loader.cpp
+++ b/source/loader/ze_loader.cpp
@@ -439,12 +439,19 @@ namespace loader
         for( auto name : discoveredDrivers )
         {
             auto handle = LOAD_DRIVER_LIBRARY( name.c_str() );
-            if (debugTraceEnabled) {
-                std::string message = "Loading Driver " + name;
-                debug_trace_message(message, "");
-            }
             if( NULL != handle )
             {
+                if (debugTraceEnabled) {
+                    std::string message = "Loading Driver " + name + " succeeded";
+#ifndef _WIN32
+                    // TODO: implement same message for windows, move dlinfo to ze_util.h as a macro
+                    struct link_map *dlinfo_map;
+                    if (dlinfo(handle, RTLD_DI_LINKMAP, &dlinfo_map) == 0) {
+                        message += " from: " + std::string(dlinfo_map->l_name);
+                    }
+#endif
+                    debug_trace_message(message, "");
+                }
                 allDrivers.emplace_back();
                 allDrivers.rbegin()->handle = handle;
                 allDrivers.rbegin()->name = name;


### PR DESCRIPTION
Added full path of loaded library to trace message. Removed redundant line in case of failure

BEFORE:
```
[2024-11-15 15:43:37.975] [ze_loader] [trace] Loading Driver libze_intel_gpu.so.1
[2024-11-15 15:43:37.975] [ze_loader] [trace] Loading Driver libze_intel_gpu_legacy1.so.1
[2024-11-15 15:43:37.975] [ze_loader] [trace] Load Library of libze_intel_gpu_legacy1.so.1 failed with libze_intel_gpu_legacy1.so.1: cannot open shared object file: No such file or directory
[2024-11-15 15:43:37.975] [ze_loader] [trace] Loading Driver libze_intel_vpu.so.1
[2024-11-15 15:43:37.975] [ze_loader] [trace] Load Library of libze_intel_vpu.so.1 failed with libze_intel_vpu.so.1: cannot open shared object file: No such file or directory
[2024-11-15 15:43:37.975] [ze_loader] [trace] Loading Driver libze_intel_npu.so.1
[2024-11-15 15:43:37.975] [ze_loader] [trace] Load Library of libze_intel_npu.so.1 failed with libze_intel_npu.so.1: cannot open shared object file: No such file or directory
```

AFTER
```
[2024-11-15 15:46:37.065] [ze_loader] [trace] Loading Driver libze_intel_gpu.so.1 succeeded from: /home/lslusarczyk/src/neodev/build_Debug/bin/libze_intel_gpu.so.1
[2024-11-15 15:46:37.065] [ze_loader] [trace] Load Library of libze_intel_gpu_legacy1.so.1 failed with libze_intel_gpu_legacy1.so.1: cannot open shared object file: No such file or directory
[2024-11-15 15:46:37.065] [ze_loader] [trace] Load Library of libze_intel_vpu.so.1 failed with libze_intel_vpu.so.1: cannot open shared object file: No such file or directory
[2024-11-15 15:46:37.065] [ze_loader] [trace] Load Library of libze_intel_npu.so.1 failed with libze_intel_npu.so.1: cannot open shared object file: No such file or directory
```