### PR TITLE
Fixed pkg-config files generation

### DIFF
--- a/samples/zello_world/CMakeLists.txt
+++ b/samples/zello_world/CMakeLists.txt
@@ -12,7 +12,7 @@ if(MSVC)
     )
 endif()
 
-target_link_libraries(${TARGET_NAME}
+target_link_libraries(${TARGET_NAME} PRIVATE
     ${TARGET_LOADER_NAME}
     ${CMAKE_DL_LIBS}
 )

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -23,30 +23,24 @@ add_subdirectory(loader)
 add_subdirectory(layers)
 add_subdirectory(drivers)
 add_subdirectory(utils)
-target_include_directories(${TARGET_LOADER_NAME} PRIVATE utils)
 
 set_target_properties(${TARGET_LOADER_NAME} PROPERTIES
     VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}"
     SOVERSION "${PROJECT_VERSION_MAJOR}"
 )
 
-target_link_libraries(${TARGET_LOADER_NAME}
-    ${CMAKE_DL_LIBS}
-)
+target_link_libraries(${TARGET_LOADER_NAME} PRIVATE ${CMAKE_DL_LIBS} level_zero_utils)
 
 if (UNIX)
     set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
     set(THREADS_PREFER_PTHREAD_FLAG TRUE)
     find_package(Threads REQUIRED)
-    target_link_libraries (${TARGET_LOADER_NAME} Threads::Threads)
+    target_link_libraries (${TARGET_LOADER_NAME} PRIVATE Threads::Threads)
 endif()
 
 if(WIN32)
-    target_link_libraries (${TARGET_LOADER_NAME} cfgmgr32.lib)
+    target_link_libraries (${TARGET_LOADER_NAME} PRIVATE cfgmgr32.lib)
 endif()
-
-# Link against utility sublibrary
-target_link_libraries(${TARGET_LOADER_NAME} utils)
 
 install(TARGETS ze_loader
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT level-zero-devel
@@ -56,6 +50,9 @@ install(TARGETS ze_loader
 )
 
 if(UNIX)
+    file(RELATIVE_PATH ze_loader_include_dir "${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig" "${CMAKE_INSTALL_FULL_INCLUDEDIR}")
+    file(RELATIVE_PATH ze_loader_lib_dir "${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig" "${CMAKE_INSTALL_FULL_LIBDIR}")
+
     configure_file(
         ${CMAKE_CURRENT_SOURCE_DIR}/libze_loader.pc.in
         ${CMAKE_CURRENT_BINARY_DIR}/libze_loader.pc

--- a/source/level-zero.pc.in
+++ b/source/level-zero.pc.in
@@ -1,5 +1,6 @@
-includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
-libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+pc_path=${pcfiledir}
+includedir=${pc_path}/@ze_loader_include_dir@
+libdir=${pc_path}/@ze_loader_lib_dir@
 
 
 Name: Level Zero

--- a/source/libze_loader.pc.in
+++ b/source/libze_loader.pc.in
@@ -1,5 +1,6 @@
-includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
-libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+pc_path=${pcfiledir}
+includedir=${pc_path}/@ze_loader_include_dir@
+libdir=${pc_path}/@ze_loader_lib_dir@
 
 
 Name: Level Zero Loader

--- a/source/utils/CMakeLists.txt
+++ b/source/utils/CMakeLists.txt
@@ -2,11 +2,14 @@
 # SPDX-License-Identifier: MIT
 
 set(logging_files logging.h logging.cpp)
-add_library(utils STATIC ${logging_files})
+add_library(level_zero_utils STATIC ${logging_files})
 
 if(SYSTEM_SPDLOG)
-       target_link_libraries(utils PUBLIC spdlog::spdlog)
+       target_link_libraries(level_zero_utils PUBLIC spdlog::spdlog)
 else()
-       target_include_directories(utils PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/third_party/spdlog_headers>)
+       target_include_directories(level_zero_utils PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/third_party/spdlog_headers>)
 endif()
-set_property(TARGET utils PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+target_include_directories(level_zero_utils PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+set_property(TARGET level_zero_utils PROPERTY POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
1. Currently, `pkg-config` files are generated with hardcoded paths to libs and includes.

I.e. if I build level-zero on one machine with non-default paths and try to use such package on another, paths will be broken.
It's valid for conda-forge, which builds packages within internal structure and then paths look like:
```
/home/conda/feedstock_root/build_artifacts/intel-level-zero_1732035758241/work/install/include
```
which cannot be used by users of `level-zero-devel` package.

The solution is to use relative paths. 

2. Renamed `utils` to `level_zero_utils` as `utils` is quite common name and clashes with other projects when `level-zero` is used as sub-project in a bigger project.

3. Use `PUBLIC` / `PRIVATE` when link libraries to hide private libraries like `utils`