### PR TITLE
Support for Sorting Drivers based on the devices provided

### DIFF
--- a/samples/include/zello_init.h
+++ b/samples/include/zello_init.h
@@ -29,11 +29,15 @@ inline bool argparse( int argc, char *argv[],
 }
 
 //////////////////////////////////////////////////////////////////////////
-inline bool init_ze( void )
+inline bool init_ze( bool legacy_init , uint32_t &driverCount, ze_init_driver_type_desc_t &driverTypeDesc)
 {
     ze_result_t result;
         // Initialize the driver
-    result = zeInit(0);
+    if (legacy_init) {
+        result = zeInit(0);
+    } else {
+        result = zeInitDrivers(&driverCount, nullptr, &driverTypeDesc);
+    }
     if(result != ZE_RESULT_SUCCESS) {
         std::cout << "Driver not initialized: " << to_string(result) << std::endl;
         return false;

--- a/samples/zello_world/zello_world.cpp
+++ b/samples/zello_world/zello_world.cpp
@@ -62,7 +62,7 @@ int main( int argc, char *argv[] )
     {
         tracing_runtime_enabled = true;
     }
-    if( argparse( argc, argv, "-legacy", "--enable_legacy_init" ) )
+    if( argparse( argc, argv, "-legacy_init", "--enable_legacy_init" ) )
     {
         legacy_init = true;
     }

--- a/source/loader/ze_loader.cpp
+++ b/source/loader/ze_loader.cpp
@@ -135,7 +135,7 @@ namespace loader
         return flags_value;
     }
 
-    bool driverSortComparitor(const driver_t &a, const driver_t &b) {
+    bool driverSortComparator(const driver_t &a, const driver_t &b) {
         if (a.pciOrderingRequested) {
             if (a.driverType == ZEL_DRIVER_TYPE_OTHER) {
                 return false;
@@ -162,7 +162,7 @@ namespace loader
      *    - If the number of drivers becomes one and interception is not forced, sets the `requireDdiReinit` flag to true.
      *    - If the initialization fails and `return_first_driver_result` is true, returns the result immediately.
      *    - If initialization succeeds, marks the driver as in use.
-     * 5. Sorts the drivers in ascending order of driver type using `driverSortComparitor`.
+     * 5. Sorts the drivers in ascending order of driver type using `driverSortComparator`.
      * 6. Logs the sorted driver list if debug tracing is enabled.
      * 7. If no drivers are left, returns `ZE_RESULT_ERROR_UNINITIALIZED`.
      * 8. Returns `ZE_RESULT_SUCCESS` if at least one driver is successfully initialized.
@@ -244,7 +244,7 @@ namespace loader
         }
 
         // Sort drivers in ascending order of driver type unless ZE_ENABLE_PCI_ID_DEVICE_ORDER, then in decending order with MIXED and OTHER at the end.
-        std::sort(drivers->begin(), drivers->end(), driverSortComparitor);
+        std::sort(drivers->begin(), drivers->end(), driverSortComparator);
 
         if (debugTraceEnabled) {
             std::string message = "Drivers after sorting:";

--- a/source/loader/ze_loader.cpp
+++ b/source/loader/ze_loader.cpp
@@ -136,8 +136,7 @@ namespace loader
     }
 
     bool driverSortComparitor(const driver_t &a, const driver_t &b) {
-        bool pciOrderingRequested = getenv_tobool( "ZE_ENABLE_PCI_ID_DEVICE_ORDER" );
-        if (pciOrderingRequested) {
+        if (a.pciOrderingRequested) {
             if (a.driverType == ZEL_DRIVER_TYPE_OTHER) {
                 return false;
             }
@@ -211,9 +210,11 @@ namespace loader
         if(drivers->size()==1) {
             return_first_driver_result=true;
         }
+        bool pciOrderingRequested = getenv_tobool( "ZE_ENABLE_PCI_ID_DEVICE_ORDER" );
 
         for(auto it = drivers->begin(); it != drivers->end(); )
         {
+            it->pciOrderingRequested = pciOrderingRequested;
             std::string freeLibraryErrorValue;
             ze_result_t result = init_driver(*it, flags, desc, globalInitStored, sysmanGlobalInitStored, sysmanOnly);
             if(result != ZE_RESULT_SUCCESS) {

--- a/source/loader/ze_loader_internal.h
+++ b/source/loader/ze_loader_internal.h
@@ -28,6 +28,9 @@ namespace loader
 {
     ///////////////////////////////////////////////////////////////////////////////
     /// @brief Driver Type Enumerations
+    /// @details The ordering of the drivers reported to the user is based on the order of the enumerations provided.
+    /// When additional driver types are added, they should be added to the end of the list to avoid reporting new device types
+    /// before known device types.
     typedef enum _zel_driver_type_t
     {
         ZEL_DRIVER_TYPE_DISCRETE_GPU= 0,          ///< The driver has Discrete GPUs only

--- a/source/loader/ze_loader_internal.h
+++ b/source/loader/ze_loader_internal.h
@@ -49,6 +49,7 @@ namespace loader
         bool driverInuse = false;
         zel_driver_type_t driverType;
         ze_driver_properties_t properties;
+        bool pciOrderingRequested = false;
     };
 
     using driver_vector_t = std::vector< driver_t >;

--- a/source/loader/ze_loader_internal.h
+++ b/source/loader/ze_loader_internal.h
@@ -26,6 +26,18 @@
 #include "spdlog/spdlog.h"
 namespace loader
 {
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Driver Type Enumerations
+    typedef enum _zel_driver_type_t
+    {
+        ZEL_DRIVER_TYPE_DISCRETE_GPU= 0,          ///< The driver has Discrete GPUs only
+        ZEL_DRIVER_TYPE_GPU = 1,                  ///< The driver has Heterogenous GPU types
+        ZEL_DRIVER_TYPE_INTEGRATED_GPU = 2,       ///< The driver has Integrated GPUs only
+        ZEL_DRIVER_TYPE_MIXED = 3,                ///< The driver has Heterogenous driver types not limited to GPU or NPU.
+        ZEL_DRIVER_TYPE_OTHER = 4,                ///< The driver has No GPU Devices and has other device types only
+        ZEL_DRIVER_TYPE_FORCE_UINT32 = 0x7fffffff
+
+    } zel_driver_type_t;
     //////////////////////////////////////////////////////////////////////////
     struct driver_t
     {
@@ -35,6 +47,8 @@ namespace loader
         dditable_t dditable = {};
         std::string name;
         bool driverInuse = false;
+        zel_driver_type_t driverType;
+        ze_driver_properties_t properties;
     };
 
     using driver_vector_t = std::vector< driver_t >;


### PR DESCRIPTION
- Added support for reporting drivers sorted based on the types of devices returned.
- By default, drivers will be sorted such that the ordering will be:
	- Drivers with Discrete GPUs only - Drivers with Discrete and Integrated GPUs - Drivers with Integrated GPUs - Drivers with Mixed Devices Types (ie GPU + NPU) - Drivers with Non GPU Devices Only
- If ZE_ENABLE_PCI_ID_DEVICE_ORDER is set, then the following ordering is provided:
	- Drivers with Integrated GPUs - Drivers with Discrete and Integrated GPUs - Drivers with Discrete GPUs only - Drivers with Mixed Devices Types (ie GPU + NPU) - Drivers with Non GPU Devices Only

- Expanded the zello_world sample to test both init paths for easy prototyping.