### PR TITLE
Remove static result in InitDrivers given first init fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Level zero loader changelog
 
+## v1.19.2
+* Remove static result in InitDrivers given first init fails
 ## v1.19.1
 * Fix to Use relative paths for events deadlock detection third party headers 
 ## v1.19.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ message(FATAL_ERROR "Visual Studio Compiler Version >= 1900 Required to build.")
 endif()
 
 # This project follows semantic versioning (https://semver.org/)
-project(level-zero VERSION 1.19.1)
+project(level-zero VERSION 1.19.2)
 
 include(GNUInstallDirs)
 

--- a/scripts/templates/libapi.cpp.mako
+++ b/scripts/templates/libapi.cpp.mako
@@ -55,8 +55,8 @@ ${th.make_func_name(n, tags, obj)}(
     )
 {
 %if re.match("Init", obj['name']):
+%if re.match("zes", n):
     static ${x}_result_t result = ${X}_RESULT_SUCCESS;
-%if re.match("zes", n): 
     std::call_once(${x}_lib::context->initOnceSysMan, [flags]() {
         result = ${x}_lib::context->Init(flags, true, nullptr);
 
@@ -81,7 +81,8 @@ ${th.make_func_name(n, tags, obj)}(
 }
 %else:
 %if re.match("InitDrivers", obj['name']):
-    std::call_once(${x}_lib::context->initOnceDrivers, [desc]() {
+    ${x}_result_t result = ${X}_RESULT_SUCCESS;
+    std::call_once(${x}_lib::context->initOnceDrivers, [desc,&result]() {
         result = ${x}_lib::context->Init(0, false, desc);
         return result;
     });
@@ -112,6 +113,7 @@ ${th.make_func_name(n, tags, obj)}(
 
     return result;
 %else:
+    static ${x}_result_t result = ${X}_RESULT_SUCCESS;
     std::call_once(${x}_lib::context->initOnce, [flags]() {
         result = ${x}_lib::context->Init(flags, false, nullptr);
 

--- a/source/lib/ze_libapi.cpp
+++ b/source/lib/ze_libapi.cpp
@@ -196,8 +196,8 @@ zeInitDrivers(
                                                     ///< including ::ze_init_driver_type_flag_t combinations.
     )
 {
-    static ze_result_t result = ZE_RESULT_SUCCESS;
-    std::call_once(ze_lib::context->initOnceDrivers, [desc]() {
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    std::call_once(ze_lib::context->initOnceDrivers, [desc,&result]() {
         result = ze_lib::context->Init(0, false, desc);
         return result;
     });

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,6 +41,8 @@ add_test(NAME tests_both_npu COMMAND tests --gtest_filter=*GivenLevelZeroLoaderP
 set_property(TEST tests_both_npu PROPERTY ENVIRONMENT "ZE_ENABLE_NULL_DRIVER=1")
 add_test(NAME tests_missing_api COMMAND tests --gtest_filter=*GivenZeInitDriversUnsupportedOnTheDriverWhenCallingZeInitDriversThenUninitializedReturned*)
 set_property(TEST tests_missing_api PROPERTY ENVIRONMENT "ZE_ENABLE_NULL_DRIVER=1")
+add_test(NAME tests_multi_call_failure COMMAND tests --gtest_filter=*GivenLevelZeroLoaderPresentWhenCallingZeInitDriversWithTypesUnsupportedWithFailureThenSupportedTypesThenSuccessReturned*)
+set_property(TEST tests_multi_call_failure PROPERTY ENVIRONMENT "ZE_ENABLE_NULL_DRIVER=1")
 
 # These tests are currently not supported on Windows. The reason is that the std::cerr is not being redirected to a pipe in Windows to be then checked against the expected output.
 if(NOT MSVC)

--- a/test/loader_api.cpp
+++ b/test/loader_api.cpp
@@ -50,6 +50,23 @@ TEST(
 
 TEST(
     LoaderInit,
+    GivenLevelZeroLoaderPresentWhenCallingZeInitDriversWithTypesUnsupportedWithFailureThenSupportedTypesThenSuccessReturned) {
+
+  uint32_t pCount = 0;
+  ze_init_driver_type_desc_t desc = {ZE_STRUCTURE_TYPE_INIT_DRIVER_TYPE_DESC};
+  desc.flags = ZE_INIT_DRIVER_TYPE_FLAG_NPU;
+  desc.pNext = nullptr;
+  putenv_safe( const_cast<char *>( "ZEL_TEST_NULL_DRIVER_TYPE=GPU" ) );
+  EXPECT_EQ(ZE_RESULT_ERROR_UNINITIALIZED, zeInitDrivers(&pCount, nullptr, &desc));
+  EXPECT_EQ(pCount, 0);
+  pCount = 0;
+  desc.flags = UINT32_MAX;
+  EXPECT_EQ(ZE_RESULT_SUCCESS, zeInitDrivers(&pCount, nullptr, &desc));
+  EXPECT_GT(pCount, 0);
+}
+
+TEST(
+    LoaderInit,
     GivenLevelZeroLoaderPresentWhenCallingZeInitDriversWithGPUTypeThenExpectPassWithGPUorAllOnly) {
 
   uint32_t pCount = 0;


### PR DESCRIPTION
- Allow for the first zeInitDrivers to fail, but all following calls to succeed with different init flags.
- Updated to v1.19.2 with the init result fix