### PR TITLE
Fix broken url

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ We encourage anyone who wants to contribute to submit
 [Issues](https://github.com/oneapi-src/level-zero/issues) and
 [Pull Requests](https://github.com/oneapi-src/level-zero/pulls). We will help
 review these for proper alignment with the
-[Level Zero Specification](https://spec.oneapi.com/level-zero/latest/index.html).
+[Level Zero Specification](https://oneapi-src.github.io/level-zero-spec/level-zero/latest/index.html).
 
 ## C++ Coding Standards
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This project is part of the larger [oneAPI](https://www.oneapi.com/) project.
 
 See the [oneAPI specification](https://spec.oneapi.com/versions/latest/introduction.html) for more information about the oneAPI project.
 
-See the [Level Zero specification](https://spec.oneapi.io/level-zero/latest/index.html) for more information about Level Zero.
+See the [Level Zero specification](https://oneapi-src.github.io/level-zero-spec/level-zero/latest/index.html) for more information about Level Zero.
 
 See the [Level Zero specification repo](https://github.com/oneapi-src/level-zero-spec) for contributing to the specification.
 


### PR DESCRIPTION
The link in the `About` section in the project home also needs to be updated.