### PR TITLE
Add script to make a copy of headers in include/level_zero

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,8 @@ To generate the code from the scripts, run the following commands:
   * `cp level-zero-spec/include/* level-zero/include/`
 * Execute the json2src script in the level-zero repo with the input.json in the specification repo with the corresponding spec version, for example:
   * `./level-zero/scripts/json2src.py --ver 1.12 --api-json level-zero-spec/scripts/input.json .`
+* Execute the copy_headers script to copy the headers to their alternative location.
+  * `./level-zero/scripts/copy_headers.py .`
 
 These scripts update the code with what would be generated in the next specification update.
 

--- a/include/level_zero/README.md
+++ b/include/level_zero/README.md
@@ -1,0 +1,12 @@
+The files in this folder are identical to the ones in `include/`, they are provided to allow
+consuming the source folder in the same way as the install folder. For example to allow the compilation of
+
+```cpp
+#include <level_zero/ze_api.h>
+// Use Level Zero functions
+```
+
+with the include path set to `<path-to-level-zero-repository/include>`.
+This matches the layout of the header files when they are installed.
+
+Do not edit these files!

--- a/include/level_zero/layers/zel_tracing_api.h
+++ b/include/level_zero/layers/zel_tracing_api.h
@@ -1,0 +1,198 @@
+/*
+ * Copyright (C) 2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file zel_tracing_api.h
+ */
+#ifndef _ZEL_TRACING_API_H
+#define _ZEL_TRACING_API_H
+#if defined(__cplusplus)
+#pragma once
+#endif
+
+// 'core' API headers
+#include "../ze_api.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+// Intel 'oneAPI' Level-Zero Loader Layer Extension APIs for API Tracing
+#if !defined(__GNUC__)
+#pragma region zel_tracing
+#endif
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle of tracer object
+typedef struct _zel_tracer_handle_t *zel_tracer_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZEL_API_TRACING_NAME
+/// @brief API Tracing Extension Name
+#define ZEL_API_TRACING_NAME  "ZEL_api_tracing"
+#endif // ZEL_API_TRACING_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief API Tracing Extension Version(s)
+typedef enum _zel_api_tracing_version_t
+{
+    ZEL_API_TRACING_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),  ///< version 1.0
+    ZEL_API_TRACING_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),  ///< latest known version
+    ZEL_API_TRACING_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} zel_api_tracing_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Alias the existing callbacks definition for 'core' callbacks
+typedef ze_callbacks_t zel_core_callbacks_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Defines structure types
+typedef enum _zel_structure_type_t
+{
+    ZEL_STRUCTURE_TYPE_TRACER_DESC = 0x1  ,///< ::zel_tracer_desc_t
+    // This enumeration value is deprecated.
+    // Pluse use ZEL_STRUCTURE_TYPE_TRACER_DESC.
+    ZEL_STRUCTURE_TYPE_TRACER_EXP_DESC = 0x1  ,///< ::zel_tracer_desc_t
+    ZEL_STRUCTURE_TYPE_FORCE_UINT32 = 0x7fffffff
+
+} zel_structure_type_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Tracer descriptor
+typedef struct _zel_tracer_desc_t
+{
+    zel_structure_type_t stype;                     ///< [in] type of this structure
+    const void* pNext;                              ///< [in][optional] pointer to extension-specific structure
+    void* pUserData;                                ///< [in] pointer passed to every tracer's callbacks
+
+} zel_tracer_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Creates a tracer
+/// 
+/// @details
+///     - The tracer is created in the disabled state.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == desc`
+///         + `nullptr == desc->pUserData`
+///         + `nullptr == phTracer`
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCreate(
+    const zel_tracer_desc_t* desc,              ///< [in] pointer to tracer descriptor
+    zel_tracer_handle_t* phTracer               ///< [out] pointer to handle of tracer object created
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Destroys a tracer.
+/// 
+/// @details
+///     - The application must **not** call this function from simultaneous
+///       threads with the same tracer handle.
+///     - The implementation of this function must be thread-safe.
+///     - The implementation of this function will stall and wait on any
+///       outstanding threads executing callbacks before freeing any Host
+///       allocations associated with this tracer.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hTracer`
+///     - ::ZE_RESULT_ERROR_HANDLE_OBJECT_IN_USE
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerDestroy(
+    zel_tracer_handle_t hTracer                 ///< [in][release] handle of tracer object to destroy
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Sets the collection of callbacks to be executed **before** driver
+///        execution.
+/// 
+/// @details
+///     - The application only needs to set the function pointers it is
+///       interested in receiving; all others should be 'nullptr'
+///     - The application must ensure that no other threads are executing
+///       functions for which the tracing functions are changing.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same tracer handle.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hTracer`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCoreCbs`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerSetPrologues(
+    zel_tracer_handle_t hTracer,                ///< [in] handle of the tracer
+    zel_core_callbacks_t* pCoreCbs                  ///< [in] pointer to table of 'core' callback function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Sets the collection of callbacks to be executed **after** driver
+///        execution.
+/// 
+/// @details
+///     - The application only needs to set the function pointers it is
+///       interested in receiving; all others should be 'nullptr'
+///     - The application must ensure that no other threads are executing
+///       functions for which the tracing functions are changing.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same tracer handle.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hTracer`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCoreCbs`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerSetEpilogues(
+    zel_tracer_handle_t hTracer,                ///< [in] handle of the tracer
+    zel_core_callbacks_t* pCoreCbs                  ///< [in] pointer to table of 'core' callback function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Enables (or disables) the tracer
+/// 
+/// @details
+///     - The application must **not** call this function from simultaneous
+///       threads with the same tracer handle.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hTracer`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerSetEnabled(
+    zel_tracer_handle_t hTracer,                ///< [in] handle of the tracer
+    ze_bool_t enable                                ///< [in] enable the tracer if true; disable if false
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+
+#if defined(__cplusplus)
+} // extern "C"
+#endif
+
+#endif // _ZEL_TRACING_API_H

--- a/include/level_zero/layers/zel_tracing_ddi.h
+++ b/include/level_zero/layers/zel_tracing_ddi.h
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file zel_tracing_ddi.h
+ *
+ * This file has been manually generated.
+ * There is no "spec" for this loader layer "tracer" API.
+ */
+
+#ifndef _ZEL_TRACING_DDI_H
+#define _ZEL_TRACING_DDI_H
+#if defined(__cplusplus)
+#pragma once
+#endif
+#include "layers/zel_tracing_api.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zelTracerCreate 
+typedef ze_result_t (ZE_APICALL *zel_pfnTracerCreate_t)(
+    const zel_tracer_desc_t*,
+    zel_tracer_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetTracerDestroy 
+typedef ze_result_t (ZE_APICALL *zel_pfnTracerDestroy_t)(
+    zel_tracer_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetTracerSetPrologues 
+typedef ze_result_t (ZE_APICALL *zel_pfnTracerSetPrologues_t)(
+    zel_tracer_handle_t,
+    zel_core_callbacks_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetTracerSetEpilogues 
+typedef ze_result_t (ZE_APICALL *zel_pfnTracerSetEpilogues_t)(
+    zel_tracer_handle_t,
+    zel_core_callbacks_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetTracerSetEnabled 
+typedef ze_result_t (ZE_APICALL *zel_pfnTracerSetEnabled_t)(
+    zel_tracer_handle_t,
+    ze_bool_t
+    );
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Tracer functions pointers
+typedef struct _zel_tracer_dditable_t
+{
+    zel_pfnTracerCreate_t                                    pfnCreate;
+    zel_pfnTracerDestroy_t                                   pfnDestroy;
+    zel_pfnTracerSetPrologues_t                              pfnSetPrologues;
+    zel_pfnTracerSetEpilogues_t                              pfnSetEpilogues;
+    zel_pfnTracerSetEnabled_t                                pfnSetEnabled;
+} zel_tracer_dditable_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Tracer table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zelGetTracerApiProcAddrTable(
+    ze_api_version_t version,                       ///< [in] API version requested
+    zel_tracer_dditable_t* pDdiTable            ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zelGetTracerApiProcAddrTable
+typedef ze_result_t (ZE_APICALL *zel_pfnGetTracerApiProcAddrTable_t)(
+    ze_api_version_t,
+    zel_tracer_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Container for tracing DDI tables
+typedef struct _zel_tracing_dditable_t
+{
+   zel_tracer_dditable_t         Tracer;
+} zel_tracing_dditable_t;
+
+#if defined(__cplusplus)
+} // extern "C"
+#endif
+
+#endif // _ZEL_TRACING_DDI_H

--- a/include/level_zero/layers/zel_tracing_register_cb.h
+++ b/include/level_zero/layers/zel_tracing_register_cb.h
@@ -1,0 +1,3543 @@
+/*
+ *
+ * Copyright (C) 2021-2022 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file zel_tracing_register_cb.h
+ *
+ */
+#ifndef zel_tracing_register_cb_H
+#define zel_tracing_register_cb_H
+#if defined(__cplusplus)
+#pragma once
+#endif
+
+#include "../ze_api.h"
+
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle of tracer object
+typedef struct _zel_tracer_handle_t *zel_tracer_handle_t;
+
+/// Callback definitions for all API released in LevelZero spec 1.1 or newer
+/// Callbacks for APIs included in spec 1.0 are contained in ze_api.helper
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeInitDrivers
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_init_drivers_params_t
+{
+    uint32_t** ppCount;
+    ze_driver_handle_t** pphDrivers;
+    ze_init_driver_type_desc_t** pdesc;
+} ze_init_drivers_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeInitDrivers
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnInitDriversCb_t)(
+    ze_init_drivers_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeRTASBuilderCreateExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_rtas_builder_create_exp_params_t
+{
+    ze_driver_handle_t* phDriver;
+    const ze_rtas_builder_exp_desc_t** ppDescriptor;
+    ze_rtas_builder_exp_handle_t** pphBuilder;
+} ze_rtas_builder_create_exp_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeRTASBuilderCreateExp
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnRTASBuilderCreateExpCb_t)(
+    ze_rtas_builder_create_exp_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeRTASBuilderGetBuildPropertiesExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_rtas_builder_get_build_properties_exp_params_t
+{
+    ze_rtas_builder_exp_handle_t* phBuilder;
+    const ze_rtas_builder_build_op_exp_desc_t** ppBuildOpDescriptor;
+    ze_rtas_builder_exp_properties_t** ppProperties;
+} ze_rtas_builder_get_build_properties_exp_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeRTASBuilderGetBuildPropertiesExp
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnRTASBuilderGetBuildPropertiesExpCb_t)(
+    ze_rtas_builder_get_build_properties_exp_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeRTASBuilderBuildExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_rtas_builder_build_exp_params_t
+{
+    ze_rtas_builder_exp_handle_t* phBuilder;
+    const ze_rtas_builder_build_op_exp_desc_t** ppBuildOpDescriptor;
+    void** ppScratchBuffer;
+    size_t* pscratchBufferSizeBytes;
+    void** ppRtasBuffer;
+    size_t* prtasBufferSizeBytes;
+    ze_rtas_parallel_operation_exp_handle_t* phParallelOperation;
+    void** ppBuildUserPtr;
+    ze_rtas_aabb_exp_t** ppBounds;
+    size_t** ppRtasBufferSizeBytes;
+} ze_rtas_builder_build_exp_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeRTASBuilderBuildExp
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnRTASBuilderBuildExpCb_t)(
+    ze_rtas_builder_build_exp_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeRTASBuilderDestroyExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_rtas_builder_destroy_exp_params_t
+{
+    ze_rtas_builder_exp_handle_t* phBuilder;
+} ze_rtas_builder_destroy_exp_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeRTASBuilderDestroyExp
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnRTASBuilderDestroyExpCb_t)(
+    ze_rtas_builder_destroy_exp_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeRTASParallelOperationCreateExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_rtas_parallel_operation_create_exp_params_t
+{
+    ze_driver_handle_t* phDriver;
+    ze_rtas_parallel_operation_exp_handle_t** pphParallelOperation;
+} ze_rtas_parallel_operation_create_exp_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeRTASParallelOperationCreateExp
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnRTASParallelOperationCreateExpCb_t)(
+    ze_rtas_parallel_operation_create_exp_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeRTASParallelOperationGetPropertiesExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_rtas_parallel_operation_get_properties_exp_params_t
+{
+    ze_rtas_parallel_operation_exp_handle_t* phParallelOperation;
+    ze_rtas_parallel_operation_exp_properties_t** ppProperties;
+} ze_rtas_parallel_operation_get_properties_exp_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeRTASParallelOperationGetPropertiesExp
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnRTASParallelOperationGetPropertiesExpCb_t)(
+    ze_rtas_parallel_operation_get_properties_exp_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeRTASParallelOperationJoinExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_rtas_parallel_operation_join_exp_params_t
+{
+    ze_rtas_parallel_operation_exp_handle_t* phParallelOperation;
+} ze_rtas_parallel_operation_join_exp_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeRTASParallelOperationJoinExp
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnRTASParallelOperationJoinExpCb_t)(
+    ze_rtas_parallel_operation_join_exp_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeRTASParallelOperationDestroyExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_rtas_parallel_operation_destroy_exp_params_t
+{
+    ze_rtas_parallel_operation_exp_handle_t* phParallelOperation;
+} ze_rtas_parallel_operation_destroy_exp_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeRTASParallelOperationDestroyExp
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnRTASParallelOperationDestroyExpCb_t)(
+    ze_rtas_parallel_operation_destroy_exp_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeDriverGetExtensionFunctionAddress
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_driver_get_extension_function_address_params_t
+{
+    ze_driver_handle_t* phDriver;
+    const char** pname;
+    void*** pppFunctionAddress;
+} ze_driver_get_extension_function_address_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeDriverGetExtensionFunctionAddress
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnDriverGetExtensionFunctionAddressCb_t)(
+    ze_driver_get_extension_function_address_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeDriverGetLastErrorDescription
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_driver_get_last_error_description_params_t
+{
+    ze_driver_handle_t* phDriver;
+    const char*** pppString;
+} ze_driver_get_last_error_description_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeDriverGetLastErrorDescription
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnDriverGetLastErrorDescriptionCb_t)(
+    ze_driver_get_last_error_description_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeDriverRTASFormatCompatibilityCheckExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_driver_rtas_format_compatibility_check_exp_params_t
+{
+    ze_driver_handle_t* phDriver;
+    ze_rtas_format_exp_t* prtasFormatA;
+    ze_rtas_format_exp_t* prtasFormatB;
+} ze_driver_rtas_format_compatibility_check_exp_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeDriverRTASFormatCompatibilityCheckExp
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnDriverRTASFormatCompatibilityCheckExpCb_t)(
+    ze_driver_rtas_format_compatibility_check_exp_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeDeviceGetGlobalTimestamps
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_device_get_global_timestamps_params_t
+{
+    ze_device_handle_t* phDevice;
+    uint64_t** phostTimestamp;
+    uint64_t** pdeviceTimestamp;
+} ze_device_get_global_timestamps_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeDeviceGetGlobalTimestamps
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnDeviceGetGlobalTimestampsCb_t)(
+    ze_device_get_global_timestamps_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeDeviceImportExternalSemaphoreExt
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_device_import_external_semaphore_ext_params_t
+{
+    ze_device_handle_t* phDevice;
+    const ze_external_semaphore_ext_desc_t** pdesc;
+    ze_external_semaphore_ext_handle_t** pphSemaphore;
+} ze_device_import_external_semaphore_ext_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeDeviceImportExternalSemaphoreExt
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnDeviceImportExternalSemaphoreExtCb_t)(
+    ze_device_import_external_semaphore_ext_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeDeviceReleaseExternalSemaphoreExt
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_device_release_external_semaphore_ext_params_t
+{
+    ze_external_semaphore_ext_handle_t* phSemaphore;
+} ze_device_release_external_semaphore_ext_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeDeviceReleaseExternalSemaphoreExt
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnDeviceReleaseExternalSemaphoreExtCb_t)(
+    ze_device_release_external_semaphore_ext_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeDeviceReserveCacheExt
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_device_reserve_cache_ext_params_t
+{
+    ze_device_handle_t* phDevice;
+    size_t* pcacheLevel;
+    size_t* pcacheReservationSize;
+} ze_device_reserve_cache_ext_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeDeviceReserveCacheExt
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnDeviceReserveCacheExtCb_t)(
+    ze_device_reserve_cache_ext_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeDeviceSetCacheAdviceExt
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_device_set_cache_advice_ext_params_t
+{
+    ze_device_handle_t* phDevice;
+    void** pptr;
+    size_t* pregionSize;
+    ze_cache_ext_region_t* pcacheRegion;
+} ze_device_set_cache_advice_ext_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeDeviceSetCacheAdviceExt
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnDeviceSetCacheAdviceExtCb_t)(
+    ze_device_set_cache_advice_ext_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeDevicePciGetPropertiesExt
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_device_pci_get_properties_ext_params_t
+{
+    ze_device_handle_t* phDevice;
+    ze_pci_ext_properties_t** ppPciProperties;
+} ze_device_pci_get_properties_ext_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeDevicePciGetPropertiesExt
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnDevicePciGetPropertiesExtCb_t)(
+    ze_device_pci_get_properties_ext_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeDeviceGetFabricVertexExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_device_get_fabric_vertex_exp_params_t
+{
+    ze_device_handle_t* phDevice;
+    ze_fabric_vertex_handle_t** pphVertex;
+} ze_device_get_fabric_vertex_exp_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeDeviceGetFabricVertexExp
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnDeviceGetFabricVertexExpCb_t)(
+    ze_device_get_fabric_vertex_exp_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeDeviceGetRootDevice
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_device_get_root_device_params_t
+{
+    ze_device_handle_t* phDevice;
+    ze_device_handle_t** pphRootDevice;
+} ze_device_get_root_device_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeDeviceGetRootDevice
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnDeviceGetRootDeviceCb_t)(
+    ze_device_get_root_device_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeContextCreateEx
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_context_create_ex_params_t
+{
+    ze_driver_handle_t* phDriver;
+    const ze_context_desc_t** pdesc;
+    uint32_t* pnumDevices;
+    ze_device_handle_t** pphDevices;
+    ze_context_handle_t** pphContext;
+} ze_context_create_ex_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeContextCreateEx
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnContextCreateExCb_t)(
+    ze_context_create_ex_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandQueueGetOrdinal
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_command_queue_get_ordinal_params_t
+{
+    ze_command_queue_handle_t* phCommandQueue;
+    uint32_t** ppOrdinal;
+} ze_command_queue_get_ordinal_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandQueueGetOrdinal
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnCommandQueueGetOrdinalCb_t)(
+    ze_command_queue_get_ordinal_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandQueueGetIndex
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_command_queue_get_index_params_t
+{
+    ze_command_queue_handle_t* phCommandQueue;
+    uint32_t** ppIndex;
+} ze_command_queue_get_index_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandQueueGetIndex
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnCommandQueueGetIndexCb_t)(
+    ze_command_queue_get_index_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandListGetNextCommandIdWithKernelsExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_command_list_get_next_command_id_with_kernels_exp_params_t
+{
+    ze_command_list_handle_t* phCommandList;
+    const ze_mutable_command_id_exp_desc_t** pdesc;
+    uint32_t* pnumKernels;
+    ze_kernel_handle_t** pphKernels;
+    uint64_t** ppCommandId;
+} ze_command_list_get_next_command_id_with_kernels_exp_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandListGetNextCommandIdWithKernelsExp
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnCommandListGetNextCommandIdWithKernelsExpCb_t)(
+    ze_command_list_get_next_command_id_with_kernels_exp_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandListUpdateMutableCommandKernelsExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_command_list_update_mutable_command_kernels_exp_params_t
+{
+    ze_command_list_handle_t* phCommandList;
+    uint32_t* pnumKernels;
+    uint64_t** ppCommandId;
+    ze_kernel_handle_t** pphKernels;
+} ze_command_list_update_mutable_command_kernels_exp_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandListUpdateMutableCommandKernelsExp
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnCommandListUpdateMutableCommandKernelsExpCb_t)(
+    ze_command_list_update_mutable_command_kernels_exp_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandListAppendSignalExternalSemaphoreExt
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_command_list_append_signal_external_semaphore_ext_params_t
+{
+    ze_command_list_handle_t* phCommandList;
+    uint32_t* pnumSemaphores;
+    ze_external_semaphore_ext_handle_t** pphSemaphores;
+    ze_external_semaphore_signal_params_ext_t** psignalParams;
+    ze_event_handle_t* phSignalEvent;
+    uint32_t* pnumWaitEvents;
+    ze_event_handle_t** pphWaitEvents;
+} ze_command_list_append_signal_external_semaphore_ext_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandListAppendSignalExternalSemaphoreExt
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnCommandListAppendSignalExternalSemaphoreExtCb_t)(
+    ze_command_list_append_signal_external_semaphore_ext_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandListAppendWaitExternalSemaphoreExt
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_command_list_append_wait_external_semaphore_ext_params_t
+{
+    ze_command_list_handle_t* phCommandList;
+    uint32_t* pnumSemaphores;
+    ze_external_semaphore_ext_handle_t** pphSemaphores;
+    ze_external_semaphore_wait_params_ext_t** pwaitParams;
+    ze_event_handle_t* phSignalEvent;
+    uint32_t* pnumWaitEvents;
+    ze_event_handle_t** pphWaitEvents;
+} ze_command_list_append_wait_external_semaphore_ext_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandListAppendWaitExternalSemaphoreExt
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnCommandListAppendWaitExternalSemaphoreExtCb_t)(
+    ze_command_list_append_wait_external_semaphore_ext_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandListAppendImageCopyToMemoryExt
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_command_list_append_image_copy_to_memory_ext_params_t
+{
+    ze_command_list_handle_t* phCommandList;
+    void** pdstptr;
+    ze_image_handle_t* phSrcImage;
+    const ze_image_region_t** ppSrcRegion;
+    uint32_t* pdestRowPitch;
+    uint32_t* pdestSlicePitch;
+    ze_event_handle_t* phSignalEvent;
+    uint32_t* pnumWaitEvents;
+    ze_event_handle_t** pphWaitEvents;
+} ze_command_list_append_image_copy_to_memory_ext_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandListAppendImageCopyToMemoryExt
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnCommandListAppendImageCopyToMemoryExtCb_t)(
+    ze_command_list_append_image_copy_to_memory_ext_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandListAppendImageCopyFromMemoryExt
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_command_list_append_image_copy_from_memory_ext_params_t
+{
+    ze_command_list_handle_t* phCommandList;
+    ze_image_handle_t* phDstImage;
+    const void** psrcptr;
+    const ze_image_region_t** ppDstRegion;
+    uint32_t* psrcRowPitch;
+    uint32_t* psrcSlicePitch;
+    ze_event_handle_t* phSignalEvent;
+    uint32_t* pnumWaitEvents;
+    ze_event_handle_t** pphWaitEvents;
+} ze_command_list_append_image_copy_from_memory_ext_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandListAppendImageCopyFromMemoryExt
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnCommandListAppendImageCopyFromMemoryExtCb_t)(
+    ze_command_list_append_image_copy_from_memory_ext_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandListHostSynchronize
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_command_list_host_synchronize_params_t
+{
+    ze_command_list_handle_t* phCommandList;
+    uint64_t* ptimeout;
+} ze_command_list_host_synchronize_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandListHostSynchronize
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnCommandListHostSynchronizeCb_t)(
+    ze_command_list_host_synchronize_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandListCreateCloneExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_command_list_create_clone_exp_params_t
+{
+    ze_command_list_handle_t* phCommandList;
+    ze_command_list_handle_t** pphClonedCommandList;
+} ze_command_list_create_clone_exp_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandListCreateCloneExp
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnCommandListCreateCloneExpCb_t)(
+    ze_command_list_create_clone_exp_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandListGetDeviceHandle
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_command_list_get_device_handle_params_t
+{
+    ze_command_list_handle_t* phCommandList;
+    ze_device_handle_t** pphDevice;
+} ze_command_list_get_device_handle_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandListGetDeviceHandle
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnCommandListGetDeviceHandleCb_t)(
+    ze_command_list_get_device_handle_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandListGetContextHandle
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_command_list_get_context_handle_params_t
+{
+    ze_command_list_handle_t* phCommandList;
+    ze_context_handle_t** pphContext;
+} ze_command_list_get_context_handle_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandListGetContextHandle
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnCommandListGetContextHandleCb_t)(
+    ze_command_list_get_context_handle_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandListGetOrdinal
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_command_list_get_ordinal_params_t
+{
+    ze_command_list_handle_t* phCommandList;
+    uint32_t** ppOrdinal;
+} ze_command_list_get_ordinal_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandListGetOrdinal
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnCommandListGetOrdinalCb_t)(
+    ze_command_list_get_ordinal_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandListImmediateGetIndex
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_command_list_immediate_get_index_params_t
+{
+    ze_command_list_handle_t* phCommandListImmediate;
+    uint32_t** ppIndex;
+} ze_command_list_immediate_get_index_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandListImmediateGetIndex
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnCommandListImmediateGetIndexCb_t)(
+    ze_command_list_immediate_get_index_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandListIsImmediate
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_command_list_is_immediate_params_t
+{
+    ze_command_list_handle_t* phCommandList;
+    ze_bool_t** ppIsImmediate;
+} ze_command_list_is_immediate_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandListIsImmediate
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnCommandListIsImmediateCb_t)(
+    ze_command_list_is_immediate_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandListImmediateAppendCommandListsExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_command_list_immediate_append_command_lists_exp_params_t
+{
+    ze_command_list_handle_t* phCommandListImmediate;
+    uint32_t* pnumCommandLists;
+    ze_command_list_handle_t** pphCommandLists;
+    ze_event_handle_t* phSignalEvent;
+    uint32_t* pnumWaitEvents;
+    ze_event_handle_t** pphWaitEvents;
+} ze_command_list_immediate_append_command_lists_exp_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandListImmediateAppendCommandListsExp
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnCommandListImmediateAppendCommandListsExpCb_t)(
+    ze_command_list_immediate_append_command_lists_exp_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandListGetNextCommandIdExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_command_list_get_next_command_id_exp_params_t
+{
+    ze_command_list_handle_t* phCommandList;
+    const ze_mutable_command_id_exp_desc_t** pdesc;
+    uint64_t** ppCommandId;
+} ze_command_list_get_next_command_id_exp_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandListGetNextCommandIdExp
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnCommandListGetNextCommandIdExpCb_t)(
+    ze_command_list_get_next_command_id_exp_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandListUpdateMutableCommandsExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_command_list_update_mutable_commands_exp_params_t
+{
+    ze_command_list_handle_t* phCommandList;
+    const ze_mutable_commands_exp_desc_t** pdesc;
+} ze_command_list_update_mutable_commands_exp_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandListUpdateMutableCommandsExp
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnCommandListUpdateMutableCommandsExpCb_t)(
+    ze_command_list_update_mutable_commands_exp_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandListUpdateMutableCommandSignalEventExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_command_list_update_mutable_command_signal_event_exp_params_t
+{
+    ze_command_list_handle_t* phCommandList;
+    uint64_t* pcommandId;
+    ze_event_handle_t* phSignalEvent;
+} ze_command_list_update_mutable_command_signal_event_exp_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandListUpdateMutableCommandSignalEventExp
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnCommandListUpdateMutableCommandSignalEventExpCb_t)(
+    ze_command_list_update_mutable_command_signal_event_exp_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandListUpdateMutableCommandWaitEventsExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_command_list_update_mutable_command_wait_events_exp_params_t
+{
+    ze_command_list_handle_t* phCommandList;
+    uint64_t* pcommandId;
+    uint32_t* pnumWaitEvents;
+    ze_event_handle_t** pphWaitEvents;
+} ze_command_list_update_mutable_command_wait_events_exp_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandListUpdateMutableCommandWaitEventsExp
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnCommandListUpdateMutableCommandWaitEventsExpCb_t)(
+    ze_command_list_update_mutable_command_wait_events_exp_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeEventQueryTimestampsExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_event_query_timestamps_exp_params_t
+{
+    ze_event_handle_t* phEvent;
+    ze_device_handle_t* phDevice;
+    uint32_t** ppCount;
+    ze_kernel_timestamp_result_t** ppTimestamps;
+} ze_event_query_timestamps_exp_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeEventQueryTimestampsExp
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnEventQueryTimestampsExpCb_t)(
+    ze_event_query_timestamps_exp_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeEventQueryKernelTimestampsExt
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_event_query_kernel_timestamps_ext_params_t
+{
+    ze_event_handle_t* phEvent;
+    ze_device_handle_t* phDevice;
+    uint32_t** ppCount;
+    ze_event_query_kernel_timestamps_results_ext_properties_t** ppResults;
+} ze_event_query_kernel_timestamps_ext_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeEventQueryKernelTimestampsExt
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnEventQueryKernelTimestampsExtCb_t)(
+    ze_event_query_kernel_timestamps_ext_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeEventGetEventPool
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_event_get_event_pool_params_t
+{
+    ze_event_handle_t* phEvent;
+    ze_event_pool_handle_t** pphEventPool;
+} ze_event_get_event_pool_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeEventGetEventPool
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnEventGetEventPoolCb_t)(
+    ze_event_get_event_pool_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeEventGetSignalScope
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_event_get_signal_scope_params_t
+{
+    ze_event_handle_t* phEvent;
+    ze_event_scope_flags_t** ppSignalScope;
+} ze_event_get_signal_scope_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeEventGetSignalScope
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnEventGetSignalScopeCb_t)(
+    ze_event_get_signal_scope_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeEventGetWaitScope
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_event_get_wait_scope_params_t
+{
+    ze_event_handle_t* phEvent;
+    ze_event_scope_flags_t** ppWaitScope;
+} ze_event_get_wait_scope_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeEventGetWaitScope
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnEventGetWaitScopeCb_t)(
+    ze_event_get_wait_scope_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeEventPoolPutIpcHandle
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_event_pool_put_ipc_handle_params_t
+{
+    ze_context_handle_t* phContext;
+    ze_ipc_event_pool_handle_t* phIpc;
+} ze_event_pool_put_ipc_handle_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeEventPoolPutIpcHandle
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnEventPoolPutIpcHandleCb_t)(
+    ze_event_pool_put_ipc_handle_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeEventPoolGetContextHandle
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_event_pool_get_context_handle_params_t
+{
+    ze_event_pool_handle_t* phEventPool;
+    ze_context_handle_t** pphContext;
+} ze_event_pool_get_context_handle_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeEventPoolGetContextHandle
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnEventPoolGetContextHandleCb_t)(
+    ze_event_pool_get_context_handle_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeEventPoolGetFlags
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_event_pool_get_flags_params_t
+{
+    ze_event_pool_handle_t* phEventPool;
+    ze_event_pool_flags_t** ppFlags;
+} ze_event_pool_get_flags_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeEventPoolGetFlags
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnEventPoolGetFlagsCb_t)(
+    ze_event_pool_get_flags_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeImageGetMemoryPropertiesExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_image_get_memory_properties_exp_params_t
+{
+    ze_image_handle_t* phImage;
+    ze_image_memory_properties_exp_t** ppMemoryProperties;
+} ze_image_get_memory_properties_exp_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeImageGetMemoryPropertiesExp
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnImageGetMemoryPropertiesExpCb_t)(
+    ze_image_get_memory_properties_exp_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeImageViewCreateExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_image_view_create_exp_params_t
+{
+    ze_context_handle_t* phContext;
+    ze_device_handle_t* phDevice;
+    const ze_image_desc_t** pdesc;
+    ze_image_handle_t* phImage;
+    ze_image_handle_t** pphImageView;
+} ze_image_view_create_exp_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeImageViewCreateExp
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnImageViewCreateExpCb_t)(
+    ze_image_view_create_exp_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeImageGetAllocPropertiesExt
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_image_get_alloc_properties_ext_params_t
+{
+    ze_context_handle_t* phContext;
+    ze_image_handle_t* phImage;
+    ze_image_allocation_ext_properties_t** ppImageAllocProperties;
+} ze_image_get_alloc_properties_ext_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeImageGetAllocPropertiesExt
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnImageGetAllocPropertiesExtCb_t)(
+    ze_image_get_alloc_properties_ext_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeImageViewCreateExt
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_image_view_create_ext_params_t
+{
+    ze_context_handle_t* phContext;
+    ze_device_handle_t* phDevice;
+    const ze_image_desc_t** pdesc;
+    ze_image_handle_t* phImage;
+    ze_image_handle_t** pphImageView;
+} ze_image_view_create_ext_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeImageViewCreateExt
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnImageViewCreateExtCb_t)(
+    ze_image_view_create_ext_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeImageGetDeviceOffsetExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_image_get_device_offset_exp_params_t
+{
+    ze_image_handle_t* phImage;
+    uint64_t** ppDeviceOffset;
+} ze_image_get_device_offset_exp_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeImageGetDeviceOffsetExp
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnImageGetDeviceOffsetExpCb_t)(
+    ze_image_get_device_offset_exp_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeKernelSetGlobalOffsetExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_kernel_set_global_offset_exp_params_t
+{
+    ze_kernel_handle_t* phKernel;
+    uint32_t* poffsetX;
+    uint32_t* poffsetY;
+    uint32_t* poffsetZ;
+} ze_kernel_set_global_offset_exp_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeKernelSetGlobalOffsetExp
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnKernelSetGlobalOffsetExpCb_t)(
+    ze_kernel_set_global_offset_exp_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeKernelGetBinaryExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_kernel_get_binary_exp_params_t
+{
+    ze_kernel_handle_t* phKernel;
+    size_t** ppSize;
+    uint8_t** ppKernelBinary;
+} ze_kernel_get_binary_exp_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeKernelGetBinaryExp
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnKernelGetBinaryExpCb_t)(
+    ze_kernel_get_binary_exp_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeKernelSchedulingHintExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_kernel_scheduling_hint_exp_params_t
+{
+    ze_kernel_handle_t* phKernel;
+    ze_scheduling_hint_exp_desc_t** ppHint;
+} ze_kernel_scheduling_hint_exp_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeKernelSchedulingHintExp
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnKernelSchedulingHintExpCb_t)(
+    ze_kernel_scheduling_hint_exp_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeMemFreeExt
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_mem_free_ext_params_t
+{
+    ze_context_handle_t* phContext;
+    const ze_memory_free_ext_desc_t** ppMemFreeDesc;
+    void** pptr;
+} ze_mem_free_ext_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeMemFreeExt
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnMemFreeExtCb_t)(
+    ze_mem_free_ext_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeMemGetIpcHandleFromFileDescriptorExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_mem_get_ipc_handle_from_file_descriptor_exp_params_t
+{
+    ze_context_handle_t* phContext;
+    uint64_t* phandle;
+    ze_ipc_mem_handle_t** ppIpcHandle;
+} ze_mem_get_ipc_handle_from_file_descriptor_exp_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeMemGetIpcHandleFromFileDescriptorExp
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnMemGetIpcHandleFromFileDescriptorExpCb_t)(
+    ze_mem_get_ipc_handle_from_file_descriptor_exp_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeMemGetFileDescriptorFromIpcHandleExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_mem_get_file_descriptor_from_ipc_handle_exp_params_t
+{
+    ze_context_handle_t* phContext;
+    ze_ipc_mem_handle_t* pipcHandle;
+    uint64_t** ppHandle;
+} ze_mem_get_file_descriptor_from_ipc_handle_exp_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeMemGetFileDescriptorFromIpcHandleExp
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnMemGetFileDescriptorFromIpcHandleExpCb_t)(
+    ze_mem_get_file_descriptor_from_ipc_handle_exp_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeMemPutIpcHandle
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_mem_put_ipc_handle_params_t
+{
+    ze_context_handle_t* phContext;
+    ze_ipc_mem_handle_t* phandle;
+} ze_mem_put_ipc_handle_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeMemPutIpcHandle
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnMemPutIpcHandleCb_t)(
+    ze_mem_put_ipc_handle_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeMemSetAtomicAccessAttributeExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_mem_set_atomic_access_attribute_exp_params_t
+{
+    ze_context_handle_t* phContext;
+    ze_device_handle_t* phDevice;
+    const void** pptr;
+    size_t* psize;
+    ze_memory_atomic_attr_exp_flags_t* pattr;
+} ze_mem_set_atomic_access_attribute_exp_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeMemSetAtomicAccessAttributeExp
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnMemSetAtomicAccessAttributeExpCb_t)(
+    ze_mem_set_atomic_access_attribute_exp_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeMemGetAtomicAccessAttributeExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_mem_get_atomic_access_attribute_exp_params_t
+{
+    ze_context_handle_t* phContext;
+    ze_device_handle_t* phDevice;
+    const void** pptr;
+    size_t* psize;
+    ze_memory_atomic_attr_exp_flags_t** ppAttr;
+} ze_mem_get_atomic_access_attribute_exp_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeMemGetAtomicAccessAttributeExp
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnMemGetAtomicAccessAttributeExpCb_t)(
+    ze_mem_get_atomic_access_attribute_exp_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeMemGetPitchFor2dImage
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_mem_get_pitch_for2d_image_params_t
+{
+    ze_context_handle_t* phContext;
+    ze_device_handle_t* phDevice;
+    size_t* pimageWidth;
+    size_t* pimageHeight;
+    unsigned int* pelementSizeInBytes;
+    size_t ** prowPitch;
+} ze_mem_get_pitch_for2d_image_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeMemGetPitchFor2dImage
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnMemGetPitchFor2dImageCb_t)(
+    ze_mem_get_pitch_for2d_image_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeModuleInspectLinkageExt
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_module_inspect_linkage_ext_params_t
+{
+    ze_linkage_inspection_ext_desc_t** ppInspectDesc;
+    uint32_t* pnumModules;
+    ze_module_handle_t** pphModules;
+    ze_module_build_log_handle_t** pphLog;
+} ze_module_inspect_linkage_ext_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeModuleInspectLinkageExt
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnModuleInspectLinkageExtCb_t)(
+    ze_module_inspect_linkage_ext_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeFabricEdgeGetExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_fabric_edge_get_exp_params_t
+{
+    ze_fabric_vertex_handle_t* phVertexA;
+    ze_fabric_vertex_handle_t* phVertexB;
+    uint32_t** ppCount;
+    ze_fabric_edge_handle_t** pphEdges;
+} ze_fabric_edge_get_exp_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeFabricEdgeGetExp
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnFabricEdgeGetExpCb_t)(
+    ze_fabric_edge_get_exp_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeFabricEdgeGetVerticesExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_fabric_edge_get_vertices_exp_params_t
+{
+    ze_fabric_edge_handle_t* phEdge;
+    ze_fabric_vertex_handle_t** pphVertexA;
+    ze_fabric_vertex_handle_t** pphVertexB;
+} ze_fabric_edge_get_vertices_exp_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeFabricEdgeGetVerticesExp
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnFabricEdgeGetVerticesExpCb_t)(
+    ze_fabric_edge_get_vertices_exp_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeFabricEdgeGetPropertiesExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_fabric_edge_get_properties_exp_params_t
+{
+    ze_fabric_edge_handle_t* phEdge;
+    ze_fabric_edge_exp_properties_t** ppEdgeProperties;
+} ze_fabric_edge_get_properties_exp_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeFabricEdgeGetPropertiesExp
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnFabricEdgeGetPropertiesExpCb_t)(
+    ze_fabric_edge_get_properties_exp_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeFabricVertexGetExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_fabric_vertex_get_exp_params_t
+{
+    ze_driver_handle_t* phDriver;
+    uint32_t** ppCount;
+    ze_fabric_vertex_handle_t** pphVertices;
+} ze_fabric_vertex_get_exp_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeFabricVertexGetExp
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnFabricVertexGetExpCb_t)(
+    ze_fabric_vertex_get_exp_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeFabricVertexGetSubVerticesExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_fabric_vertex_get_sub_vertices_exp_params_t
+{
+    ze_fabric_vertex_handle_t* phVertex;
+    uint32_t** ppCount;
+    ze_fabric_vertex_handle_t** pphSubvertices;
+} ze_fabric_vertex_get_sub_vertices_exp_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeFabricVertexGetSubVerticesExp
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnFabricVertexGetSubVerticesExpCb_t)(
+    ze_fabric_vertex_get_sub_vertices_exp_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeFabricVertexGetPropertiesExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_fabric_vertex_get_properties_exp_params_t
+{
+    ze_fabric_vertex_handle_t* phVertex;
+    ze_fabric_vertex_exp_properties_t** ppVertexProperties;
+} ze_fabric_vertex_get_properties_exp_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeFabricVertexGetPropertiesExp
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnFabricVertexGetPropertiesExpCb_t)(
+    ze_fabric_vertex_get_properties_exp_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeFabricVertexGetDeviceExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+
+typedef struct _ze_fabric_vertex_get_device_exp_params_t
+{
+    ze_fabric_vertex_handle_t* phVertex;
+    ze_device_handle_t** pphDevice;
+} ze_fabric_vertex_get_device_exp_params_t;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeFabricVertexGetDeviceExp
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+
+typedef void (ZE_APICALL *ze_pfnFabricVertexGetDeviceExpCb_t)(
+    ze_fabric_vertex_get_device_exp_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+
+typedef enum _zel_tracer_reg_t
+{
+    ZEL_REGISTER_PROLOGUE = 0,
+    ZEL_REGISTER_EPILOGUE = 1     
+} zel_tracer_reg_t;
+
+/// APIs to register callbacks for each core API
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerInitRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnInitCb_t pfnInitCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerDriverGetRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnDriverGetCb_t pfnGetCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerInitDriversRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnInitDriversCb_t pfnInitDriversCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerDriverGetApiVersionRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnDriverGetApiVersionCb_t pfnGetApiVersionCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerDriverGetPropertiesRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnDriverGetPropertiesCb_t pfnGetPropertiesCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerDriverGetIpcPropertiesRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnDriverGetIpcPropertiesCb_t pfnGetIpcPropertiesCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerDriverGetExtensionPropertiesRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnDriverGetExtensionPropertiesCb_t pfnGetExtensionPropertiesCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerDriverGetExtensionFunctionAddressRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnDriverGetExtensionFunctionAddressCb_t pfnGetExtensionFunctionAddressCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerDriverGetLastErrorDescriptionRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnDriverGetLastErrorDescriptionCb_t pfnGetLastErrorDescriptionCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerDeviceGetRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnDeviceGetCb_t pfnGetCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerDeviceGetRootDeviceRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnDeviceGetRootDeviceCb_t pfnGetRootDeviceCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerDeviceGetSubDevicesRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnDeviceGetSubDevicesCb_t pfnGetSubDevicesCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerDeviceGetPropertiesRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnDeviceGetPropertiesCb_t pfnGetPropertiesCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerDeviceGetComputePropertiesRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnDeviceGetComputePropertiesCb_t pfnGetComputePropertiesCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerDeviceGetModulePropertiesRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnDeviceGetModulePropertiesCb_t pfnGetModulePropertiesCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerDeviceGetCommandQueueGroupPropertiesRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnDeviceGetCommandQueueGroupPropertiesCb_t pfnGetCommandQueueGroupPropertiesCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerDeviceGetMemoryPropertiesRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnDeviceGetMemoryPropertiesCb_t pfnGetMemoryPropertiesCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerDeviceGetMemoryAccessPropertiesRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnDeviceGetMemoryAccessPropertiesCb_t pfnGetMemoryAccessPropertiesCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerDeviceGetCachePropertiesRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnDeviceGetCachePropertiesCb_t pfnGetCachePropertiesCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerDeviceGetImagePropertiesRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnDeviceGetImagePropertiesCb_t pfnGetImagePropertiesCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerDeviceGetExternalMemoryPropertiesRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnDeviceGetExternalMemoryPropertiesCb_t pfnGetExternalMemoryPropertiesCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerDeviceGetP2PPropertiesRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnDeviceGetP2PPropertiesCb_t pfnGetP2PPropertiesCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerDeviceCanAccessPeerRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnDeviceCanAccessPeerCb_t pfnCanAccessPeerCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerDeviceGetStatusRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnDeviceGetStatusCb_t pfnGetStatusCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerDeviceGetGlobalTimestampsRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnDeviceGetGlobalTimestampsCb_t pfnGetGlobalTimestampsCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerContextCreateRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnContextCreateCb_t pfnCreateCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerContextCreateExRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnContextCreateExCb_t pfnCreateExCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerContextDestroyRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnContextDestroyCb_t pfnDestroyCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerContextGetStatusRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnContextGetStatusCb_t pfnGetStatusCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandQueueCreateRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandQueueCreateCb_t pfnCreateCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandQueueDestroyRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandQueueDestroyCb_t pfnDestroyCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandQueueExecuteCommandListsRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandQueueExecuteCommandListsCb_t pfnExecuteCommandListsCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandQueueSynchronizeRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandQueueSynchronizeCb_t pfnSynchronizeCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandQueueGetOrdinalRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandQueueGetOrdinalCb_t pfnGetOrdinalCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandQueueGetIndexRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandQueueGetIndexCb_t pfnGetIndexCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandListCreateRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandListCreateCb_t pfnCreateCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandListCreateImmediateRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandListCreateImmediateCb_t pfnCreateImmediateCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandListDestroyRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandListDestroyCb_t pfnDestroyCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandListCloseRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandListCloseCb_t pfnCloseCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandListResetRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandListResetCb_t pfnResetCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandListAppendWriteGlobalTimestampRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandListAppendWriteGlobalTimestampCb_t pfnAppendWriteGlobalTimestampCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandListHostSynchronizeRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandListHostSynchronizeCb_t pfnHostSynchronizeCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandListGetDeviceHandleRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandListGetDeviceHandleCb_t pfnGetDeviceHandleCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandListGetContextHandleRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandListGetContextHandleCb_t pfnGetContextHandleCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandListGetOrdinalRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandListGetOrdinalCb_t pfnGetOrdinalCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandListImmediateGetIndexRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandListImmediateGetIndexCb_t pfnImmediateGetIndexCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandListIsImmediateRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandListIsImmediateCb_t pfnIsImmediateCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandListAppendBarrierRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandListAppendBarrierCb_t pfnAppendBarrierCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandListAppendMemoryRangesBarrierRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandListAppendMemoryRangesBarrierCb_t pfnAppendMemoryRangesBarrierCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerContextSystemBarrierRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnContextSystemBarrierCb_t pfnSystemBarrierCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandListAppendMemoryCopyRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandListAppendMemoryCopyCb_t pfnAppendMemoryCopyCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandListAppendMemoryFillRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandListAppendMemoryFillCb_t pfnAppendMemoryFillCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandListAppendMemoryCopyRegionRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandListAppendMemoryCopyRegionCb_t pfnAppendMemoryCopyRegionCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandListAppendMemoryCopyFromContextRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandListAppendMemoryCopyFromContextCb_t pfnAppendMemoryCopyFromContextCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandListAppendImageCopyRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandListAppendImageCopyCb_t pfnAppendImageCopyCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandListAppendImageCopyRegionRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandListAppendImageCopyRegionCb_t pfnAppendImageCopyRegionCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandListAppendImageCopyToMemoryRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandListAppendImageCopyToMemoryCb_t pfnAppendImageCopyToMemoryCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandListAppendImageCopyFromMemoryRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandListAppendImageCopyFromMemoryCb_t pfnAppendImageCopyFromMemoryCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandListAppendMemoryPrefetchRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandListAppendMemoryPrefetchCb_t pfnAppendMemoryPrefetchCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandListAppendMemAdviseRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandListAppendMemAdviseCb_t pfnAppendMemAdviseCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerEventPoolCreateRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnEventPoolCreateCb_t pfnCreateCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerEventPoolDestroyRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnEventPoolDestroyCb_t pfnDestroyCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerEventCreateRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnEventCreateCb_t pfnCreateCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerEventDestroyRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnEventDestroyCb_t pfnDestroyCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerEventPoolGetIpcHandleRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnEventPoolGetIpcHandleCb_t pfnGetIpcHandleCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerEventPoolPutIpcHandleRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnEventPoolPutIpcHandleCb_t pfnPutIpcHandleCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerEventPoolOpenIpcHandleRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnEventPoolOpenIpcHandleCb_t pfnOpenIpcHandleCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerEventPoolCloseIpcHandleRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnEventPoolCloseIpcHandleCb_t pfnCloseIpcHandleCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandListAppendSignalEventRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandListAppendSignalEventCb_t pfnAppendSignalEventCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandListAppendWaitOnEventsRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandListAppendWaitOnEventsCb_t pfnAppendWaitOnEventsCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerEventHostSignalRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnEventHostSignalCb_t pfnHostSignalCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerEventHostSynchronizeRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnEventHostSynchronizeCb_t pfnHostSynchronizeCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerEventQueryStatusRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnEventQueryStatusCb_t pfnQueryStatusCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandListAppendEventResetRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandListAppendEventResetCb_t pfnAppendEventResetCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerEventHostResetRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnEventHostResetCb_t pfnHostResetCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerEventQueryKernelTimestampRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnEventQueryKernelTimestampCb_t pfnQueryKernelTimestampCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandListAppendQueryKernelTimestampsRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandListAppendQueryKernelTimestampsCb_t pfnAppendQueryKernelTimestampsCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerEventGetEventPoolRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnEventGetEventPoolCb_t pfnGetEventPoolCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerEventGetSignalScopeRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnEventGetSignalScopeCb_t pfnGetSignalScopeCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerEventGetWaitScopeRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnEventGetWaitScopeCb_t pfnGetWaitScopeCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerEventPoolGetContextHandleRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnEventPoolGetContextHandleCb_t pfnGetContextHandleCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerEventPoolGetFlagsRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnEventPoolGetFlagsCb_t pfnGetFlagsCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerFenceCreateRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnFenceCreateCb_t pfnCreateCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerFenceDestroyRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnFenceDestroyCb_t pfnDestroyCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerFenceHostSynchronizeRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnFenceHostSynchronizeCb_t pfnHostSynchronizeCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerFenceQueryStatusRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnFenceQueryStatusCb_t pfnQueryStatusCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerFenceResetRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnFenceResetCb_t pfnResetCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerImageGetPropertiesRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnImageGetPropertiesCb_t pfnGetPropertiesCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerImageCreateRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnImageCreateCb_t pfnCreateCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerImageDestroyRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnImageDestroyCb_t pfnDestroyCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerMemAllocSharedRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnMemAllocSharedCb_t pfnAllocSharedCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerMemAllocDeviceRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnMemAllocDeviceCb_t pfnAllocDeviceCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerMemAllocHostRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnMemAllocHostCb_t pfnAllocHostCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerMemFreeRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnMemFreeCb_t pfnFreeCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerMemGetAllocPropertiesRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnMemGetAllocPropertiesCb_t pfnGetAllocPropertiesCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerMemGetAddressRangeRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnMemGetAddressRangeCb_t pfnGetAddressRangeCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerMemGetIpcHandleRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnMemGetIpcHandleCb_t pfnGetIpcHandleCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerMemGetIpcHandleFromFileDescriptorExpRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnMemGetIpcHandleFromFileDescriptorExpCb_t pfnGetIpcHandleFromFileDescriptorExpCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerMemGetFileDescriptorFromIpcHandleExpRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnMemGetFileDescriptorFromIpcHandleExpCb_t pfnGetFileDescriptorFromIpcHandleExpCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerMemPutIpcHandleRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnMemPutIpcHandleCb_t pfnPutIpcHandleCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerMemOpenIpcHandleRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnMemOpenIpcHandleCb_t pfnOpenIpcHandleCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerMemCloseIpcHandleRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnMemCloseIpcHandleCb_t pfnCloseIpcHandleCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerMemSetAtomicAccessAttributeExpRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnMemSetAtomicAccessAttributeExpCb_t pfnSetAtomicAccessAttributeExpCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerMemGetAtomicAccessAttributeExpRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnMemGetAtomicAccessAttributeExpCb_t pfnGetAtomicAccessAttributeExpCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerModuleCreateRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnModuleCreateCb_t pfnCreateCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerModuleDestroyRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnModuleDestroyCb_t pfnDestroyCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerModuleDynamicLinkRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnModuleDynamicLinkCb_t pfnDynamicLinkCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerModuleBuildLogDestroyRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnModuleBuildLogDestroyCb_t pfnDestroyCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerModuleBuildLogGetStringRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnModuleBuildLogGetStringCb_t pfnGetStringCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerModuleGetNativeBinaryRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnModuleGetNativeBinaryCb_t pfnGetNativeBinaryCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerModuleGetGlobalPointerRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnModuleGetGlobalPointerCb_t pfnGetGlobalPointerCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerModuleGetKernelNamesRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnModuleGetKernelNamesCb_t pfnGetKernelNamesCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerModuleGetPropertiesRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnModuleGetPropertiesCb_t pfnGetPropertiesCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerKernelCreateRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnKernelCreateCb_t pfnCreateCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerKernelDestroyRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnKernelDestroyCb_t pfnDestroyCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerModuleGetFunctionPointerRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnModuleGetFunctionPointerCb_t pfnGetFunctionPointerCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerKernelSetGroupSizeRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnKernelSetGroupSizeCb_t pfnSetGroupSizeCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerKernelSuggestGroupSizeRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnKernelSuggestGroupSizeCb_t pfnSuggestGroupSizeCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerKernelSuggestMaxCooperativeGroupCountRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnKernelSuggestMaxCooperativeGroupCountCb_t pfnSuggestMaxCooperativeGroupCountCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerKernelSetArgumentValueRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnKernelSetArgumentValueCb_t pfnSetArgumentValueCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerKernelSetIndirectAccessRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnKernelSetIndirectAccessCb_t pfnSetIndirectAccessCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerKernelGetIndirectAccessRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnKernelGetIndirectAccessCb_t pfnGetIndirectAccessCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerKernelGetSourceAttributesRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnKernelGetSourceAttributesCb_t pfnGetSourceAttributesCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerKernelSetCacheConfigRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnKernelSetCacheConfigCb_t pfnSetCacheConfigCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerKernelGetPropertiesRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnKernelGetPropertiesCb_t pfnGetPropertiesCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerKernelGetNameRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnKernelGetNameCb_t pfnGetNameCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandListAppendLaunchKernelRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandListAppendLaunchKernelCb_t pfnAppendLaunchKernelCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandListAppendLaunchCooperativeKernelRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandListAppendLaunchCooperativeKernelCb_t pfnAppendLaunchCooperativeKernelCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandListAppendLaunchKernelIndirectRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandListAppendLaunchKernelIndirectCb_t pfnAppendLaunchKernelIndirectCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandListAppendLaunchMultipleKernelsIndirectRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandListAppendLaunchMultipleKernelsIndirectCb_t pfnAppendLaunchMultipleKernelsIndirectCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerContextMakeMemoryResidentRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnContextMakeMemoryResidentCb_t pfnMakeMemoryResidentCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerContextEvictMemoryRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnContextEvictMemoryCb_t pfnEvictMemoryCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerContextMakeImageResidentRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnContextMakeImageResidentCb_t pfnMakeImageResidentCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerContextEvictImageRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnContextEvictImageCb_t pfnEvictImageCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerSamplerCreateRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnSamplerCreateCb_t pfnCreateCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerSamplerDestroyRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnSamplerDestroyCb_t pfnDestroyCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerVirtualMemReserveRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnVirtualMemReserveCb_t pfnReserveCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerVirtualMemFreeRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnVirtualMemFreeCb_t pfnFreeCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerVirtualMemQueryPageSizeRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnVirtualMemQueryPageSizeCb_t pfnQueryPageSizeCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerPhysicalMemCreateRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnPhysicalMemCreateCb_t pfnCreateCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerPhysicalMemDestroyRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnPhysicalMemDestroyCb_t pfnDestroyCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerVirtualMemMapRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnVirtualMemMapCb_t pfnMapCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerVirtualMemUnmapRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnVirtualMemUnmapCb_t pfnUnmapCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerVirtualMemSetAccessAttributeRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnVirtualMemSetAccessAttributeCb_t pfnSetAccessAttributeCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerVirtualMemGetAccessAttributeRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnVirtualMemGetAccessAttributeCb_t pfnGetAccessAttributeCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerKernelSetGlobalOffsetExpRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnKernelSetGlobalOffsetExpCb_t pfnSetGlobalOffsetExpCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerKernelGetBinaryExpRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnKernelGetBinaryExpCb_t pfnGetBinaryExpCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerDeviceImportExternalSemaphoreExtRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnDeviceImportExternalSemaphoreExtCb_t pfnImportExternalSemaphoreExtCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerDeviceReleaseExternalSemaphoreExtRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnDeviceReleaseExternalSemaphoreExtCb_t pfnReleaseExternalSemaphoreExtCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandListAppendSignalExternalSemaphoreExtRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandListAppendSignalExternalSemaphoreExtCb_t pfnAppendSignalExternalSemaphoreExtCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandListAppendWaitExternalSemaphoreExtRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandListAppendWaitExternalSemaphoreExtCb_t pfnAppendWaitExternalSemaphoreExtCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerDeviceReserveCacheExtRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnDeviceReserveCacheExtCb_t pfnReserveCacheExtCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerDeviceSetCacheAdviceExtRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnDeviceSetCacheAdviceExtCb_t pfnSetCacheAdviceExtCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerEventQueryTimestampsExpRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnEventQueryTimestampsExpCb_t pfnQueryTimestampsExpCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerImageGetMemoryPropertiesExpRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnImageGetMemoryPropertiesExpCb_t pfnGetMemoryPropertiesExpCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerImageViewCreateExtRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnImageViewCreateExtCb_t pfnViewCreateExtCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerImageViewCreateExpRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnImageViewCreateExpCb_t pfnViewCreateExpCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerKernelSchedulingHintExpRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnKernelSchedulingHintExpCb_t pfnSchedulingHintExpCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerDevicePciGetPropertiesExtRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnDevicePciGetPropertiesExtCb_t pfnPciGetPropertiesExtCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandListAppendImageCopyToMemoryExtRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandListAppendImageCopyToMemoryExtCb_t pfnAppendImageCopyToMemoryExtCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandListAppendImageCopyFromMemoryExtRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandListAppendImageCopyFromMemoryExtCb_t pfnAppendImageCopyFromMemoryExtCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerImageGetAllocPropertiesExtRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnImageGetAllocPropertiesExtCb_t pfnGetAllocPropertiesExtCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerModuleInspectLinkageExtRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnModuleInspectLinkageExtCb_t pfnInspectLinkageExtCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerMemFreeExtRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnMemFreeExtCb_t pfnFreeExtCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerFabricVertexGetExpRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnFabricVertexGetExpCb_t pfnGetExpCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerFabricVertexGetSubVerticesExpRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnFabricVertexGetSubVerticesExpCb_t pfnGetSubVerticesExpCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerFabricVertexGetPropertiesExpRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnFabricVertexGetPropertiesExpCb_t pfnGetPropertiesExpCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerFabricVertexGetDeviceExpRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnFabricVertexGetDeviceExpCb_t pfnGetDeviceExpCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerDeviceGetFabricVertexExpRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnDeviceGetFabricVertexExpCb_t pfnGetFabricVertexExpCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerFabricEdgeGetExpRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnFabricEdgeGetExpCb_t pfnGetExpCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerFabricEdgeGetVerticesExpRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnFabricEdgeGetVerticesExpCb_t pfnGetVerticesExpCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerFabricEdgeGetPropertiesExpRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnFabricEdgeGetPropertiesExpCb_t pfnGetPropertiesExpCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerEventQueryKernelTimestampsExtRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnEventQueryKernelTimestampsExtCb_t pfnQueryKernelTimestampsExtCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerRTASBuilderCreateExpRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnRTASBuilderCreateExpCb_t pfnCreateExpCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerRTASBuilderGetBuildPropertiesExpRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnRTASBuilderGetBuildPropertiesExpCb_t pfnGetBuildPropertiesExpCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerDriverRTASFormatCompatibilityCheckExpRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnDriverRTASFormatCompatibilityCheckExpCb_t pfnRTASFormatCompatibilityCheckExpCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerRTASBuilderBuildExpRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnRTASBuilderBuildExpCb_t pfnBuildExpCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerRTASBuilderDestroyExpRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnRTASBuilderDestroyExpCb_t pfnDestroyExpCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerRTASParallelOperationCreateExpRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnRTASParallelOperationCreateExpCb_t pfnCreateExpCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerRTASParallelOperationGetPropertiesExpRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnRTASParallelOperationGetPropertiesExpCb_t pfnGetPropertiesExpCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerRTASParallelOperationJoinExpRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnRTASParallelOperationJoinExpCb_t pfnJoinExpCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerRTASParallelOperationDestroyExpRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnRTASParallelOperationDestroyExpCb_t pfnDestroyExpCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerMemGetPitchFor2dImageRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnMemGetPitchFor2dImageCb_t pfnGetPitchFor2dImageCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerImageGetDeviceOffsetExpRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnImageGetDeviceOffsetExpCb_t pfnGetDeviceOffsetExpCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandListCreateCloneExpRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandListCreateCloneExpCb_t pfnCreateCloneExpCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandListImmediateAppendCommandListsExpRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandListImmediateAppendCommandListsExpCb_t pfnImmediateAppendCommandListsExpCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandListGetNextCommandIdExpRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandListGetNextCommandIdExpCb_t pfnGetNextCommandIdExpCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandListGetNextCommandIdWithKernelsExpRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandListGetNextCommandIdWithKernelsExpCb_t pfnGetNextCommandIdWithKernelsExpCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandListUpdateMutableCommandsExpRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandListUpdateMutableCommandsExpCb_t pfnUpdateMutableCommandsExpCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandListUpdateMutableCommandSignalEventExpRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandListUpdateMutableCommandSignalEventExpCb_t pfnUpdateMutableCommandSignalEventExpCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandListUpdateMutableCommandWaitEventsExpRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandListUpdateMutableCommandWaitEventsExpCb_t pfnUpdateMutableCommandWaitEventsExpCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerCommandListUpdateMutableCommandKernelsExpRegisterCallback(
+    zel_tracer_handle_t hTracer,
+    zel_tracer_reg_t callback_type,
+    ze_pfnCommandListUpdateMutableCommandKernelsExpCb_t pfnUpdateMutableCommandKernelsExpCb
+    );
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelTracerResetAllCallbacks(zel_tracer_handle_t hTracer);
+
+
+#if defined(__cplusplus)
+} // extern "C"
+#endif
+
+#endif // zel_tracing_register_cb_H

--- a/include/level_zero/loader/ze_loader.h
+++ b/include/level_zero/loader/ze_loader.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2021 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file ze_loader.h
+ */
+
+#ifndef _ZE_LOADER_H
+#define _ZE_LOADER_H
+#if defined(__cplusplus)
+#pragma once
+#endif
+
+#include "../ze_api.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+ typedef struct _zel_version {
+    int major;
+    int minor;
+    int patch; 
+  } zel_version_t; 
+
+ //Ex component string "ze_tracing", "ze_validation", etc 
+#define ZEL_COMPONENT_STRING_SIZE 64 
+
+ typedef struct zel_component_version {
+    char component_name[ZEL_COMPONENT_STRING_SIZE];
+    ze_api_version_t spec_version;
+    zel_version_t component_lib_version;
+} zel_component_version_t; 
+
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelLoaderGetVersions(
+   size_t *num_elems,                     //Pointer to num versions to get.  
+   zel_component_version_t *versions);    //Pointer to array of versions. If set to NULL, num_elems is returned
+
+typedef enum _zel_handle_type_t {
+   ZEL_HANDLE_DRIVER,
+   ZEL_HANDLE_DEVICE,
+   ZEL_HANDLE_CONTEXT,
+   ZEL_HANDLE_COMMAND_QUEUE,
+   ZEL_HANDLE_COMMAND_LIST,
+   ZEL_HANDLE_FENCE,
+   ZEL_HANDLE_EVENT_POOL,
+   ZEL_HANDLE_EVENT,
+   ZEL_HANDLE_IMAGE,
+   ZEL_HANDLE_MODULE,
+   ZEL_HANDLE_MODULE_BUILD_LOG,
+   ZEL_HANDLE_KERNEL,
+   ZEL_HANDLE_SAMPLER,
+   ZEL_HANDLE_PHYSICAL_MEM
+} zel_handle_type_t;
+
+//Translates Loader Handles to Driver Handles if loader handle intercept is enabled.
+//If handle intercept is not enabled handleOut is set to handleIn  
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zelLoaderTranslateHandle(
+   zel_handle_type_t handleType,   //Handle Type
+   void *handleIn,                  //Input: handle to translate from loader handle to driver handle
+   void **handleOut);                //Output: Pointer to handleOut is set to driver handle if successful
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for handling calls to released drivers in teardown.
+///
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zelSetDriverTeardown();
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for Enabling the Tracing Layer During Runtime.
+///
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zelEnableTracingLayer();
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for Disabling the Tracing Layer During Runtime.
+///
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zelDisableTracingLayer();
+
+#if defined(__cplusplus)
+} // extern "C"
+#endif
+#endif //_ZE_LOADER_H

--- a/include/level_zero/ze.py
+++ b/include/level_zero/ze.py
@@ -1,0 +1,6397 @@
+"""
+ Copyright (C) 2019-2021 Intel Corporation
+
+ SPDX-License-Identifier: MIT
+
+ @file ze.py
+ @version v1.12-r1.12.15
+
+ """
+import platform
+from ctypes import *
+from enum import *
+
+###############################################################################
+__version__ = "1.0"
+
+###############################################################################
+## @brief Generates generic 'oneAPI' API versions
+def ZE_MAKE_VERSION( _major, _minor ):
+    return (( _major << 16 )|( _minor & 0x0000ffff))
+
+###############################################################################
+## @brief Extracts 'oneAPI' API major version
+def ZE_MAJOR_VERSION( _ver ):
+    return ( _ver >> 16 )
+
+###############################################################################
+## @brief Extracts 'oneAPI' API minor version
+def ZE_MINOR_VERSION( _ver ):
+    return ( _ver & 0x0000ffff )
+
+###############################################################################
+## @brief Calling convention for all API functions
+# ZE_APICALL not required for python
+
+###############################################################################
+## @brief Microsoft-specific dllexport storage-class attribute
+# ZE_APIEXPORT not required for python
+
+###############################################################################
+## @brief GCC-specific dllexport storage-class attribute
+# ZE_APIEXPORT not required for python
+
+###############################################################################
+## @brief Microsoft-specific dllexport storage-class attribute
+# ZE_DLLEXPORT not required for python
+
+###############################################################################
+## @brief GCC-specific dllexport storage-class attribute
+# ZE_DLLEXPORT not required for python
+
+###############################################################################
+## @brief compiler-independent type
+class ze_bool_t(c_ubyte):
+    pass
+
+###############################################################################
+## @brief Handle of a driver instance
+class ze_driver_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle of driver's device object
+class ze_device_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle of driver's context object
+class ze_context_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle of driver's command queue object
+class ze_command_queue_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle of driver's command list object
+class ze_command_list_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle of driver's fence object
+class ze_fence_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle of driver's event pool object
+class ze_event_pool_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle of driver's event object
+class ze_event_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle of driver's image object
+class ze_image_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle of driver's module object
+class ze_module_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle of module's build log object
+class ze_module_build_log_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle of driver's kernel object
+class ze_kernel_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle of driver's sampler object
+class ze_sampler_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle of physical memory object
+class ze_physical_mem_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle of driver's fabric vertex object
+class ze_fabric_vertex_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle of driver's fabric edge object
+class ze_fabric_edge_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Maximum IPC handle size
+ZE_MAX_IPC_HANDLE_SIZE = 64
+
+###############################################################################
+## @brief IPC handle to a memory allocation
+class ze_ipc_mem_handle_t(Structure):
+    _fields_ = [
+        ("data", c_char * ZE_MAX_IPC_HANDLE_SIZE)                       ## [out] Opaque data representing an IPC handle
+    ]
+
+###############################################################################
+## @brief IPC handle to a event pool allocation
+class ze_ipc_event_pool_handle_t(Structure):
+    _fields_ = [
+        ("data", c_char * ZE_MAX_IPC_HANDLE_SIZE)                       ## [out] Opaque data representing an IPC handle
+    ]
+
+###############################################################################
+## @brief Generic macro for enumerator bit masks
+def ZE_BIT( _i ):
+    return ( 1 << _i )
+
+###############################################################################
+## @brief Defines Return/Error codes
+class ze_result_v(IntEnum):
+    SUCCESS = 0                                                             ## [Core] success
+    NOT_READY = 1                                                           ## [Core] synchronization primitive not signaled
+    ERROR_DEVICE_LOST = 0x70000001                                          ## [Core] device hung, reset, was removed, or driver update occurred
+    ERROR_OUT_OF_HOST_MEMORY = 0x70000002                                   ## [Core] insufficient host memory to satisfy call
+    ERROR_OUT_OF_DEVICE_MEMORY = 0x70000003                                 ## [Core] insufficient device memory to satisfy call
+    ERROR_MODULE_BUILD_FAILURE = 0x70000004                                 ## [Core] error occurred when building module, see build log for details
+    ERROR_MODULE_LINK_FAILURE = 0x70000005                                  ## [Core] error occurred when linking modules, see build log for details
+    ERROR_DEVICE_REQUIRES_RESET = 0x70000006                                ## [Core] device requires a reset
+    ERROR_DEVICE_IN_LOW_POWER_STATE = 0x70000007                            ## [Core] device currently in low power state
+    EXP_ERROR_DEVICE_IS_NOT_VERTEX = 0x7ff00001                             ## [Core, Experimental] device is not represented by a fabric vertex
+    EXP_ERROR_VERTEX_IS_NOT_DEVICE = 0x7ff00002                             ## [Core, Experimental] fabric vertex does not represent a device
+    EXP_ERROR_REMOTE_DEVICE = 0x7ff00003                                    ## [Core, Experimental] fabric vertex represents a remote device or
+                                                                            ## subdevice
+    EXP_ERROR_OPERANDS_INCOMPATIBLE = 0x7ff00004                            ## [Core, Experimental] operands of comparison are not compatible
+    EXP_RTAS_BUILD_RETRY = 0x7ff00005                                       ## [Core, Experimental] ray tracing acceleration structure build
+                                                                            ## operation failed due to insufficient resources, retry with a larger
+                                                                            ## acceleration structure buffer allocation
+    EXP_RTAS_BUILD_DEFERRED = 0x7ff00006                                    ## [Core, Experimental] ray tracing acceleration structure build
+                                                                            ## operation deferred to parallel operation join
+    ERROR_INSUFFICIENT_PERMISSIONS = 0x70010000                             ## [Sysman] access denied due to permission level
+    ERROR_NOT_AVAILABLE = 0x70010001                                        ## [Sysman] resource already in use and simultaneous access not allowed
+                                                                            ## or resource was removed
+    ERROR_DEPENDENCY_UNAVAILABLE = 0x70020000                               ## [Common] external required dependency is unavailable or missing
+    WARNING_DROPPED_DATA = 0x70020001                                       ## [Tools] data may have been dropped
+    ERROR_UNINITIALIZED = 0x78000001                                        ## [Validation] driver is not initialized
+    ERROR_UNSUPPORTED_VERSION = 0x78000002                                  ## [Validation] generic error code for unsupported versions
+    ERROR_UNSUPPORTED_FEATURE = 0x78000003                                  ## [Validation] generic error code for unsupported features
+    ERROR_INVALID_ARGUMENT = 0x78000004                                     ## [Validation] generic error code for invalid arguments
+    ERROR_INVALID_NULL_HANDLE = 0x78000005                                  ## [Validation] handle argument is not valid
+    ERROR_HANDLE_OBJECT_IN_USE = 0x78000006                                 ## [Validation] object pointed to by handle still in-use by device
+    ERROR_INVALID_NULL_POINTER = 0x78000007                                 ## [Validation] pointer argument may not be nullptr
+    ERROR_INVALID_SIZE = 0x78000008                                         ## [Validation] size argument is invalid (e.g., must not be zero)
+    ERROR_UNSUPPORTED_SIZE = 0x78000009                                     ## [Validation] size argument is not supported by the device (e.g., too
+                                                                            ## large)
+    ERROR_UNSUPPORTED_ALIGNMENT = 0x7800000a                                ## [Validation] alignment argument is not supported by the device (e.g.,
+                                                                            ## too small)
+    ERROR_INVALID_SYNCHRONIZATION_OBJECT = 0x7800000b                       ## [Validation] synchronization object in invalid state
+    ERROR_INVALID_ENUMERATION = 0x7800000c                                  ## [Validation] enumerator argument is not valid
+    ERROR_UNSUPPORTED_ENUMERATION = 0x7800000d                              ## [Validation] enumerator argument is not supported by the device
+    ERROR_UNSUPPORTED_IMAGE_FORMAT = 0x7800000e                             ## [Validation] image format is not supported by the device
+    ERROR_INVALID_NATIVE_BINARY = 0x7800000f                                ## [Validation] native binary is not supported by the device
+    ERROR_INVALID_GLOBAL_NAME = 0x78000010                                  ## [Validation] global variable is not found in the module
+    ERROR_INVALID_KERNEL_NAME = 0x78000011                                  ## [Validation] kernel name is not found in the module
+    ERROR_INVALID_FUNCTION_NAME = 0x78000012                                ## [Validation] function name is not found in the module
+    ERROR_INVALID_GROUP_SIZE_DIMENSION = 0x78000013                         ## [Validation] group size dimension is not valid for the kernel or
+                                                                            ## device
+    ERROR_INVALID_GLOBAL_WIDTH_DIMENSION = 0x78000014                       ## [Validation] global width dimension is not valid for the kernel or
+                                                                            ## device
+    ERROR_INVALID_KERNEL_ARGUMENT_INDEX = 0x78000015                        ## [Validation] kernel argument index is not valid for kernel
+    ERROR_INVALID_KERNEL_ARGUMENT_SIZE = 0x78000016                         ## [Validation] kernel argument size does not match kernel
+    ERROR_INVALID_KERNEL_ATTRIBUTE_VALUE = 0x78000017                       ## [Validation] value of kernel attribute is not valid for the kernel or
+                                                                            ## device
+    ERROR_INVALID_MODULE_UNLINKED = 0x78000018                              ## [Validation] module with imports needs to be linked before kernels can
+                                                                            ## be created from it.
+    ERROR_INVALID_COMMAND_LIST_TYPE = 0x78000019                            ## [Validation] command list type does not match command queue type
+    ERROR_OVERLAPPING_REGIONS = 0x7800001a                                  ## [Validation] copy operations do not support overlapping regions of
+                                                                            ## memory
+    WARNING_ACTION_REQUIRED = 0x7800001b                                    ## [Sysman] an action is required to complete the desired operation
+    ERROR_INVALID_KERNEL_HANDLE = 0x7800001c                                ## [Core, Validation] kernel handle is invalid for the operation
+    ERROR_UNKNOWN = 0x7ffffffe                                              ## [Core] unknown or internal error
+
+class ze_result_t(c_int):
+    def __str__(self):
+        return str(ze_result_v(self.value))
+
+
+###############################################################################
+## @brief Defines structure types
+class ze_structure_type_v(IntEnum):
+    DRIVER_PROPERTIES = 0x1                                                 ## ::ze_driver_properties_t
+    DRIVER_IPC_PROPERTIES = 0x2                                             ## ::ze_driver_ipc_properties_t
+    DEVICE_PROPERTIES = 0x3                                                 ## ::ze_device_properties_t
+    DEVICE_COMPUTE_PROPERTIES = 0x4                                         ## ::ze_device_compute_properties_t
+    DEVICE_MODULE_PROPERTIES = 0x5                                          ## ::ze_device_module_properties_t
+    COMMAND_QUEUE_GROUP_PROPERTIES = 0x6                                    ## ::ze_command_queue_group_properties_t
+    DEVICE_MEMORY_PROPERTIES = 0x7                                          ## ::ze_device_memory_properties_t
+    DEVICE_MEMORY_ACCESS_PROPERTIES = 0x8                                   ## ::ze_device_memory_access_properties_t
+    DEVICE_CACHE_PROPERTIES = 0x9                                           ## ::ze_device_cache_properties_t
+    DEVICE_IMAGE_PROPERTIES = 0xa                                           ## ::ze_device_image_properties_t
+    DEVICE_P2P_PROPERTIES = 0xb                                             ## ::ze_device_p2p_properties_t
+    DEVICE_EXTERNAL_MEMORY_PROPERTIES = 0xc                                 ## ::ze_device_external_memory_properties_t
+    CONTEXT_DESC = 0xd                                                      ## ::ze_context_desc_t
+    COMMAND_QUEUE_DESC = 0xe                                                ## ::ze_command_queue_desc_t
+    COMMAND_LIST_DESC = 0xf                                                 ## ::ze_command_list_desc_t
+    EVENT_POOL_DESC = 0x10                                                  ## ::ze_event_pool_desc_t
+    EVENT_DESC = 0x11                                                       ## ::ze_event_desc_t
+    FENCE_DESC = 0x12                                                       ## ::ze_fence_desc_t
+    IMAGE_DESC = 0x13                                                       ## ::ze_image_desc_t
+    IMAGE_PROPERTIES = 0x14                                                 ## ::ze_image_properties_t
+    DEVICE_MEM_ALLOC_DESC = 0x15                                            ## ::ze_device_mem_alloc_desc_t
+    HOST_MEM_ALLOC_DESC = 0x16                                              ## ::ze_host_mem_alloc_desc_t
+    MEMORY_ALLOCATION_PROPERTIES = 0x17                                     ## ::ze_memory_allocation_properties_t
+    EXTERNAL_MEMORY_EXPORT_DESC = 0x18                                      ## ::ze_external_memory_export_desc_t
+    EXTERNAL_MEMORY_IMPORT_FD = 0x19                                        ## ::ze_external_memory_import_fd_t
+    EXTERNAL_MEMORY_EXPORT_FD = 0x1a                                        ## ::ze_external_memory_export_fd_t
+    MODULE_DESC = 0x1b                                                      ## ::ze_module_desc_t
+    MODULE_PROPERTIES = 0x1c                                                ## ::ze_module_properties_t
+    KERNEL_DESC = 0x1d                                                      ## ::ze_kernel_desc_t
+    KERNEL_PROPERTIES = 0x1e                                                ## ::ze_kernel_properties_t
+    SAMPLER_DESC = 0x1f                                                     ## ::ze_sampler_desc_t
+    PHYSICAL_MEM_DESC = 0x20                                                ## ::ze_physical_mem_desc_t
+    KERNEL_PREFERRED_GROUP_SIZE_PROPERTIES = 0x21                           ## ::ze_kernel_preferred_group_size_properties_t
+    EXTERNAL_MEMORY_IMPORT_WIN32 = 0x22                                     ## ::ze_external_memory_import_win32_handle_t
+    EXTERNAL_MEMORY_EXPORT_WIN32 = 0x23                                     ## ::ze_external_memory_export_win32_handle_t
+    DEVICE_RAYTRACING_EXT_PROPERTIES = 0x00010001                           ## ::ze_device_raytracing_ext_properties_t
+    RAYTRACING_MEM_ALLOC_EXT_DESC = 0x10002                                 ## ::ze_raytracing_mem_alloc_ext_desc_t
+    FLOAT_ATOMIC_EXT_PROPERTIES = 0x10003                                   ## ::ze_float_atomic_ext_properties_t
+    CACHE_RESERVATION_EXT_DESC = 0x10004                                    ## ::ze_cache_reservation_ext_desc_t
+    EU_COUNT_EXT = 0x10005                                                  ## ::ze_eu_count_ext_t
+    SRGB_EXT_DESC = 0x10006                                                 ## ::ze_srgb_ext_desc_t
+    LINKAGE_INSPECTION_EXT_DESC = 0x10007                                   ## ::ze_linkage_inspection_ext_desc_t
+    PCI_EXT_PROPERTIES = 0x10008                                            ## ::ze_pci_ext_properties_t
+    DRIVER_MEMORY_FREE_EXT_PROPERTIES = 0x10009                             ## ::ze_driver_memory_free_ext_properties_t
+    MEMORY_FREE_EXT_DESC = 0x1000a                                          ## ::ze_memory_free_ext_desc_t
+    MEMORY_COMPRESSION_HINTS_EXT_DESC = 0x1000b                             ## ::ze_memory_compression_hints_ext_desc_t
+    IMAGE_ALLOCATION_EXT_PROPERTIES = 0x1000c                               ## ::ze_image_allocation_ext_properties_t
+    DEVICE_LUID_EXT_PROPERTIES = 0x1000d                                    ## ::ze_device_luid_ext_properties_t
+    DEVICE_MEMORY_EXT_PROPERTIES = 0x1000e                                  ## ::ze_device_memory_ext_properties_t
+    DEVICE_IP_VERSION_EXT = 0x1000f                                         ## ::ze_device_ip_version_ext_t
+    IMAGE_VIEW_PLANAR_EXT_DESC = 0x10010                                    ## ::ze_image_view_planar_ext_desc_t
+    EVENT_QUERY_KERNEL_TIMESTAMPS_EXT_PROPERTIES = 0x10011                  ## ::ze_event_query_kernel_timestamps_ext_properties_t
+    EVENT_QUERY_KERNEL_TIMESTAMPS_RESULTS_EXT_PROPERTIES = 0x10012          ## ::ze_event_query_kernel_timestamps_results_ext_properties_t
+    KERNEL_MAX_GROUP_SIZE_EXT_PROPERTIES = 0x10013                          ## ::ze_kernel_max_group_size_ext_properties_t
+    RELAXED_ALLOCATION_LIMITS_EXP_DESC = 0x00020001                         ## ::ze_relaxed_allocation_limits_exp_desc_t
+    MODULE_PROGRAM_EXP_DESC = 0x00020002                                    ## ::ze_module_program_exp_desc_t
+    SCHEDULING_HINT_EXP_PROPERTIES = 0x00020003                             ## ::ze_scheduling_hint_exp_properties_t
+    SCHEDULING_HINT_EXP_DESC = 0x00020004                                   ## ::ze_scheduling_hint_exp_desc_t
+    IMAGE_VIEW_PLANAR_EXP_DESC = 0x00020005                                 ## ::ze_image_view_planar_exp_desc_t
+    DEVICE_PROPERTIES_1_2 = 0x00020006                                      ## ::ze_device_properties_t
+    IMAGE_MEMORY_EXP_PROPERTIES = 0x00020007                                ## ::ze_image_memory_properties_exp_t
+    POWER_SAVING_HINT_EXP_DESC = 0x00020008                                 ## ::ze_context_power_saving_hint_exp_desc_t
+    COPY_BANDWIDTH_EXP_PROPERTIES = 0x00020009                              ## ::ze_copy_bandwidth_exp_properties_t
+    DEVICE_P2P_BANDWIDTH_EXP_PROPERTIES = 0x0002000A                        ## ::ze_device_p2p_bandwidth_exp_properties_t
+    FABRIC_VERTEX_EXP_PROPERTIES = 0x0002000B                               ## ::ze_fabric_vertex_exp_properties_t
+    FABRIC_EDGE_EXP_PROPERTIES = 0x0002000C                                 ## ::ze_fabric_edge_exp_properties_t
+    MEMORY_SUB_ALLOCATIONS_EXP_PROPERTIES = 0x0002000D                      ## ::ze_memory_sub_allocations_exp_properties_t
+    RTAS_BUILDER_EXP_DESC = 0x0002000E                                      ## ::ze_rtas_builder_exp_desc_t
+    RTAS_BUILDER_BUILD_OP_EXP_DESC = 0x0002000F                             ## ::ze_rtas_builder_build_op_exp_desc_t
+    RTAS_BUILDER_EXP_PROPERTIES = 0x00020010                                ## ::ze_rtas_builder_exp_properties_t
+    RTAS_PARALLEL_OPERATION_EXP_PROPERTIES = 0x00020011                     ## ::ze_rtas_parallel_operation_exp_properties_t
+    RTAS_DEVICE_EXP_PROPERTIES = 0x00020012                                 ## ::ze_rtas_device_exp_properties_t
+    RTAS_GEOMETRY_AABBS_EXP_CB_PARAMS = 0x00020013                          ## ::ze_rtas_geometry_aabbs_exp_cb_params_t
+    COUNTER_BASED_EVENT_POOL_EXP_DESC = 0x00020014                          ## ::ze_event_pool_counter_based_exp_desc_t
+    MUTABLE_COMMAND_LIST_EXP_PROPERTIES = 0x00020015                        ## ::ze_mutable_command_list_exp_properties_t
+    MUTABLE_COMMAND_LIST_EXP_DESC = 0x00020016                              ## ::ze_mutable_command_list_exp_desc_t
+    MUTABLE_COMMAND_ID_EXP_DESC = 0x00020017                                ## ::ze_mutable_command_id_exp_desc_t
+    MUTABLE_COMMANDS_EXP_DESC = 0x00020018                                  ## ::ze_mutable_commands_exp_desc_t
+    MUTABLE_KERNEL_ARGUMENT_EXP_DESC = 0x00020019                           ## ::ze_mutable_kernel_argument_exp_desc_t
+    MUTABLE_GROUP_COUNT_EXP_DESC = 0x0002001A                               ## ::ze_mutable_group_count_exp_desc_t
+    MUTABLE_GROUP_SIZE_EXP_DESC = 0x0002001B                                ## ::ze_mutable_group_size_exp_desc_t
+    MUTABLE_GLOBAL_OFFSET_EXP_DESC = 0x0002001C                             ## ::ze_mutable_global_offset_exp_desc_t
+    PITCHED_ALLOC_DEVICE_EXP_PROPERTIES = 0x0002001D                        ## ::ze_device_pitched_alloc_exp_properties_t
+    BINDLESS_IMAGE_EXP_DESC = 0x0002001E                                    ## ::ze_image_bindless_exp_desc_t
+    PITCHED_IMAGE_EXP_DESC = 0x0002001F                                     ## ::ze_image_pitched_exp_desc_t
+    MUTABLE_GRAPH_ARGUMENT_EXP_DESC = 0x00020020                            ## ::ze_mutable_graph_argument_exp_desc_t
+    INIT_DRIVER_TYPE_DESC = 0x00020021                                      ## ::ze_init_driver_type_desc_t
+    EXTERNAL_SEMAPHORE_EXT_DESC = 0x00020022                                ## ::ze_external_semaphore_ext_desc_t
+    EXTERNAL_SEMAPHORE_WIN32_EXT_DESC = 0x00020023                          ## ::ze_external_semaphore_win32_ext_desc_t
+    EXTERNAL_SEMAPHORE_FD_EXT_DESC = 0x00020024                             ## ::ze_external_semaphore_fd_ext_desc_t
+    EXTERNAL_SEMAPHORE_SIGNAL_PARAMS_EXT = 0x00020025                       ## ::ze_external_semaphore_signal_params_ext_t
+    EXTERNAL_SEMAPHORE_WAIT_PARAMS_EXT = 0x00020026                         ## ::ze_external_semaphore_wait_params_ext_t
+    DRIVER_DDI_HANDLES_EXT_PROPERTIES = 0x00020027                          ## ::ze_driver_ddi_handles_ext_properties_t
+
+class ze_structure_type_t(c_int):
+    def __str__(self):
+        return str(ze_structure_type_v(self.value))
+
+
+###############################################################################
+## @brief External memory type flags
+class ze_external_memory_type_flags_v(IntEnum):
+    OPAQUE_FD = ZE_BIT(0)                                                   ## an opaque POSIX file descriptor handle
+    DMA_BUF = ZE_BIT(1)                                                     ## a file descriptor handle for a Linux dma_buf
+    OPAQUE_WIN32 = ZE_BIT(2)                                                ## an NT handle
+    OPAQUE_WIN32_KMT = ZE_BIT(3)                                            ## a global share (KMT) handle
+    D3D11_TEXTURE = ZE_BIT(4)                                               ## an NT handle referring to a Direct3D 10 or 11 texture resource
+    D3D11_TEXTURE_KMT = ZE_BIT(5)                                           ## a global share (KMT) handle referring to a Direct3D 10 or 11 texture
+                                                                            ## resource
+    D3D12_HEAP = ZE_BIT(6)                                                  ## an NT handle referring to a Direct3D 12 heap resource
+    D3D12_RESOURCE = ZE_BIT(7)                                              ## an NT handle referring to a Direct3D 12 committed resource
+
+class ze_external_memory_type_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Bandwidth unit
+class ze_bandwidth_unit_v(IntEnum):
+    UNKNOWN = 0                                                             ## The unit used for bandwidth is unknown
+    BYTES_PER_NANOSEC = 1                                                   ## Bandwidth is provided in bytes/nanosec
+    BYTES_PER_CLOCK = 2                                                     ## Bandwidth is provided in bytes/clock
+
+class ze_bandwidth_unit_t(c_int):
+    def __str__(self):
+        return str(ze_bandwidth_unit_v(self.value))
+
+
+###############################################################################
+## @brief Latency unit
+class ze_latency_unit_v(IntEnum):
+    UNKNOWN = 0                                                             ## The unit used for latency is unknown
+    NANOSEC = 1                                                             ## Latency is provided in nanosecs
+    CLOCK = 2                                                               ## Latency is provided in clocks
+    HOP = 3                                                                 ## Latency is provided in hops (normalized so that the lowest latency
+                                                                            ## link has a latency of 1 hop)
+
+class ze_latency_unit_t(c_int):
+    def __str__(self):
+        return str(ze_latency_unit_v(self.value))
+
+
+###############################################################################
+## @brief Maximum universal unique id (UUID) size in bytes
+ZE_MAX_UUID_SIZE = 16
+
+###############################################################################
+## @brief Universal unique id (UUID)
+class ze_uuid_t(Structure):
+    _fields_ = [
+        ("id", c_ubyte * ZE_MAX_UUID_SIZE)                              ## [out] opaque data representing a UUID
+    ]
+
+###############################################################################
+## @brief Base for all callback function parameter types
+class ze_base_cb_params_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p)                                             ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+    ]
+
+###############################################################################
+## @brief Base for all properties types
+class ze_base_properties_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p)                                             ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+    ]
+
+###############################################################################
+## @brief Base for all descriptor types
+class ze_base_desc_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p)                                             ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+    ]
+
+###############################################################################
+## @brief Forces driver to only report devices (and sub-devices) as specified by
+##        values
+
+###############################################################################
+## @brief Forces driver to report devices from lowest to highest PCI bus ID
+
+###############################################################################
+## @brief Forces all shared allocations into device memory
+
+###############################################################################
+## @brief Defines the device hierarchy model exposed by Level Zero driver
+##        implementation
+
+###############################################################################
+## @brief Supported initialization flags
+class ze_init_flags_v(IntEnum):
+    GPU_ONLY = ZE_BIT(0)                                                    ## only initialize GPU drivers
+    VPU_ONLY = ZE_BIT(1)                                                    ## only initialize VPU drivers
+
+class ze_init_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Supported driver initialization type flags
+## 
+## @details
+##     - Bit Field which details the driver types to be initialized and
+##       returned to the user.
+##     - Value Definition:
+##     - 0, do not init or retrieve any drivers.
+##     - ZE_INIT_DRIVER_TYPE_FLAG_GPU,	GPU Drivers are Init and driver handles
+##       retrieved.
+##     - ZE_INIT_DRIVER_TYPE_FLAG_NPU,	NPU Drivers are Init and driver handles
+##       retrieved.
+##     - ZE_INIT_DRIVER_TYPE_FLAG_GPU | ZE_INIT_DRIVER_TYPE_FLAG_NPU, NPU & GPU
+##       Drivers are Init and driver handles retrieved.
+##     - UINT32_MAX	All Drivers of any type are Init and driver handles
+##       retrieved.
+class ze_init_driver_type_flags_v(IntEnum):
+    GPU = ZE_BIT(0)                                                         ## initialize and retrieve GPU drivers
+    NPU = ZE_BIT(1)                                                         ## initialize and retrieve NPU drivers
+
+class ze_init_driver_type_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Init Driver Type descriptor
+class ze_init_driver_type_desc_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("flags", ze_init_driver_type_flags_t)                          ## [in] driver type init flags.
+                                                                        ## must be a valid combination of ::ze_init_driver_type_flag_t or UINT32_MAX;
+                                                                        ## driver types are init and retrieved based on these init flags in zeInitDrivers().
+    ]
+
+###############################################################################
+## @brief Supported API versions
+## 
+## @details
+##     - API versions contain major and minor attributes, use
+##       ::ZE_MAJOR_VERSION and ::ZE_MINOR_VERSION
+class ze_api_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    _1_1 = ZE_MAKE_VERSION( 1, 1 )                                          ## version 1.1
+    _1_2 = ZE_MAKE_VERSION( 1, 2 )                                          ## version 1.2
+    _1_3 = ZE_MAKE_VERSION( 1, 3 )                                          ## version 1.3
+    _1_4 = ZE_MAKE_VERSION( 1, 4 )                                          ## version 1.4
+    _1_5 = ZE_MAKE_VERSION( 1, 5 )                                          ## version 1.5
+    _1_6 = ZE_MAKE_VERSION( 1, 6 )                                          ## version 1.6
+    _1_7 = ZE_MAKE_VERSION( 1, 7 )                                          ## version 1.7
+    _1_8 = ZE_MAKE_VERSION( 1, 8 )                                          ## version 1.8
+    _1_9 = ZE_MAKE_VERSION( 1, 9 )                                          ## version 1.9
+    _1_10 = ZE_MAKE_VERSION( 1, 10 )                                        ## version 1.10
+    _1_11 = ZE_MAKE_VERSION( 1, 11 )                                        ## version 1.11
+    _1_12 = ZE_MAKE_VERSION( 1, 12 )                                        ## version 1.12
+    CURRENT = ZE_MAKE_VERSION( 1, 12 )                                      ## latest known version
+
+class ze_api_version_t(c_int):
+    def __str__(self):
+        return str(ze_api_version_v(self.value))
+
+
+###############################################################################
+## @brief Current API version as a macro
+ZE_API_VERSION_CURRENT_M = ZE_MAKE_VERSION( 1, 12 )
+
+###############################################################################
+## @brief Maximum driver universal unique id (UUID) size in bytes
+ZE_MAX_DRIVER_UUID_SIZE = 16
+
+###############################################################################
+## @brief Driver universal unique id (UUID)
+class ze_driver_uuid_t(Structure):
+    _fields_ = [
+        ("id", c_ubyte * ZE_MAX_DRIVER_UUID_SIZE)                       ## [out] opaque data representing a driver UUID
+    ]
+
+###############################################################################
+## @brief Driver properties queried using ::zeDriverGetProperties
+class ze_driver_properties_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("uuid", ze_driver_uuid_t),                                     ## [out] universal unique identifier.
+        ("driverVersion", c_ulong)                                      ## [out] driver version
+                                                                        ## The driver version is a non-zero, monotonically increasing value where
+                                                                        ## higher values always indicate a more recent version.
+    ]
+
+###############################################################################
+## @brief Supported IPC property flags
+class ze_ipc_property_flags_v(IntEnum):
+    MEMORY = ZE_BIT(0)                                                      ## Supports passing memory allocations between processes. See
+                                                                            ## ::zeMemGetIpcHandle.
+    EVENT_POOL = ZE_BIT(1)                                                  ## Supports passing event pools between processes. See
+                                                                            ## ::zeEventPoolGetIpcHandle.
+
+class ze_ipc_property_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief IPC properties queried using ::zeDriverGetIpcProperties
+class ze_driver_ipc_properties_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("flags", ze_ipc_property_flags_t)                              ## [out] 0 (none) or a valid combination of ::ze_ipc_property_flag_t
+    ]
+
+###############################################################################
+## @brief Maximum extension name string size
+ZE_MAX_EXTENSION_NAME = 256
+
+###############################################################################
+## @brief Extension properties queried using ::zeDriverGetExtensionProperties
+class ze_driver_extension_properties_t(Structure):
+    _fields_ = [
+        ("name", c_char * ZE_MAX_EXTENSION_NAME),                       ## [out] extension name
+        ("version", c_ulong)                                            ## [out] extension version using ::ZE_MAKE_VERSION
+    ]
+
+###############################################################################
+## @brief Supported device types
+class ze_device_type_v(IntEnum):
+    GPU = 1                                                                 ## Graphics Processing Unit
+    CPU = 2                                                                 ## Central Processing Unit
+    FPGA = 3                                                                ## Field Programmable Gate Array
+    MCA = 4                                                                 ## Memory Copy Accelerator
+    VPU = 5                                                                 ## Vision Processing Unit
+
+class ze_device_type_t(c_int):
+    def __str__(self):
+        return str(ze_device_type_v(self.value))
+
+
+###############################################################################
+## @brief Maximum device universal unique id (UUID) size in bytes
+ZE_MAX_DEVICE_UUID_SIZE = 16
+
+###############################################################################
+## @brief Device universal unique id (UUID)
+class ze_device_uuid_t(Structure):
+    _fields_ = [
+        ("id", c_ubyte * ZE_MAX_DEVICE_UUID_SIZE)                       ## [out] opaque data representing a device UUID
+    ]
+
+###############################################################################
+## @brief Maximum device name string size
+ZE_MAX_DEVICE_NAME = 256
+
+###############################################################################
+## @brief Supported device property flags
+class ze_device_property_flags_v(IntEnum):
+    INTEGRATED = ZE_BIT(0)                                                  ## Device is integrated with the Host.
+    SUBDEVICE = ZE_BIT(1)                                                   ## Device handle used for query represents a sub-device.
+    ECC = ZE_BIT(2)                                                         ## Device supports error correction memory access.
+    ONDEMANDPAGING = ZE_BIT(3)                                              ## Device supports on-demand page-faulting.
+
+class ze_device_property_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Device properties queried using ::zeDeviceGetProperties
+class ze_device_properties_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("type", ze_device_type_t),                                     ## [out] generic device type
+        ("vendorId", c_ulong),                                          ## [out] vendor id from PCI configuration
+        ("deviceId", c_ulong),                                          ## [out] device id from PCI configuration.
+                                                                        ## Note, the device id uses little-endian format.
+        ("flags", ze_device_property_flags_t),                          ## [out] 0 (none) or a valid combination of ::ze_device_property_flag_t
+        ("subdeviceId", c_ulong),                                       ## [out] sub-device id. Only valid if ::ZE_DEVICE_PROPERTY_FLAG_SUBDEVICE
+                                                                        ## is set.
+        ("coreClockRate", c_ulong),                                     ## [out] Clock rate for device core.
+        ("maxMemAllocSize", c_ulonglong),                               ## [out] Maximum memory allocation size.
+        ("maxHardwareContexts", c_ulong),                               ## [out] Maximum number of logical hardware contexts.
+        ("maxCommandQueuePriority", c_ulong),                           ## [out] Maximum priority for command queues. Higher value is higher
+                                                                        ## priority.
+        ("numThreadsPerEU", c_ulong),                                   ## [out] Maximum number of threads per EU.
+        ("physicalEUSimdWidth", c_ulong),                               ## [out] The physical EU simd width.
+        ("numEUsPerSubslice", c_ulong),                                 ## [out] Maximum number of EUs per sub-slice.
+        ("numSubslicesPerSlice", c_ulong),                              ## [out] Maximum number of sub-slices per slice.
+        ("numSlices", c_ulong),                                         ## [out] Maximum number of slices.
+        ("timerResolution", c_ulonglong),                               ## [out] Returns the resolution of device timer used for profiling,
+                                                                        ## timestamps, etc. When stype==::ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES the
+                                                                        ## units are in nanoseconds. When
+                                                                        ## stype==::ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES_1_2 units are in
+                                                                        ## cycles/sec
+        ("timestampValidBits", c_ulong),                                ## [out] Returns the number of valid bits in the timestamp value.
+        ("kernelTimestampValidBits", c_ulong),                          ## [out] Returns the number of valid bits in the kernel timestamp values
+        ("uuid", ze_device_uuid_t),                                     ## [out] universal unique identifier. Note: Subdevices will have their
+                                                                        ## own uuid.
+        ("name", c_char * ZE_MAX_DEVICE_NAME)                           ## [out] Device name
+    ]
+
+###############################################################################
+## @brief Device thread identifier.
+class ze_device_thread_t(Structure):
+    _fields_ = [
+        ("slice", c_ulong),                                             ## [in,out] the slice number.
+                                                                        ## Must be `UINT32_MAX` (all) or less than the `numSlices` member of ::ze_device_properties_t.
+        ("subslice", c_ulong),                                          ## [in,out] the sub-slice number within its slice.
+                                                                        ## Must be `UINT32_MAX` (all) or less than the `numSubslicesPerSlice`
+                                                                        ## member of ::ze_device_properties_t.
+        ("eu", c_ulong),                                                ## [in,out] the EU number within its sub-slice.
+                                                                        ## Must be `UINT32_MAX` (all) or less than the `numEUsPerSubslice` member
+                                                                        ## of ::ze_device_properties_t.
+        ("thread", c_ulong)                                             ## [in,out] the thread number within its EU.
+                                                                        ## Must be `UINT32_MAX` (all) or less than the `numThreadsPerEU` member
+                                                                        ## of ::ze_device_properties_t.
+    ]
+
+###############################################################################
+## @brief Maximum number of subgroup sizes supported.
+ZE_SUBGROUPSIZE_COUNT = 8
+
+###############################################################################
+## @brief Device compute properties queried using ::zeDeviceGetComputeProperties
+class ze_device_compute_properties_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("maxTotalGroupSize", c_ulong),                                 ## [out] Maximum items per compute group. (groupSizeX * groupSizeY *
+                                                                        ## groupSizeZ) <= maxTotalGroupSize
+        ("maxGroupSizeX", c_ulong),                                     ## [out] Maximum items for X dimension in group
+        ("maxGroupSizeY", c_ulong),                                     ## [out] Maximum items for Y dimension in group
+        ("maxGroupSizeZ", c_ulong),                                     ## [out] Maximum items for Z dimension in group
+        ("maxGroupCountX", c_ulong),                                    ## [out] Maximum groups that can be launched for x dimension
+        ("maxGroupCountY", c_ulong),                                    ## [out] Maximum groups that can be launched for y dimension
+        ("maxGroupCountZ", c_ulong),                                    ## [out] Maximum groups that can be launched for z dimension
+        ("maxSharedLocalMemory", c_ulong),                              ## [out] Maximum shared local memory per group.
+        ("numSubGroupSizes", c_ulong),                                  ## [out] Number of subgroup sizes supported. This indicates number of
+                                                                        ## entries in subGroupSizes.
+        ("subGroupSizes", c_ulong * ZE_SUBGROUPSIZE_COUNT)              ## [out] Size group sizes supported.
+    ]
+
+###############################################################################
+## @brief Maximum native kernel universal unique id (UUID) size in bytes
+ZE_MAX_NATIVE_KERNEL_UUID_SIZE = 16
+
+###############################################################################
+## @brief Native kernel universal unique id (UUID)
+class ze_native_kernel_uuid_t(Structure):
+    _fields_ = [
+        ("id", c_ubyte * ZE_MAX_NATIVE_KERNEL_UUID_SIZE)                ## [out] opaque data representing a native kernel UUID
+    ]
+
+###############################################################################
+## @brief Supported device module flags
+class ze_device_module_flags_v(IntEnum):
+    FP16 = ZE_BIT(0)                                                        ## Device supports 16-bit floating-point operations
+    FP64 = ZE_BIT(1)                                                        ## Device supports 64-bit floating-point operations
+    INT64_ATOMICS = ZE_BIT(2)                                               ## Device supports 64-bit atomic operations
+    DP4A = ZE_BIT(3)                                                        ## Device supports four component dot product and accumulate operations
+
+class ze_device_module_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Supported floating-Point capability flags
+class ze_device_fp_flags_v(IntEnum):
+    DENORM = ZE_BIT(0)                                                      ## Supports denorms
+    INF_NAN = ZE_BIT(1)                                                     ## Supports INF and quiet NaNs
+    ROUND_TO_NEAREST = ZE_BIT(2)                                            ## Supports rounding to nearest even rounding mode
+    ROUND_TO_ZERO = ZE_BIT(3)                                               ## Supports rounding to zero.
+    ROUND_TO_INF = ZE_BIT(4)                                                ## Supports rounding to both positive and negative INF.
+    FMA = ZE_BIT(5)                                                         ## Supports IEEE754-2008 fused multiply-add.
+    ROUNDED_DIVIDE_SQRT = ZE_BIT(6)                                         ## Supports rounding as defined by IEEE754 for divide and sqrt
+                                                                            ## operations.
+    SOFT_FLOAT = ZE_BIT(7)                                                  ## Uses software implementation for basic floating-point operations.
+
+class ze_device_fp_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Device module properties queried using ::zeDeviceGetModuleProperties
+class ze_device_module_properties_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("spirvVersionSupported", c_ulong),                             ## [out] Maximum supported SPIR-V version.
+                                                                        ## Returns zero if SPIR-V is not supported.
+                                                                        ## Contains major and minor attributes, use ::ZE_MAJOR_VERSION and ::ZE_MINOR_VERSION.
+        ("flags", ze_device_module_flags_t),                            ## [out] 0 or a valid combination of ::ze_device_module_flag_t
+        ("fp16flags", ze_device_fp_flags_t),                            ## [out] Capabilities for half-precision floating-point operations.
+                                                                        ## returns 0 (if ::ZE_DEVICE_MODULE_FLAG_FP16 is not set) or a
+                                                                        ## combination of ::ze_device_fp_flag_t.
+        ("fp32flags", ze_device_fp_flags_t),                            ## [out] Capabilities for single-precision floating-point operations.
+                                                                        ## returns a combination of ::ze_device_fp_flag_t.
+        ("fp64flags", ze_device_fp_flags_t),                            ## [out] Capabilities for double-precision floating-point operations.
+                                                                        ## returns 0 (if ::ZE_DEVICE_MODULE_FLAG_FP64 is not set) or a
+                                                                        ## combination of ::ze_device_fp_flag_t.
+        ("maxArgumentsSize", c_ulong),                                  ## [out] Maximum kernel argument size that is supported.
+        ("printfBufferSize", c_ulong),                                  ## [out] Maximum size of internal buffer that holds output of printf
+                                                                        ## calls from kernel.
+        ("nativeKernelSupported", ze_native_kernel_uuid_t)              ## [out] Compatibility UUID of supported native kernel.
+                                                                        ## UUID may or may not be the same across driver release, devices, or
+                                                                        ## operating systems.
+                                                                        ## Application is responsible for ensuring UUID matches before creating
+                                                                        ## module using
+                                                                        ## previously created native kernel.
+    ]
+
+###############################################################################
+## @brief Supported command queue group property flags
+class ze_command_queue_group_property_flags_v(IntEnum):
+    COMPUTE = ZE_BIT(0)                                                     ## Command queue group supports enqueing compute commands.
+    COPY = ZE_BIT(1)                                                        ## Command queue group supports enqueing copy commands.
+    COOPERATIVE_KERNELS = ZE_BIT(2)                                         ## Command queue group supports cooperative kernels.
+                                                                            ## See ::zeCommandListAppendLaunchCooperativeKernel for more details.
+    METRICS = ZE_BIT(3)                                                     ## Command queue groups supports metric queries.
+
+class ze_command_queue_group_property_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Command queue group properties queried using
+##        ::zeDeviceGetCommandQueueGroupProperties
+class ze_command_queue_group_properties_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("flags", ze_command_queue_group_property_flags_t),             ## [out] 0 (none) or a valid combination of
+                                                                        ## ::ze_command_queue_group_property_flag_t
+        ("maxMemoryFillPatternSize", c_size_t),                         ## [out] maximum `pattern_size` supported by command queue group.
+                                                                        ## See ::zeCommandListAppendMemoryFill for more details.
+        ("numQueues", c_ulong)                                          ## [out] the number of physical engines within the group.
+    ]
+
+###############################################################################
+## @brief Supported device memory property flags
+class ze_device_memory_property_flags_v(IntEnum):
+    TBD = ZE_BIT(0)                                                         ## reserved for future use
+
+class ze_device_memory_property_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Device local memory properties queried using
+##        ::zeDeviceGetMemoryProperties
+class ze_device_memory_properties_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("flags", ze_device_memory_property_flags_t),                   ## [out] 0 (none) or a valid combination of
+                                                                        ## ::ze_device_memory_property_flag_t
+        ("maxClockRate", c_ulong),                                      ## [out] Maximum clock rate for device memory.
+        ("maxBusWidth", c_ulong),                                       ## [out] Maximum bus width between device and memory.
+        ("totalSize", c_ulonglong),                                     ## [out] Total memory size in bytes that is available to the device.
+        ("name", c_char * ZE_MAX_DEVICE_NAME)                           ## [out] Memory name
+    ]
+
+###############################################################################
+## @brief Memory access capability flags
+## 
+## @details
+##     - Supported access capabilities for different types of memory
+##       allocations
+class ze_memory_access_cap_flags_v(IntEnum):
+    RW = ZE_BIT(0)                                                          ## Supports load/store access
+    ATOMIC = ZE_BIT(1)                                                      ## Supports atomic access
+    CONCURRENT = ZE_BIT(2)                                                  ## Supports concurrent access
+    CONCURRENT_ATOMIC = ZE_BIT(3)                                           ## Supports concurrent atomic access
+
+class ze_memory_access_cap_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Device memory access properties queried using
+##        ::zeDeviceGetMemoryAccessProperties
+class ze_device_memory_access_properties_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("hostAllocCapabilities", ze_memory_access_cap_flags_t),        ## [out] host memory capabilities.
+                                                                        ## returns 0 (unsupported) or a combination of ::ze_memory_access_cap_flag_t.
+        ("deviceAllocCapabilities", ze_memory_access_cap_flags_t),      ## [out] device memory capabilities.
+                                                                        ## returns 0 (unsupported) or a combination of ::ze_memory_access_cap_flag_t.
+        ("sharedSingleDeviceAllocCapabilities", ze_memory_access_cap_flags_t),  ## [out] shared, single-device memory capabilities.
+                                                                        ## returns 0 (unsupported) or a combination of ::ze_memory_access_cap_flag_t.
+        ("sharedCrossDeviceAllocCapabilities", ze_memory_access_cap_flags_t),   ## [out] shared, cross-device memory capabilities.
+                                                                        ## returns 0 (unsupported) or a combination of ::ze_memory_access_cap_flag_t.
+        ("sharedSystemAllocCapabilities", ze_memory_access_cap_flags_t) ## [out] shared, system memory capabilities.
+                                                                        ## returns 0 (unsupported) or a combination of ::ze_memory_access_cap_flag_t.
+    ]
+
+###############################################################################
+## @brief Supported cache control property flags
+class ze_device_cache_property_flags_v(IntEnum):
+    USER_CONTROL = ZE_BIT(0)                                                ## Device support User Cache Control (i.e. SLM section vs Generic Cache)
+
+class ze_device_cache_property_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Device cache properties queried using ::zeDeviceGetCacheProperties
+class ze_device_cache_properties_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("flags", ze_device_cache_property_flags_t),                    ## [out] 0 (none) or a valid combination of
+                                                                        ## ::ze_device_cache_property_flag_t
+        ("cacheSize", c_size_t)                                         ## [out] Per-cache size, in bytes
+    ]
+
+###############################################################################
+## @brief Device image properties queried using ::zeDeviceGetImageProperties
+class ze_device_image_properties_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("maxImageDims1D", c_ulong),                                    ## [out] Maximum image dimensions for 1D resources. if 0, then 1D images
+                                                                        ## are unsupported.
+        ("maxImageDims2D", c_ulong),                                    ## [out] Maximum image dimensions for 2D resources. if 0, then 2D images
+                                                                        ## are unsupported.
+        ("maxImageDims3D", c_ulong),                                    ## [out] Maximum image dimensions for 3D resources. if 0, then 3D images
+                                                                        ## are unsupported.
+        ("maxImageBufferSize", c_ulonglong),                            ## [out] Maximum image buffer size in bytes. if 0, then buffer images are
+                                                                        ## unsupported.
+        ("maxImageArraySlices", c_ulong),                               ## [out] Maximum image array slices. if 0, then image arrays are
+                                                                        ## unsupported.
+        ("maxSamplers", c_ulong),                                       ## [out] Max samplers that can be used in kernel. if 0, then sampling is
+                                                                        ## unsupported.
+        ("maxReadImageArgs", c_ulong),                                  ## [out] Returns the maximum number of simultaneous image objects that
+                                                                        ## can be read from by a kernel. if 0, then reading images is
+                                                                        ## unsupported.
+        ("maxWriteImageArgs", c_ulong)                                  ## [out] Returns the maximum number of simultaneous image objects that
+                                                                        ## can be written to by a kernel. if 0, then writing images is
+                                                                        ## unsupported.
+    ]
+
+###############################################################################
+## @brief Device external memory import and export properties
+class ze_device_external_memory_properties_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("memoryAllocationImportTypes", ze_external_memory_type_flags_t),   ## [out] Supported external memory import types for memory allocations.
+        ("memoryAllocationExportTypes", ze_external_memory_type_flags_t),   ## [out] Supported external memory export types for memory allocations.
+        ("imageImportTypes", ze_external_memory_type_flags_t),          ## [out] Supported external memory import types for images.
+        ("imageExportTypes", ze_external_memory_type_flags_t)           ## [out] Supported external memory export types for images.
+    ]
+
+###############################################################################
+## @brief Supported device peer-to-peer property flags
+class ze_device_p2p_property_flags_v(IntEnum):
+    ACCESS = ZE_BIT(0)                                                      ## Device supports access between peer devices.
+    ATOMICS = ZE_BIT(1)                                                     ## Device supports atomics between peer devices.
+
+class ze_device_p2p_property_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Device peer-to-peer properties queried using
+##        ::zeDeviceGetP2PProperties
+class ze_device_p2p_properties_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("flags", ze_device_p2p_property_flags_t)                       ## [out] 0 (none) or a valid combination of
+                                                                        ## ::ze_device_p2p_property_flag_t
+    ]
+
+###############################################################################
+## @brief Supported context creation flags
+class ze_context_flags_v(IntEnum):
+    TBD = ZE_BIT(0)                                                         ## reserved for future use
+
+class ze_context_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Context descriptor
+class ze_context_desc_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("flags", ze_context_flags_t)                                   ## [in] creation flags.
+                                                                        ## must be 0 (default) or a valid combination of ::ze_context_flag_t;
+                                                                        ## default behavior may use implicit driver-based heuristics.
+    ]
+
+###############################################################################
+## @brief Supported command queue flags
+class ze_command_queue_flags_v(IntEnum):
+    EXPLICIT_ONLY = ZE_BIT(0)                                               ## command queue should be optimized for submission to a single device engine.
+                                                                            ## driver **must** disable any implicit optimizations for distributing
+                                                                            ## work across multiple engines.
+                                                                            ## this flag should be used when applications want full control over
+                                                                            ## multi-engine submission and scheduling.
+    IN_ORDER = ZE_BIT(1)                                                    ## To be used only when creating immediate command lists. Commands
+                                                                            ## appended to the immediate command
+                                                                            ## list are executed in-order, with driver implementation enforcing
+                                                                            ## dependencies between them.
+                                                                            ## Application is not required to have the signal event of a given
+                                                                            ## command being the wait event of
+                                                                            ## the next to define an in-order list, and application is allowed to
+                                                                            ## pass signal and wait events
+                                                                            ## to each appended command to implement more complex dependency graphs.
+
+class ze_command_queue_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Supported command queue modes
+class ze_command_queue_mode_v(IntEnum):
+    DEFAULT = 0                                                             ## implicit default behavior; uses driver-based heuristics
+    SYNCHRONOUS = 1                                                         ## Device execution always completes immediately on execute;
+                                                                            ## Host thread is blocked using wait on implicit synchronization object
+    ASYNCHRONOUS = 2                                                        ## Device execution is scheduled and will complete in future;
+                                                                            ## explicit synchronization object must be used to determine completeness
+
+class ze_command_queue_mode_t(c_int):
+    def __str__(self):
+        return str(ze_command_queue_mode_v(self.value))
+
+
+###############################################################################
+## @brief Supported command queue priorities
+class ze_command_queue_priority_v(IntEnum):
+    NORMAL = 0                                                              ## [default] normal priority
+    PRIORITY_LOW = 1                                                        ## lower priority than normal
+    PRIORITY_HIGH = 2                                                       ## higher priority than normal
+
+class ze_command_queue_priority_t(c_int):
+    def __str__(self):
+        return str(ze_command_queue_priority_v(self.value))
+
+
+###############################################################################
+## @brief Command Queue descriptor
+class ze_command_queue_desc_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("ordinal", c_ulong),                                           ## [in] command queue group ordinal
+        ("index", c_ulong),                                             ## [in] command queue index within the group;
+                                                                        ## must be zero if ::ZE_COMMAND_QUEUE_FLAG_EXPLICIT_ONLY is not set
+        ("flags", ze_command_queue_flags_t),                            ## [in] usage flags.
+                                                                        ## must be 0 (default) or a valid combination of ::ze_command_queue_flag_t;
+                                                                        ## default behavior may use implicit driver-based heuristics to balance
+                                                                        ## latency and throughput.
+        ("mode", ze_command_queue_mode_t),                              ## [in] operation mode
+        ("priority", ze_command_queue_priority_t)                       ## [in] priority
+    ]
+
+###############################################################################
+## @brief Supported command list creation flags
+class ze_command_list_flags_v(IntEnum):
+    RELAXED_ORDERING = ZE_BIT(0)                                            ## driver may reorder commands (e.g., kernels, copies) between barriers
+                                                                            ## and synchronization primitives.
+                                                                            ## using this flag may increase Host overhead of ::zeCommandListClose.
+                                                                            ## therefore, this flag should **not** be set for low-latency usage-models.
+    MAXIMIZE_THROUGHPUT = ZE_BIT(1)                                         ## driver may perform additional optimizations that increase execution
+                                                                            ## throughput. 
+                                                                            ## using this flag may increase Host overhead of ::zeCommandListClose and ::zeCommandQueueExecuteCommandLists.
+                                                                            ## therefore, this flag should **not** be set for low-latency usage-models.
+    EXPLICIT_ONLY = ZE_BIT(2)                                               ## command list should be optimized for submission to a single command
+                                                                            ## queue and device engine.
+                                                                            ## driver **must** disable any implicit optimizations for distributing
+                                                                            ## work across multiple engines.
+                                                                            ## this flag should be used when applications want full control over
+                                                                            ## multi-engine submission and scheduling.
+    IN_ORDER = ZE_BIT(3)                                                    ## commands appended to this command list are executed in-order, with
+                                                                            ## driver implementation
+                                                                            ## enforcing dependencies between them. Application is not required to
+                                                                            ## have the signal event
+                                                                            ## of a given command being the wait event of the next to define an
+                                                                            ## in-order list, and
+                                                                            ## application is allowed to pass signal and wait events to each appended
+                                                                            ## command to implement
+                                                                            ## more complex dependency graphs. Cannot be combined with ::ZE_COMMAND_LIST_FLAG_RELAXED_ORDERING.
+    EXP_CLONEABLE = ZE_BIT(4)                                               ## this command list may be cloned using ::zeCommandListCreateCloneExp
+                                                                            ## after ::zeCommandListClose.
+
+class ze_command_list_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Command List descriptor
+class ze_command_list_desc_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("commandQueueGroupOrdinal", c_ulong),                          ## [in] command queue group ordinal to which this command list will be
+                                                                        ## submitted
+        ("flags", ze_command_list_flags_t)                              ## [in] usage flags.
+                                                                        ## must be 0 (default) or a valid combination of ::ze_command_list_flag_t;
+                                                                        ## default behavior may use implicit driver-based heuristics to balance
+                                                                        ## latency and throughput.
+    ]
+
+###############################################################################
+## @brief Copy region descriptor
+class ze_copy_region_t(Structure):
+    _fields_ = [
+        ("originX", c_ulong),                                           ## [in] The origin x offset for region in bytes
+        ("originY", c_ulong),                                           ## [in] The origin y offset for region in rows
+        ("originZ", c_ulong),                                           ## [in] The origin z offset for region in slices
+        ("width", c_ulong),                                             ## [in] The region width relative to origin in bytes
+        ("height", c_ulong),                                            ## [in] The region height relative to origin in rows
+        ("depth", c_ulong)                                              ## [in] The region depth relative to origin in slices. Set this to 0 for
+                                                                        ## 2D copy.
+    ]
+
+###############################################################################
+## @brief Region descriptor
+class ze_image_region_t(Structure):
+    _fields_ = [
+        ("originX", c_ulong),                                           ## [in] The origin x offset for region in pixels
+        ("originY", c_ulong),                                           ## [in] The origin y offset for region in pixels
+        ("originZ", c_ulong),                                           ## [in] The origin z offset for region in pixels
+        ("width", c_ulong),                                             ## [in] The region width relative to origin in pixels
+        ("height", c_ulong),                                            ## [in] The region height relative to origin in pixels
+        ("depth", c_ulong)                                              ## [in] The region depth relative to origin. For 1D or 2D images, set
+                                                                        ## this to 1.
+    ]
+
+###############################################################################
+## @brief Supported memory advice hints
+class ze_memory_advice_v(IntEnum):
+    SET_READ_MOSTLY = 0                                                     ## hint that memory will be read from frequently and written to rarely
+    CLEAR_READ_MOSTLY = 1                                                   ## removes the effect of ::ZE_MEMORY_ADVICE_SET_READ_MOSTLY
+    SET_PREFERRED_LOCATION = 2                                              ## hint that the preferred memory location is the specified device
+    CLEAR_PREFERRED_LOCATION = 3                                            ## removes the effect of ::ZE_MEMORY_ADVICE_SET_PREFERRED_LOCATION
+    SET_NON_ATOMIC_MOSTLY = 4                                               ## hints that memory will mostly be accessed non-atomically
+    CLEAR_NON_ATOMIC_MOSTLY = 5                                             ## removes the effect of ::ZE_MEMORY_ADVICE_SET_NON_ATOMIC_MOSTLY
+    BIAS_CACHED = 6                                                         ## hints that memory should be cached
+    BIAS_UNCACHED = 7                                                       ## hints that memory should be not be cached
+    SET_SYSTEM_MEMORY_PREFERRED_LOCATION = 8                                ## hint that the preferred memory location is host memory
+    CLEAR_SYSTEM_MEMORY_PREFERRED_LOCATION = 9                              ## removes the effect of
+                                                                            ## ::ZE_MEMORY_ADVICE_SET_SYSTEM_MEMORY_PREFERRED_LOCATION
+
+class ze_memory_advice_t(c_int):
+    def __str__(self):
+        return str(ze_memory_advice_v(self.value))
+
+
+###############################################################################
+## @brief Supported event pool creation flags
+class ze_event_pool_flags_v(IntEnum):
+    HOST_VISIBLE = ZE_BIT(0)                                                ## signals and waits are also visible to host
+    IPC = ZE_BIT(1)                                                         ## signals and waits may be shared across processes
+    KERNEL_TIMESTAMP = ZE_BIT(2)                                            ## Indicates all events in pool will contain kernel timestamps
+    KERNEL_MAPPED_TIMESTAMP = ZE_BIT(3)                                     ## Indicates all events in pool will contain kernel timestamps
+                                                                            ## synchronized to host time domain; cannot be combined with
+                                                                            ## ::ZE_EVENT_POOL_FLAG_KERNEL_TIMESTAMP
+
+class ze_event_pool_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Event pool descriptor
+class ze_event_pool_desc_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("flags", ze_event_pool_flags_t),                               ## [in] creation flags.
+                                                                        ## must be 0 (default) or a valid combination of ::ze_event_pool_flag_t;
+                                                                        ## default behavior is signals and waits are visible to the entire device
+                                                                        ## and peer devices.
+        ("count", c_ulong)                                              ## [in] number of events within the pool; must be greater than 0
+    ]
+
+###############################################################################
+## @brief Supported event scope flags
+class ze_event_scope_flags_v(IntEnum):
+    SUBDEVICE = ZE_BIT(0)                                                   ## cache hierarchies are flushed or invalidated sufficient for local
+                                                                            ## sub-device access
+    DEVICE = ZE_BIT(1)                                                      ## cache hierarchies are flushed or invalidated sufficient for global
+                                                                            ## device access and peer device access
+    HOST = ZE_BIT(2)                                                        ## cache hierarchies are flushed or invalidated sufficient for device and
+                                                                            ## host access
+
+class ze_event_scope_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Event descriptor
+class ze_event_desc_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("index", c_ulong),                                             ## [in] index of the event within the pool; must be less than the count
+                                                                        ## specified during pool creation
+        ("signal", ze_event_scope_flags_t),                             ## [in] defines the scope of relevant cache hierarchies to flush on a
+                                                                        ## signal action before the event is triggered.
+                                                                        ## must be 0 (default) or a valid combination of ::ze_event_scope_flag_t;
+                                                                        ## default behavior is synchronization within the command list only, no
+                                                                        ## additional cache hierarchies are flushed.
+        ("wait", ze_event_scope_flags_t)                                ## [in] defines the scope of relevant cache hierarchies to invalidate on
+                                                                        ## a wait action after the event is complete.
+                                                                        ## must be 0 (default) or a valid combination of ::ze_event_scope_flag_t;
+                                                                        ## default behavior is synchronization within the command list only, no
+                                                                        ## additional cache hierarchies are invalidated.
+    ]
+
+###############################################################################
+## @brief Kernel timestamp clock data
+## 
+## @details
+##     - The timestamp frequency can be queried from the `timerResolution`
+##       member of ::ze_device_properties_t.
+##     - The number of valid bits in the timestamp value can be queried from
+##       the `kernelTimestampValidBits` member of ::ze_device_properties_t.
+class ze_kernel_timestamp_data_t(Structure):
+    _fields_ = [
+        ("kernelStart", c_ulonglong),                                   ## [out] device clock at start of kernel execution
+        ("kernelEnd", c_ulonglong)                                      ## [out] device clock at end of kernel execution
+    ]
+
+###############################################################################
+## @brief Kernel timestamp result
+class ze_kernel_timestamp_result_t(Structure):
+    _fields_ = [
+        ("global", ze_kernel_timestamp_data_t),                         ## [out] wall-clock data
+        ("context", ze_kernel_timestamp_data_t)                         ## [out] context-active data; only includes clocks while device context
+                                                                        ## was actively executing.
+    ]
+
+###############################################################################
+## @brief Supported fence creation flags
+class ze_fence_flags_v(IntEnum):
+    SIGNALED = ZE_BIT(0)                                                    ## fence is created in the signaled state, otherwise not signaled.
+
+class ze_fence_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Fence descriptor
+class ze_fence_desc_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("flags", ze_fence_flags_t)                                     ## [in] creation flags.
+                                                                        ## must be 0 (default) or a valid combination of ::ze_fence_flag_t.
+    ]
+
+###############################################################################
+## @brief Supported image creation flags
+class ze_image_flags_v(IntEnum):
+    KERNEL_WRITE = ZE_BIT(0)                                                ## kernels will write contents
+    BIAS_UNCACHED = ZE_BIT(1)                                               ## device should not cache contents
+
+class ze_image_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Supported image types
+class ze_image_type_v(IntEnum):
+    _1D = 0                                                                 ## 1D
+    _1DARRAY = 1                                                            ## 1D array
+    _2D = 2                                                                 ## 2D
+    _2DARRAY = 3                                                            ## 2D array
+    _3D = 4                                                                 ## 3D
+    BUFFER = 5                                                              ## Buffer
+
+class ze_image_type_t(c_int):
+    def __str__(self):
+        return str(ze_image_type_v(self.value))
+
+
+###############################################################################
+## @brief Supported image format layouts
+class ze_image_format_layout_v(IntEnum):
+    _8 = 0                                                                  ## 8-bit single component layout
+    _16 = 1                                                                 ## 16-bit single component layout
+    _32 = 2                                                                 ## 32-bit single component layout
+    _8_8 = 3                                                                ## 2-component 8-bit layout
+    _8_8_8_8 = 4                                                            ## 4-component 8-bit layout
+    _16_16 = 5                                                              ## 2-component 16-bit layout
+    _16_16_16_16 = 6                                                        ## 4-component 16-bit layout
+    _32_32 = 7                                                              ## 2-component 32-bit layout
+    _32_32_32_32 = 8                                                        ## 4-component 32-bit layout
+    _10_10_10_2 = 9                                                         ## 4-component 10_10_10_2 layout
+    _11_11_10 = 10                                                          ## 3-component 11_11_10 layout
+    _5_6_5 = 11                                                             ## 3-component 5_6_5 layout
+    _5_5_5_1 = 12                                                           ## 4-component 5_5_5_1 layout
+    _4_4_4_4 = 13                                                           ## 4-component 4_4_4_4 layout
+    Y8 = 14                                                                 ## Media Format: Y8. Format type and swizzle is ignored for this.
+    NV12 = 15                                                               ## Media Format: NV12. Format type and swizzle is ignored for this.
+    YUYV = 16                                                               ## Media Format: YUYV. Format type and swizzle is ignored for this.
+    VYUY = 17                                                               ## Media Format: VYUY. Format type and swizzle is ignored for this.
+    YVYU = 18                                                               ## Media Format: YVYU. Format type and swizzle is ignored for this.
+    UYVY = 19                                                               ## Media Format: UYVY. Format type and swizzle is ignored for this.
+    AYUV = 20                                                               ## Media Format: AYUV. Format type and swizzle is ignored for this.
+    P010 = 21                                                               ## Media Format: P010. Format type and swizzle is ignored for this.
+    Y410 = 22                                                               ## Media Format: Y410. Format type and swizzle is ignored for this.
+    P012 = 23                                                               ## Media Format: P012. Format type and swizzle is ignored for this.
+    Y16 = 24                                                                ## Media Format: Y16. Format type and swizzle is ignored for this.
+    P016 = 25                                                               ## Media Format: P016. Format type and swizzle is ignored for this.
+    Y216 = 26                                                               ## Media Format: Y216. Format type and swizzle is ignored for this.
+    P216 = 27                                                               ## Media Format: P216. Format type and swizzle is ignored for this.
+    P8 = 28                                                                 ## Media Format: P8. Format type and swizzle is ignored for this.
+    YUY2 = 29                                                               ## Media Format: YUY2. Format type and swizzle is ignored for this.
+    A8P8 = 30                                                               ## Media Format: A8P8. Format type and swizzle is ignored for this.
+    IA44 = 31                                                               ## Media Format: IA44. Format type and swizzle is ignored for this.
+    AI44 = 32                                                               ## Media Format: AI44. Format type and swizzle is ignored for this.
+    Y416 = 33                                                               ## Media Format: Y416. Format type and swizzle is ignored for this.
+    Y210 = 34                                                               ## Media Format: Y210. Format type and swizzle is ignored for this.
+    I420 = 35                                                               ## Media Format: I420. Format type and swizzle is ignored for this.
+    YV12 = 36                                                               ## Media Format: YV12. Format type and swizzle is ignored for this.
+    _400P = 37                                                              ## Media Format: 400P. Format type and swizzle is ignored for this.
+    _422H = 38                                                              ## Media Format: 422H. Format type and swizzle is ignored for this.
+    _422V = 39                                                              ## Media Format: 422V. Format type and swizzle is ignored for this.
+    _444P = 40                                                              ## Media Format: 444P. Format type and swizzle is ignored for this.
+    RGBP = 41                                                               ## Media Format: RGBP. Format type and swizzle is ignored for this.
+    BRGP = 42                                                               ## Media Format: BRGP. Format type and swizzle is ignored for this.
+    _8_8_8 = 43                                                             ## 3-component 8-bit layout
+    _16_16_16 = 44                                                          ## 3-component 16-bit layout
+    _32_32_32 = 45                                                          ## 3-component 32-bit layout
+
+class ze_image_format_layout_t(c_int):
+    def __str__(self):
+        return str(ze_image_format_layout_v(self.value))
+
+
+###############################################################################
+## @brief Supported image format types
+class ze_image_format_type_v(IntEnum):
+    UINT = 0                                                                ## Unsigned integer
+    SINT = 1                                                                ## Signed integer
+    UNORM = 2                                                               ## Unsigned normalized integer
+    SNORM = 3                                                               ## Signed normalized integer
+    FLOAT = 4                                                               ## Float
+
+class ze_image_format_type_t(c_int):
+    def __str__(self):
+        return str(ze_image_format_type_v(self.value))
+
+
+###############################################################################
+## @brief Supported image format component swizzle into channel
+class ze_image_format_swizzle_v(IntEnum):
+    R = 0                                                                   ## Red component
+    G = 1                                                                   ## Green component
+    B = 2                                                                   ## Blue component
+    A = 3                                                                   ## Alpha component
+    _0 = 4                                                                  ## Zero
+    _1 = 5                                                                  ## One
+    X = 6                                                                   ## Don't care
+
+class ze_image_format_swizzle_t(c_int):
+    def __str__(self):
+        return str(ze_image_format_swizzle_v(self.value))
+
+
+###############################################################################
+## @brief Image format 
+class ze_image_format_t(Structure):
+    _fields_ = [
+        ("layout", ze_image_format_layout_t),                           ## [in] image format component layout (e.g. N-component layouts and media
+                                                                        ## formats)
+        ("type", ze_image_format_type_t),                               ## [in] image format type
+        ("x", ze_image_format_swizzle_t),                               ## [in] image component swizzle into channel x
+        ("y", ze_image_format_swizzle_t),                               ## [in] image component swizzle into channel y
+        ("z", ze_image_format_swizzle_t),                               ## [in] image component swizzle into channel z
+        ("w", ze_image_format_swizzle_t)                                ## [in] image component swizzle into channel w
+    ]
+
+###############################################################################
+## @brief Image descriptor
+class ze_image_desc_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("flags", ze_image_flags_t),                                    ## [in] creation flags.
+                                                                        ## must be 0 (default) or a valid combination of ::ze_image_flag_t;
+                                                                        ## default is read-only, cached access.
+        ("type", ze_image_type_t),                                      ## [in] image type. Media format layouts are unsupported for
+                                                                        ## ::ZE_IMAGE_TYPE_BUFFER
+        ("format", ze_image_format_t),                                  ## [in] image format
+        ("width", c_ulonglong),                                         ## [in] width dimension.
+                                                                        ## ::ZE_IMAGE_TYPE_BUFFER: size in bytes; see the `maxImageBufferSize`
+                                                                        ## member of ::ze_device_image_properties_t for limits.
+                                                                        ## ::ZE_IMAGE_TYPE_1D, ::ZE_IMAGE_TYPE_1DARRAY: width in pixels; see the
+                                                                        ## `maxImageDims1D` member of ::ze_device_image_properties_t for limits.
+                                                                        ## ::ZE_IMAGE_TYPE_2D, ::ZE_IMAGE_TYPE_2DARRAY: width in pixels; see the
+                                                                        ## `maxImageDims2D` member of ::ze_device_image_properties_t for limits.
+                                                                        ## ::ZE_IMAGE_TYPE_3D: width in pixels; see the `maxImageDims3D` member
+                                                                        ## of ::ze_device_image_properties_t for limits.
+        ("height", c_ulong),                                            ## [in] height dimension.
+                                                                        ## ::ZE_IMAGE_TYPE_2D, ::ZE_IMAGE_TYPE_2DARRAY: height in pixels; see the
+                                                                        ## `maxImageDims2D` member of ::ze_device_image_properties_t for limits.
+                                                                        ## ::ZE_IMAGE_TYPE_3D: height in pixels; see the `maxImageDims3D` member
+                                                                        ## of ::ze_device_image_properties_t for limits.
+                                                                        ## other: ignored.
+        ("depth", c_ulong),                                             ## [in] depth dimension.
+                                                                        ## ::ZE_IMAGE_TYPE_3D: depth in pixels; see the `maxImageDims3D` member
+                                                                        ## of ::ze_device_image_properties_t for limits.
+                                                                        ## other: ignored.
+        ("arraylevels", c_ulong),                                       ## [in] array levels.
+                                                                        ## ::ZE_IMAGE_TYPE_1DARRAY, ::ZE_IMAGE_TYPE_2DARRAY: see the
+                                                                        ## `maxImageArraySlices` member of ::ze_device_image_properties_t for limits.
+                                                                        ## other: ignored.
+        ("miplevels", c_ulong)                                          ## [in] mipmap levels (must be 0)
+    ]
+
+###############################################################################
+## @brief Supported sampler filtering flags
+class ze_image_sampler_filter_flags_v(IntEnum):
+    POINT = ZE_BIT(0)                                                       ## device supports point filtering
+    LINEAR = ZE_BIT(1)                                                      ## device supports linear filtering
+
+class ze_image_sampler_filter_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Image properties
+class ze_image_properties_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("samplerFilterFlags", ze_image_sampler_filter_flags_t)         ## [out] supported sampler filtering.
+                                                                        ## returns 0 (unsupported) or a combination of ::ze_image_sampler_filter_flag_t.
+    ]
+
+###############################################################################
+## @brief Supported memory allocation flags
+class ze_device_mem_alloc_flags_v(IntEnum):
+    BIAS_CACHED = ZE_BIT(0)                                                 ## device should cache allocation
+    BIAS_UNCACHED = ZE_BIT(1)                                               ## device should not cache allocation (UC)
+    BIAS_INITIAL_PLACEMENT = ZE_BIT(2)                                      ## optimize shared allocation for first access on the device
+
+class ze_device_mem_alloc_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Device memory allocation descriptor
+class ze_device_mem_alloc_desc_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("flags", ze_device_mem_alloc_flags_t),                         ## [in] flags specifying additional allocation controls.
+                                                                        ## must be 0 (default) or a valid combination of ::ze_device_mem_alloc_flag_t;
+                                                                        ## default behavior may use implicit driver-based heuristics.
+        ("ordinal", c_ulong)                                            ## [in] ordinal of the device's local memory to allocate from.
+                                                                        ## must be less than the count returned from ::zeDeviceGetMemoryProperties.
+    ]
+
+###############################################################################
+## @brief Supported host memory allocation flags
+class ze_host_mem_alloc_flags_v(IntEnum):
+    BIAS_CACHED = ZE_BIT(0)                                                 ## host should cache allocation
+    BIAS_UNCACHED = ZE_BIT(1)                                               ## host should not cache allocation (UC)
+    BIAS_WRITE_COMBINED = ZE_BIT(2)                                         ## host memory should be allocated write-combined (WC)
+    BIAS_INITIAL_PLACEMENT = ZE_BIT(3)                                      ## optimize shared allocation for first access on the host
+
+class ze_host_mem_alloc_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Host memory allocation descriptor
+class ze_host_mem_alloc_desc_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("flags", ze_host_mem_alloc_flags_t)                            ## [in] flags specifying additional allocation controls.
+                                                                        ## must be 0 (default) or a valid combination of ::ze_host_mem_alloc_flag_t;
+                                                                        ## default behavior may use implicit driver-based heuristics.
+    ]
+
+###############################################################################
+## @brief Memory allocation type
+class ze_memory_type_v(IntEnum):
+    UNKNOWN = 0                                                             ## the memory pointed to is of unknown type
+    HOST = 1                                                                ## the memory pointed to is a host allocation
+    DEVICE = 2                                                              ## the memory pointed to is a device allocation
+    SHARED = 3                                                              ## the memory pointed to is a shared ownership allocation
+
+class ze_memory_type_t(c_int):
+    def __str__(self):
+        return str(ze_memory_type_v(self.value))
+
+
+###############################################################################
+## @brief Memory allocation properties queried using ::zeMemGetAllocProperties
+class ze_memory_allocation_properties_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("type", ze_memory_type_t),                                     ## [out] type of allocated memory
+        ("id", c_ulonglong),                                            ## [out] identifier for this allocation
+        ("pageSize", c_ulonglong)                                       ## [out] page size used for allocation
+    ]
+
+###############################################################################
+## @brief Supported IPC memory flags
+class ze_ipc_memory_flags_v(IntEnum):
+    BIAS_CACHED = ZE_BIT(0)                                                 ## device should cache allocation
+    BIAS_UNCACHED = ZE_BIT(1)                                               ## device should not cache allocation (UC)
+
+class ze_ipc_memory_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Additional allocation descriptor for exporting external memory
+## 
+## @details
+##     - This structure may be passed to ::zeMemAllocDevice and
+##       ::zeMemAllocHost, via the `pNext` member of
+##       ::ze_device_mem_alloc_desc_t or ::ze_host_mem_alloc_desc_t,
+##       respectively, to indicate an exportable memory allocation.
+##     - This structure may be passed to ::zeImageCreate, via the `pNext`
+##       member of ::ze_image_desc_t, to indicate an exportable image.
+class ze_external_memory_export_desc_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("flags", ze_external_memory_type_flags_t)                      ## [in] flags specifying memory export types for this allocation.
+                                                                        ## must be 0 (default) or a valid combination of ::ze_external_memory_type_flags_t
+    ]
+
+###############################################################################
+## @brief Additional allocation descriptor for importing external memory as a
+##        file descriptor
+## 
+## @details
+##     - This structure may be passed to ::zeMemAllocDevice or
+##       ::zeMemAllocHost, via the `pNext` member of
+##       ::ze_device_mem_alloc_desc_t or of ::ze_host_mem_alloc_desc_t,
+##       respectively, to import memory from a file descriptor.
+##     - This structure may be passed to ::zeImageCreate, via the `pNext`
+##       member of ::ze_image_desc_t, to import memory from a file descriptor.
+class ze_external_memory_import_fd_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("flags", ze_external_memory_type_flags_t),                     ## [in] flags specifying the memory import type for the file descriptor.
+                                                                        ## must be 0 (default) or a valid combination of ::ze_external_memory_type_flags_t
+        ("fd", c_int)                                                   ## [in] the file descriptor handle to import
+    ]
+
+###############################################################################
+## @brief Exports an allocation as a file descriptor
+## 
+## @details
+##     - This structure may be passed to ::zeMemGetAllocProperties, via the
+##       `pNext` member of ::ze_memory_allocation_properties_t, to export a
+##       memory allocation as a file descriptor.
+##     - This structure may be passed to ::zeImageGetAllocPropertiesExt, via
+##       the `pNext` member of ::ze_image_allocation_ext_properties_t, to
+##       export an image as a file descriptor.
+##     - The requested memory export type must have been specified when the
+##       allocation was made.
+class ze_external_memory_export_fd_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("flags", ze_external_memory_type_flags_t),                     ## [in] flags specifying the memory export type for the file descriptor.
+                                                                        ## must be 0 (default) or a valid combination of ::ze_external_memory_type_flags_t
+        ("fd", c_int)                                                   ## [out] the exported file descriptor handle representing the allocation.
+    ]
+
+###############################################################################
+## @brief Additional allocation descriptor for importing external memory as a
+##        Win32 handle
+## 
+## @details
+##     - When `handle` is `nullptr`, `name` must not be `nullptr`.
+##     - When `name` is `nullptr`, `handle` must not be `nullptr`.
+##     - When `flags` is ::ZE_EXTERNAL_MEMORY_TYPE_FLAG_OPAQUE_WIN32_KMT,
+##       `name` must be `nullptr`.
+##     - This structure may be passed to ::zeMemAllocDevice or
+##       ::zeMemAllocHost, via the `pNext` member of
+##       ::ze_device_mem_alloc_desc_t or of ::ze_host_mem_alloc_desc_t,
+##       respectively, to import memory from a Win32 handle.
+##     - This structure may be passed to ::zeImageCreate, via the `pNext`
+##       member of ::ze_image_desc_t, to import memory from a Win32 handle.
+class ze_external_memory_import_win32_handle_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("flags", ze_external_memory_type_flags_t),                     ## [in] flags specifying the memory import type for the Win32 handle.
+                                                                        ## must be 0 (default) or a valid combination of ::ze_external_memory_type_flags_t
+        ("handle", c_void_p),                                           ## [in][optional] the Win32 handle to import
+        ("name", c_void_p)                                              ## [in][optional] name of a memory object to import
+    ]
+
+###############################################################################
+## @brief Exports an allocation as a Win32 handle
+## 
+## @details
+##     - This structure may be passed to ::zeMemGetAllocProperties, via the
+##       `pNext` member of ::ze_memory_allocation_properties_t, to export a
+##       memory allocation as a Win32 handle.
+##     - This structure may be passed to ::zeImageGetAllocPropertiesExt, via
+##       the `pNext` member of ::ze_image_allocation_ext_properties_t, to
+##       export an image as a Win32 handle.
+##     - The requested memory export type must have been specified when the
+##       allocation was made.
+class ze_external_memory_export_win32_handle_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("flags", ze_external_memory_type_flags_t),                     ## [in] flags specifying the memory export type for the Win32 handle.
+                                                                        ## must be 0 (default) or a valid combination of ::ze_external_memory_type_flags_t
+        ("handle", c_void_p)                                            ## [out] the exported Win32 handle representing the allocation.
+    ]
+
+###############################################################################
+## @brief atomic access attribute flags
+class ze_memory_atomic_attr_exp_flags_v(IntEnum):
+    NO_ATOMICS = ZE_BIT(0)                                                  ## Atomics on the pointer are not allowed
+    NO_HOST_ATOMICS = ZE_BIT(1)                                             ## Host atomics on the pointer are not allowed
+    HOST_ATOMICS = ZE_BIT(2)                                                ## Host atomics on the pointer are allowed. Requires
+                                                                            ## ::ZE_MEMORY_ACCESS_CAP_FLAG_ATOMIC returned by
+                                                                            ## ::zeDeviceGetMemoryAccessProperties.
+    NO_DEVICE_ATOMICS = ZE_BIT(3)                                           ## Device atomics on the pointer are not allowed
+    DEVICE_ATOMICS = ZE_BIT(4)                                              ## Device atomics on the pointer are allowed. Requires
+                                                                            ## ::ZE_MEMORY_ACCESS_CAP_FLAG_ATOMIC returned by
+                                                                            ## ::zeDeviceGetMemoryAccessProperties.
+    NO_SYSTEM_ATOMICS = ZE_BIT(5)                                           ## Concurrent atomics on the pointer from both host and device are not
+                                                                            ## allowed
+    SYSTEM_ATOMICS = ZE_BIT(6)                                              ## Concurrent atomics on the pointer from both host and device are
+                                                                            ## allowed. Requires ::ZE_MEMORY_ACCESS_CAP_FLAG_CONCURRENT_ATOMIC
+                                                                            ## returned by ::zeDeviceGetMemoryAccessProperties.
+
+class ze_memory_atomic_attr_exp_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Supported module creation input formats
+class ze_module_format_v(IntEnum):
+    IL_SPIRV = 0                                                            ## Format is SPIRV IL format
+    NATIVE = 1                                                              ## Format is device native format
+
+class ze_module_format_t(c_int):
+    def __str__(self):
+        return str(ze_module_format_v(self.value))
+
+
+###############################################################################
+## @brief Specialization constants - User defined constants
+class ze_module_constants_t(Structure):
+    _fields_ = [
+        ("numConstants", c_ulong),                                      ## [in] Number of specialization constants.
+        ("pConstantIds", POINTER(c_ulong)),                             ## [in][range(0, numConstants)] Array of IDs that is sized to
+                                                                        ## numConstants.
+        ("pConstantValues", POINTER(c_void_p))                          ## [in][range(0, numConstants)] Array of pointers to values that is sized
+                                                                        ## to numConstants.
+    ]
+
+###############################################################################
+## @brief Module descriptor
+class ze_module_desc_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("format", ze_module_format_t),                                 ## [in] Module format passed in with pInputModule
+        ("inputSize", c_size_t),                                        ## [in] size of input IL or ISA from pInputModule.
+        ("pInputModule", POINTER(c_ubyte)),                             ## [in] pointer to IL or ISA
+        ("pBuildFlags", c_char_p),                                      ## [in][optional] string containing one or more (comma-separated)
+                                                                        ## compiler flags. If unsupported, flag is ignored with a warning.
+                                                                        ##  - "-ze-opt-disable"
+                                                                        ##       - Disable optimizations
+                                                                        ##  - "-ze-opt-level"
+                                                                        ##       - Specifies optimization level for compiler. Levels are
+                                                                        ## implementation specific.
+                                                                        ##           - 0 is no optimizations (equivalent to -ze-opt-disable)
+                                                                        ##           - 1 is optimize minimally (may be the same as 2)
+                                                                        ##           - 2 is optimize more (default)
+                                                                        ##  - "-ze-opt-greater-than-4GB-buffer-required"
+                                                                        ##       - Use 64-bit offset calculations for buffers.
+                                                                        ##  - "-ze-opt-large-register-file"
+                                                                        ##       - Increase number of registers available to threads.
+                                                                        ##  - "-ze-opt-has-buffer-offset-arg"
+                                                                        ##       - Extend stateless to stateful optimization to more
+                                                                        ##         cases with the use of additional offset (e.g. 64-bit
+                                                                        ##         pointer to binding table with 32-bit offset).
+                                                                        ##  - "-g"
+                                                                        ##       - Include debugging information.
+        ("pConstants", POINTER(ze_module_constants_t))                  ## [in][optional] pointer to specialization constants. Valid only for
+                                                                        ## SPIR-V input. This must be set to nullptr if no specialization
+                                                                        ## constants are provided.
+    ]
+
+###############################################################################
+## @brief Supported module property flags
+class ze_module_property_flags_v(IntEnum):
+    IMPORTS = ZE_BIT(0)                                                     ## Module has imports (i.e. imported global variables and/or kernels).
+                                                                            ## See ::zeModuleDynamicLink.
+
+class ze_module_property_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Module properties
+class ze_module_properties_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("flags", ze_module_property_flags_t)                           ## [out] 0 (none) or a valid combination of ::ze_module_property_flag_t
+    ]
+
+###############################################################################
+## @brief Supported kernel creation flags
+class ze_kernel_flags_v(IntEnum):
+    FORCE_RESIDENCY = ZE_BIT(0)                                             ## force all device allocations to be resident during execution
+    EXPLICIT_RESIDENCY = ZE_BIT(1)                                          ## application is responsible for all residency of device allocations.
+                                                                            ## driver may disable implicit residency management.
+
+class ze_kernel_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Kernel descriptor
+class ze_kernel_desc_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("flags", ze_kernel_flags_t),                                   ## [in] creation flags.
+                                                                        ## must be 0 (default) or a valid combination of ::ze_kernel_flag_t;
+                                                                        ## default behavior may use driver-based residency.
+        ("pKernelName", c_char_p)                                       ## [in] null-terminated name of kernel in module
+    ]
+
+###############################################################################
+## @brief Kernel indirect access flags
+class ze_kernel_indirect_access_flags_v(IntEnum):
+    HOST = ZE_BIT(0)                                                        ## Indicates that the kernel accesses host allocations indirectly.
+    DEVICE = ZE_BIT(1)                                                      ## Indicates that the kernel accesses device allocations indirectly.
+    SHARED = ZE_BIT(2)                                                      ## Indicates that the kernel accesses shared allocations indirectly.
+
+class ze_kernel_indirect_access_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Supported Cache Config flags
+class ze_cache_config_flags_v(IntEnum):
+    LARGE_SLM = ZE_BIT(0)                                                   ## Large SLM size
+    LARGE_DATA = ZE_BIT(1)                                                  ## Large General Data size
+
+class ze_cache_config_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Maximum kernel universal unique id (UUID) size in bytes
+ZE_MAX_KERNEL_UUID_SIZE = 16
+
+###############################################################################
+## @brief Maximum module universal unique id (UUID) size in bytes
+ZE_MAX_MODULE_UUID_SIZE = 16
+
+###############################################################################
+## @brief Kernel universal unique id (UUID)
+class ze_kernel_uuid_t(Structure):
+    _fields_ = [
+        ("kid", c_ubyte * ZE_MAX_KERNEL_UUID_SIZE),                     ## [out] opaque data representing a kernel UUID
+        ("mid", c_ubyte * ZE_MAX_MODULE_UUID_SIZE)                      ## [out] opaque data representing the kernel's module UUID
+    ]
+
+###############################################################################
+## @brief Kernel properties
+class ze_kernel_properties_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("numKernelArgs", c_ulong),                                     ## [out] number of kernel arguments.
+        ("requiredGroupSizeX", c_ulong),                                ## [out] required group size in the X dimension,
+                                                                        ## or zero if there is no required group size
+        ("requiredGroupSizeY", c_ulong),                                ## [out] required group size in the Y dimension,
+                                                                        ## or zero if there is no required group size
+        ("requiredGroupSizeZ", c_ulong),                                ## [out] required group size in the Z dimension,
+                                                                        ## or zero if there is no required group size
+        ("requiredNumSubGroups", c_ulong),                              ## [out] required number of subgroups per thread group,
+                                                                        ## or zero if there is no required number of subgroups
+        ("requiredSubgroupSize", c_ulong),                              ## [out] required subgroup size,
+                                                                        ## or zero if there is no required subgroup size
+        ("maxSubgroupSize", c_ulong),                                   ## [out] maximum subgroup size
+        ("maxNumSubgroups", c_ulong),                                   ## [out] maximum number of subgroups per thread group
+        ("localMemSize", c_ulong),                                      ## [out] local memory size used by each thread group
+        ("privateMemSize", c_ulong),                                    ## [out] private memory size allocated by compiler used by each thread
+        ("spillMemSize", c_ulong),                                      ## [out] spill memory size allocated by compiler
+        ("uuid", ze_kernel_uuid_t)                                      ## [out] universal unique identifier.
+    ]
+
+###############################################################################
+## @brief Additional kernel preferred group size properties
+## 
+## @details
+##     - This structure may be passed to ::zeKernelGetProperties, via the
+##       `pNext` member of ::ze_kernel_properties_t, to query additional kernel
+##       preferred group size properties.
+class ze_kernel_preferred_group_size_properties_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("preferredMultiple", c_ulong)                                  ## [out] preferred group size multiple
+    ]
+
+###############################################################################
+## @brief Kernel dispatch group count.
+class ze_group_count_t(Structure):
+    _fields_ = [
+        ("groupCountX", c_ulong),                                       ## [in] number of thread groups in X dimension
+        ("groupCountY", c_ulong),                                       ## [in] number of thread groups in Y dimension
+        ("groupCountZ", c_ulong)                                        ## [in] number of thread groups in Z dimension
+    ]
+
+###############################################################################
+## @brief Module Program Extension Name
+ZE_MODULE_PROGRAM_EXP_NAME = "ZE_experimental_module_program"
+
+###############################################################################
+## @brief Module Program Extension Version(s)
+class ze_module_program_exp_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class ze_module_program_exp_version_t(c_int):
+    def __str__(self):
+        return str(ze_module_program_exp_version_v(self.value))
+
+
+###############################################################################
+## @brief Module extended descriptor to support multiple input modules.
+## 
+## @details
+##     - Implementation must support ::ZE_experimental_module_program extension
+##     - Modules support import and export linkage for functions and global
+##       variables.
+##     - SPIR-V import and export linkage types are used. See SPIR-V
+##       specification for linkage details.
+##     - pInputModules, pBuildFlags, and pConstants from ::ze_module_desc_t is
+##       ignored.
+##     - Format in ::ze_module_desc_t needs to be set to
+##       ::ZE_MODULE_FORMAT_IL_SPIRV.
+class ze_module_program_exp_desc_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("count", c_ulong),                                             ## [in] Count of input modules
+        ("inputSizes", POINTER(c_size_t)),                              ## [in][range(0, count)] sizes of each input IL module in pInputModules.
+        ("pInputModules", POINTER(c_ubyte*)),                           ## [in][range(0, count)] pointer to an array of IL (e.g. SPIR-V modules).
+                                                                        ## Valid only for SPIR-V input.
+        ("pBuildFlags", POINTER(c_char_p)),                             ## [in][optional][range(0, count)] array of strings containing build
+                                                                        ## flags. See pBuildFlags in ::ze_module_desc_t.
+        ("pConstants", POINTER(ze_module_constants_t*))                 ## [in][optional][range(0, count)] pointer to array of specialization
+                                                                        ## constant strings. Valid only for SPIR-V input. This must be set to
+                                                                        ## nullptr if no specialization constants are provided.
+    ]
+
+###############################################################################
+## @brief Raytracing Extension Name
+ZE_RAYTRACING_EXT_NAME = "ZE_extension_raytracing"
+
+###############################################################################
+## @brief Raytracing Extension Version(s)
+class ze_raytracing_ext_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class ze_raytracing_ext_version_t(c_int):
+    def __str__(self):
+        return str(ze_raytracing_ext_version_v(self.value))
+
+
+###############################################################################
+## @brief Supported raytracing capability flags
+class ze_device_raytracing_ext_flags_v(IntEnum):
+    RAYQUERY = ZE_BIT(0)                                                    ## Supports rayquery
+
+class ze_device_raytracing_ext_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Raytracing properties queried using ::zeDeviceGetModuleProperties
+## 
+## @details
+##     - This structure may be returned from ::zeDeviceGetModuleProperties, via
+##       the `pNext` member of ::ze_device_module_properties_t.
+class ze_device_raytracing_ext_properties_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("flags", ze_device_raytracing_ext_flags_t),                    ## [out] 0 or a valid combination of ::ze_device_raytracing_ext_flags_t
+        ("maxBVHLevels", c_ulong)                                       ## [out] Maximum number of BVH levels supported
+    ]
+
+###############################################################################
+## @brief Supported raytracing memory allocation flags
+class ze_raytracing_mem_alloc_ext_flags_v(IntEnum):
+    TBD = ZE_BIT(0)                                                         ## reserved for future use
+
+class ze_raytracing_mem_alloc_ext_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Raytracing memory allocation descriptor
+## 
+## @details
+##     - This structure must be passed to ::zeMemAllocShared or
+##       ::zeMemAllocDevice, via the `pNext` member of
+##       ::ze_device_mem_alloc_desc_t, for any memory allocation that is to be
+##       accessed by raytracing fixed-function of the device.
+class ze_raytracing_mem_alloc_ext_desc_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("flags", ze_raytracing_mem_alloc_ext_flags_t)                  ## [in] flags specifying additional allocation controls.
+                                                                        ## must be 0 (default) or a valid combination of ::ze_raytracing_mem_alloc_ext_flag_t;
+                                                                        ## default behavior may use implicit driver-based heuristics.
+    ]
+
+###############################################################################
+## @brief Sampler addressing modes
+class ze_sampler_address_mode_v(IntEnum):
+    NONE = 0                                                                ## No coordinate modifications for out-of-bounds image access.
+    REPEAT = 1                                                              ## Out-of-bounds coordinates are wrapped back around.
+    CLAMP = 2                                                               ## Out-of-bounds coordinates are clamped to edge.
+    CLAMP_TO_BORDER = 3                                                     ## Out-of-bounds coordinates are clamped to border color which is (0.0f,
+                                                                            ## 0.0f, 0.0f, 0.0f) if image format swizzle contains alpha, otherwise
+                                                                            ## (0.0f, 0.0f, 0.0f, 1.0f).
+    MIRROR = 4                                                              ## Out-of-bounds coordinates are mirrored starting from edge.
+
+class ze_sampler_address_mode_t(c_int):
+    def __str__(self):
+        return str(ze_sampler_address_mode_v(self.value))
+
+
+###############################################################################
+## @brief Sampler filtering modes
+class ze_sampler_filter_mode_v(IntEnum):
+    NEAREST = 0                                                             ## No coordinate modifications for out of bounds image access.
+    LINEAR = 1                                                              ## Out-of-bounds coordinates are wrapped back around.
+
+class ze_sampler_filter_mode_t(c_int):
+    def __str__(self):
+        return str(ze_sampler_filter_mode_v(self.value))
+
+
+###############################################################################
+## @brief Sampler descriptor
+class ze_sampler_desc_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("addressMode", ze_sampler_address_mode_t),                     ## [in] Sampler addressing mode to determine how out-of-bounds
+                                                                        ## coordinates are handled.
+        ("filterMode", ze_sampler_filter_mode_t),                       ## [in] Sampler filter mode to determine how samples are filtered.
+        ("isNormalized", ze_bool_t)                                     ## [in] Are coordinates normalized [0, 1] or not.
+    ]
+
+###############################################################################
+## @brief Virtual memory page access attributes
+class ze_memory_access_attribute_v(IntEnum):
+    NONE = 0                                                                ## Indicates the memory page is inaccessible.
+    READWRITE = 1                                                           ## Indicates the memory page supports read write access.
+    READONLY = 2                                                            ## Indicates the memory page supports read-only access.
+
+class ze_memory_access_attribute_t(c_int):
+    def __str__(self):
+        return str(ze_memory_access_attribute_v(self.value))
+
+
+###############################################################################
+## @brief Supported physical memory creation flags
+class ze_physical_mem_flags_v(IntEnum):
+    ALLOCATE_ON_DEVICE = ZE_BIT(0)                                          ## [default] allocate physical device memory.
+    ALLOCATE_ON_HOST = ZE_BIT(1)                                            ## Allocate physical host memory instead.
+
+class ze_physical_mem_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Physical memory descriptor
+class ze_physical_mem_desc_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("flags", ze_physical_mem_flags_t),                             ## [in] creation flags.
+                                                                        ## must be 0 (default) or a valid combination of
+                                                                        ## ::ze_physical_mem_flag_t; default is to create physical device memory.
+        ("size", c_size_t)                                              ## [in] size in bytes to reserve; must be page aligned.
+    ]
+
+###############################################################################
+## @brief Floating-Point Atomics Extension Name
+ZE_FLOAT_ATOMICS_EXT_NAME = "ZE_extension_float_atomics"
+
+###############################################################################
+## @brief Floating-Point Atomics Extension Version(s)
+class ze_float_atomics_ext_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class ze_float_atomics_ext_version_t(c_int):
+    def __str__(self):
+        return str(ze_float_atomics_ext_version_v(self.value))
+
+
+###############################################################################
+## @brief Supported floating-point atomic capability flags
+class ze_device_fp_atomic_ext_flags_v(IntEnum):
+    GLOBAL_LOAD_STORE = ZE_BIT(0)                                           ## Supports atomic load, store, and exchange
+    GLOBAL_ADD = ZE_BIT(1)                                                  ## Supports atomic add and subtract
+    GLOBAL_MIN_MAX = ZE_BIT(2)                                              ## Supports atomic min and max
+    LOCAL_LOAD_STORE = ZE_BIT(16)                                           ## Supports atomic load, store, and exchange
+    LOCAL_ADD = ZE_BIT(17)                                                  ## Supports atomic add and subtract
+    LOCAL_MIN_MAX = ZE_BIT(18)                                              ## Supports atomic min and max
+
+class ze_device_fp_atomic_ext_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Device floating-point atomic properties queried using
+##        ::zeDeviceGetModuleProperties
+## 
+## @details
+##     - This structure may be returned from ::zeDeviceGetModuleProperties, via
+##       the `pNext` member of ::ze_device_module_properties_t.
+class ze_float_atomic_ext_properties_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("fp16Flags", ze_device_fp_atomic_ext_flags_t),                 ## [out] Capabilities for half-precision floating-point atomic operations
+        ("fp32Flags", ze_device_fp_atomic_ext_flags_t),                 ## [out] Capabilities for single-precision floating-point atomic
+                                                                        ## operations
+        ("fp64Flags", ze_device_fp_atomic_ext_flags_t)                  ## [out] Capabilities for double-precision floating-point atomic
+                                                                        ## operations
+    ]
+
+###############################################################################
+## @brief Global Offset Extension Name
+ZE_GLOBAL_OFFSET_EXP_NAME = "ZE_experimental_global_offset"
+
+###############################################################################
+## @brief Global Offset Extension Version(s)
+class ze_global_offset_exp_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class ze_global_offset_exp_version_t(c_int):
+    def __str__(self):
+        return str(ze_global_offset_exp_version_v(self.value))
+
+
+###############################################################################
+## @brief Relaxed Allocation Limits Extension Name
+ZE_RELAXED_ALLOCATION_LIMITS_EXP_NAME = "ZE_experimental_relaxed_allocation_limits"
+
+###############################################################################
+## @brief Relaxed Allocation Limits Extension Version(s)
+class ze_relaxed_allocation_limits_exp_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class ze_relaxed_allocation_limits_exp_version_t(c_int):
+    def __str__(self):
+        return str(ze_relaxed_allocation_limits_exp_version_v(self.value))
+
+
+###############################################################################
+## @brief Supported relaxed memory allocation flags
+class ze_relaxed_allocation_limits_exp_flags_v(IntEnum):
+    MAX_SIZE = ZE_BIT(0)                                                    ## Allocation size may exceed the `maxMemAllocSize` member of
+                                                                            ## ::ze_device_properties_t.
+
+class ze_relaxed_allocation_limits_exp_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Relaxed limits memory allocation descriptor
+## 
+## @details
+##     - This structure may be passed to ::zeMemAllocShared or
+##       ::zeMemAllocDevice, via the `pNext` member of
+##       ::ze_device_mem_alloc_desc_t.
+##     - This structure may also be passed to ::zeMemAllocHost, via the `pNext`
+##       member of ::ze_host_mem_alloc_desc_t.
+class ze_relaxed_allocation_limits_exp_desc_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("flags", ze_relaxed_allocation_limits_exp_flags_t)             ## [in] flags specifying allocation limits to relax.
+                                                                        ## must be 0 (default) or a valid combination of ::ze_relaxed_allocation_limits_exp_flag_t;
+    ]
+
+###############################################################################
+## @brief Get Kernel Binary Extension Name
+ZE_GET_KERNEL_BINARY_EXP_NAME = "ZE_extension_kernel_binary_exp"
+
+###############################################################################
+## @brief Get Kernel Binary Extension Version(s)
+class ze_kernel_get_binary_exp_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class ze_kernel_get_binary_exp_version_t(c_int):
+    def __str__(self):
+        return str(ze_kernel_get_binary_exp_version_v(self.value))
+
+
+###############################################################################
+## @brief Driver Direct Device Interface (DDI) Handles Extension Name
+ZE_DRIVER_DDI_HANDLES_EXT_NAME = "ZE_extension_driver_ddi_handles"
+
+###############################################################################
+## @brief Driver Direct Device Interface (DDI) Handles Extension Version(s)
+class ze_driver_ddi_handles_ext_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class ze_driver_ddi_handles_ext_version_t(c_int):
+    def __str__(self):
+        return str(ze_driver_ddi_handles_ext_version_v(self.value))
+
+
+###############################################################################
+## @brief Driver Direct Device Interface (DDI) Handle Extension Flags
+class ze_driver_ddi_handle_ext_flags_v(IntEnum):
+    DDI_HANDLE_EXT_SUPPORTED = ZE_BIT(0)                                    ## Driver Supports DDI Handles Extension
+
+class ze_driver_ddi_handle_ext_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Driver DDI Handles properties queried using ::zeDriverGetProperties
+## 
+## @details
+##     - This structure may be returned from ::zeDriverGetProperties, via the
+##       `pNext` member of ::ze_driver_properties_t.
+class ze_driver_ddi_handles_ext_properties_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("flags", ze_driver_ddi_handle_ext_flags_t)                     ## [out] 0 (none) or a valid combination of ::ze_driver_ddi_handle_ext_flags_t
+    ]
+
+###############################################################################
+## @brief External Semaphores Extension Name
+ZE_EXTERNAL_SEMAPHORES_EXTENSION_NAME = "ZE_extension_external_semaphores"
+
+###############################################################################
+## @brief External Semaphores Extension Version
+class ze_external_semaphore_ext_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class ze_external_semaphore_ext_version_t(c_int):
+    def __str__(self):
+        return str(ze_external_semaphore_ext_version_v(self.value))
+
+
+###############################################################################
+## @brief Handle of external semaphore object
+class ze_external_semaphore_ext_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief External Semaphores Type Flags
+class ze_external_semaphore_ext_flags_v(IntEnum):
+    OPAQUE_FD = ZE_BIT(0)                                                   ## Semaphore is an Linux opaque file descriptor
+    OPAQUE_WIN32 = ZE_BIT(1)                                                ## Semaphore is an opaque Win32 handle for monitored fence
+    OPAQUE_WIN32_KMT = ZE_BIT(2)                                            ## Semaphore is an opaque Win32 KMT handle for monitored fence
+    D3D12_FENCE = ZE_BIT(3)                                                 ## Semaphore is a D3D12 fence
+    D3D11_FENCE = ZE_BIT(4)                                                 ## Semaphore is a D3D11 fence
+    KEYED_MUTEX = ZE_BIT(5)                                                 ## Semaphore is a keyed mutex for Win32
+    KEYED_MUTEX_KMT = ZE_BIT(6)                                             ## Semaphore is a keyed mutex for Win32 KMT
+    VK_TIMELINE_SEMAPHORE_FD = ZE_BIT(7)                                    ## Semaphore is a Vulkan Timeline semaphore for Linux
+    VK_TIMELINE_SEMAPHORE_WIN32 = ZE_BIT(8)                                 ## Semaphore is a Vulkan Timeline semaphore for Win32
+
+class ze_external_semaphore_ext_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief External Semaphore Descriptor
+class ze_external_semaphore_ext_desc_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("flags", ze_external_semaphore_ext_flags_t)                    ## [in] The flags describing the type of the semaphore.
+                                                                        ## must be 0 (default) or a valid combination of ::ze_external_semaphore_ext_flag_t.
+                                                                        ## When importing a semaphore, pNext should be pointing to one of the
+                                                                        ## following structures: ::ze_external_semaphore_win32_ext_desc_t or ::ze_external_semaphore_fd_ext_desc_t.
+    ]
+
+###############################################################################
+## @brief External Semaphore Win32 Descriptor
+class ze_external_semaphore_win32_ext_desc_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("handle", c_void_p),                                           ## [in] Win32 handle of the semaphore.
+                                                                        ## Must be a valid Win32 handle.
+        ("name", c_char_p)                                              ## [in] Name of the semaphore.
+                                                                        ## Must be a valid null-terminated string.
+    ]
+
+###############################################################################
+## @brief External Semaphore FD Descriptor
+class ze_external_semaphore_fd_ext_desc_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("fd", c_int)                                                   ## [in] File descriptor of the semaphore.
+                                                                        ## Must be a valid file descriptor.
+    ]
+
+###############################################################################
+## @brief External Semaphore Signal parameters
+class ze_external_semaphore_signal_params_ext_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("value", c_ulonglong)                                          ## [in] [optional] Value to signal.
+                                                                        ## Specified by user as an expected value with some of semaphore types,
+                                                                        ## such as ::ZE_EXTERNAL_SEMAPHORE_EXT_FLAG_D3D12_FENCE.
+    ]
+
+###############################################################################
+## @brief External Semaphore Wait parameters
+class ze_external_semaphore_wait_params_ext_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("value", c_ulonglong)                                          ## [in] [optional] Value to wait for.
+                                                                        ## Specified by user as an expected value with some of semaphore types,
+                                                                        ## such as ::ZE_EXTERNAL_SEMAPHORE_EXT_FLAG_D3D12_FENCE.
+    ]
+
+###############################################################################
+## @brief Cache_Reservation Extension Name
+ZE_CACHE_RESERVATION_EXT_NAME = "ZE_extension_cache_reservation"
+
+###############################################################################
+## @brief Cache_Reservation Extension Version(s)
+class ze_cache_reservation_ext_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class ze_cache_reservation_ext_version_t(c_int):
+    def __str__(self):
+        return str(ze_cache_reservation_ext_version_v(self.value))
+
+
+###############################################################################
+## @brief Cache Reservation Region
+class ze_cache_ext_region_v(IntEnum):
+    ZE_CACHE_REGION_DEFAULT = 0                                             ## [DEPRECATED] utilize driver default scheme. Use
+                                                                            ## ::ZE_CACHE_EXT_REGION_DEFAULT.
+    ZE_CACHE_RESERVE_REGION = 1                                             ## [DEPRECATED] utilize reserved region. Use
+                                                                            ## ::ZE_CACHE_EXT_REGION_RESERVED.
+    ZE_CACHE_NON_RESERVED_REGION = 2                                        ## [DEPRECATED] utilize non-reserverd region. Use
+                                                                            ## ::ZE_CACHE_EXT_REGION_NON_RESERVED.
+    DEFAULT = 0                                                             ## utilize driver default scheme
+    RESERVED = 1                                                            ## utilize reserved region
+    NON_RESERVED = 2                                                        ## utilize non-reserverd region
+
+class ze_cache_ext_region_t(c_int):
+    def __str__(self):
+        return str(ze_cache_ext_region_v(self.value))
+
+
+###############################################################################
+## @brief CacheReservation structure
+## 
+## @details
+##     - This structure must be passed to ::zeDeviceGetCacheProperties via the
+##       `pNext` member of ::ze_device_cache_properties_t
+##     - Used for determining the max cache reservation allowed on device. Size
+##       of zero means no reservation available.
+class ze_cache_reservation_ext_desc_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("maxCacheReservationSize", c_size_t)                           ## [out] max cache reservation size
+    ]
+
+###############################################################################
+## @brief Event Query Timestamps Extension Name
+ZE_EVENT_QUERY_TIMESTAMPS_EXP_NAME = "ZE_experimental_event_query_timestamps"
+
+###############################################################################
+## @brief Event Query Timestamps Extension Version(s)
+class ze_event_query_timestamps_exp_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class ze_event_query_timestamps_exp_version_t(c_int):
+    def __str__(self):
+        return str(ze_event_query_timestamps_exp_version_v(self.value))
+
+
+###############################################################################
+## @brief Image Memory Properties Extension Name
+ZE_IMAGE_MEMORY_PROPERTIES_EXP_NAME = "ZE_experimental_image_memory_properties"
+
+###############################################################################
+## @brief Image Memory Properties Extension Version(s)
+class ze_image_memory_properties_exp_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class ze_image_memory_properties_exp_version_t(c_int):
+    def __str__(self):
+        return str(ze_image_memory_properties_exp_version_v(self.value))
+
+
+###############################################################################
+## @brief Image memory properties
+class ze_image_memory_properties_exp_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("size", c_ulonglong),                                          ## [out] size of image allocation in bytes.
+        ("rowPitch", c_ulonglong),                                      ## [out] size of image row in bytes.
+        ("slicePitch", c_ulonglong)                                     ## [out] size of image slice in bytes.
+    ]
+
+###############################################################################
+## @brief Image View Extension Name
+ZE_IMAGE_VIEW_EXT_NAME = "ZE_extension_image_view"
+
+###############################################################################
+## @brief Image View Extension Version(s)
+class ze_image_view_ext_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class ze_image_view_ext_version_t(c_int):
+    def __str__(self):
+        return str(ze_image_view_ext_version_v(self.value))
+
+
+###############################################################################
+## @brief Image View Extension Name
+ZE_IMAGE_VIEW_EXP_NAME = "ZE_experimental_image_view"
+
+###############################################################################
+## @brief Image View Extension Version(s)
+class ze_image_view_exp_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class ze_image_view_exp_version_t(c_int):
+    def __str__(self):
+        return str(ze_image_view_exp_version_v(self.value))
+
+
+###############################################################################
+## @brief Image View Planar Extension Name
+ZE_IMAGE_VIEW_PLANAR_EXT_NAME = "ZE_extension_image_view_planar"
+
+###############################################################################
+## @brief Image View Planar Extension Version(s)
+class ze_image_view_planar_ext_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class ze_image_view_planar_ext_version_t(c_int):
+    def __str__(self):
+        return str(ze_image_view_planar_ext_version_v(self.value))
+
+
+###############################################################################
+## @brief Image view planar descriptor
+class ze_image_view_planar_ext_desc_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("planeIndex", c_ulong)                                         ## [in] the 0-based plane index (e.g. NV12 is 0 = Y plane, 1 UV plane)
+    ]
+
+###############################################################################
+## @brief Image View Planar Extension Name
+ZE_IMAGE_VIEW_PLANAR_EXP_NAME = "ZE_experimental_image_view_planar"
+
+###############################################################################
+## @brief Image View Planar Extension Version(s)
+class ze_image_view_planar_exp_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class ze_image_view_planar_exp_version_t(c_int):
+    def __str__(self):
+        return str(ze_image_view_planar_exp_version_v(self.value))
+
+
+###############################################################################
+## @brief Image view planar descriptor
+class ze_image_view_planar_exp_desc_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("planeIndex", c_ulong)                                         ## [in] the 0-based plane index (e.g. NV12 is 0 = Y plane, 1 UV plane)
+    ]
+
+###############################################################################
+## @brief Kernel Scheduling Hints Extension Name
+ZE_KERNEL_SCHEDULING_HINTS_EXP_NAME = "ZE_experimental_scheduling_hints"
+
+###############################################################################
+## @brief Kernel Scheduling Hints Extension Version(s)
+class ze_scheduling_hints_exp_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class ze_scheduling_hints_exp_version_t(c_int):
+    def __str__(self):
+        return str(ze_scheduling_hints_exp_version_v(self.value))
+
+
+###############################################################################
+## @brief Supported kernel scheduling hint flags
+class ze_scheduling_hint_exp_flags_v(IntEnum):
+    OLDEST_FIRST = ZE_BIT(0)                                                ## Hint that the kernel prefers oldest-first scheduling
+    ROUND_ROBIN = ZE_BIT(1)                                                 ## Hint that the kernel prefers round-robin scheduling
+    STALL_BASED_ROUND_ROBIN = ZE_BIT(2)                                     ## Hint that the kernel prefers stall-based round-robin scheduling
+
+class ze_scheduling_hint_exp_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Device kernel scheduling hint properties queried using
+##        ::zeDeviceGetModuleProperties
+## 
+## @details
+##     - This structure may be returned from ::zeDeviceGetModuleProperties, via
+##       the `pNext` member of ::ze_device_module_properties_t.
+class ze_scheduling_hint_exp_properties_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("schedulingHintFlags", ze_scheduling_hint_exp_flags_t)         ## [out] Supported kernel scheduling hints.
+                                                                        ## May be 0 (none) or a valid combination of ::ze_scheduling_hint_exp_flag_t.
+    ]
+
+###############################################################################
+## @brief Kernel scheduling hint descriptor
+## 
+## @details
+##     - This structure may be passed to ::zeKernelSchedulingHintExp.
+class ze_scheduling_hint_exp_desc_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("flags", ze_scheduling_hint_exp_flags_t)                       ## [in] flags specifying kernel scheduling hints.
+                                                                        ## must be 0 (default) or a valid combination of ::ze_scheduling_hint_exp_flag_t.
+    ]
+
+###############################################################################
+## @brief Linkonce ODR Extension Name
+ZE_LINKONCE_ODR_EXT_NAME = "ZE_extension_linkonce_odr"
+
+###############################################################################
+## @brief Linkonce ODR Extension Version(s)
+class ze_linkonce_odr_ext_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class ze_linkonce_odr_ext_version_t(c_int):
+    def __str__(self):
+        return str(ze_linkonce_odr_ext_version_v(self.value))
+
+
+###############################################################################
+## @brief Power Saving Hint Extension Name
+ZE_CONTEXT_POWER_SAVING_HINT_EXP_NAME = "ZE_experimental_power_saving_hint"
+
+###############################################################################
+## @brief Power Saving Hint Extension Version(s)
+class ze_power_saving_hint_exp_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class ze_power_saving_hint_exp_version_t(c_int):
+    def __str__(self):
+        return str(ze_power_saving_hint_exp_version_v(self.value))
+
+
+###############################################################################
+## @brief Supported device types
+class ze_power_saving_hint_type_v(IntEnum):
+    MIN = 0                                                                 ## Minumum power savings. The device will make no attempt to save power
+                                                                            ## while executing work submitted to this context.
+    MAX = 100                                                               ## Maximum power savings. The device will do everything to bring power to
+                                                                            ## a minimum while executing work submitted to this context.
+
+class ze_power_saving_hint_type_t(c_int):
+    def __str__(self):
+        return str(ze_power_saving_hint_type_v(self.value))
+
+
+###############################################################################
+## @brief Extended context descriptor containing power saving hint.
+class ze_context_power_saving_hint_exp_desc_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("hint", c_ulong)                                               ## [in] power saving hint (default value = 0). This is value from [0,100]
+                                                                        ## and can use pre-defined settings from ::ze_power_saving_hint_type_t.
+    ]
+
+###############################################################################
+## @brief Subgroups Extension Name
+ZE_SUBGROUPS_EXT_NAME = "ZE_extension_subgroups"
+
+###############################################################################
+## @brief Subgroups Extension Version(s)
+class ze_subgroup_ext_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class ze_subgroup_ext_version_t(c_int):
+    def __str__(self):
+        return str(ze_subgroup_ext_version_v(self.value))
+
+
+###############################################################################
+## @brief EU Count Extension Name
+ZE_EU_COUNT_EXT_NAME = "ZE_extension_eu_count"
+
+###############################################################################
+## @brief EU Count Extension Version(s)
+class ze_eu_count_ext_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class ze_eu_count_ext_version_t(c_int):
+    def __str__(self):
+        return str(ze_eu_count_ext_version_v(self.value))
+
+
+###############################################################################
+## @brief EU count queried using ::zeDeviceGetProperties
+## 
+## @details
+##     - This structure may be returned from ::zeDeviceGetProperties via the
+##       `pNext` member of ::ze_device_properties_t.
+##     - Used for determining the total number of EUs available on device.
+class ze_eu_count_ext_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("numTotalEUs", c_ulong)                                        ## [out] Total number of EUs available
+    ]
+
+###############################################################################
+## @brief PCI Properties Extension Name
+ZE_PCI_PROPERTIES_EXT_NAME = "ZE_extension_pci_properties"
+
+###############################################################################
+## @brief PCI Properties Extension Version(s)
+class ze_pci_properties_ext_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class ze_pci_properties_ext_version_t(c_int):
+    def __str__(self):
+        return str(ze_pci_properties_ext_version_v(self.value))
+
+
+###############################################################################
+## @brief Device PCI address
+## 
+## @details
+##     - This structure may be passed to ::zeDevicePciGetPropertiesExt as an
+##       attribute of ::ze_pci_ext_properties_t.
+##     - A PCI BDF address is the bus:device:function address of the device and
+##       is useful for locating the device in the PCI switch fabric.
+class ze_pci_address_ext_t(Structure):
+    _fields_ = [
+        ("domain", c_ulong),                                            ## [out] PCI domain number
+        ("bus", c_ulong),                                               ## [out] PCI BDF bus number
+        ("device", c_ulong),                                            ## [out] PCI BDF device number
+        ("function", c_ulong)                                           ## [out] PCI BDF function number
+    ]
+
+###############################################################################
+## @brief Device PCI speed
+class ze_pci_speed_ext_t(Structure):
+    _fields_ = [
+        ("genVersion", c_int32_t),                                      ## [out] The link generation. A value of -1 means that this property is
+                                                                        ## unknown.
+        ("width", c_int32_t),                                           ## [out] The number of lanes. A value of -1 means that this property is
+                                                                        ## unknown.
+        ("maxBandwidth", c_int64_t)                                     ## [out] The theoretical maximum bandwidth in bytes/sec (sum of all
+                                                                        ## lanes). A value of -1 means that this property is unknown.
+    ]
+
+###############################################################################
+## @brief Static PCI properties
+class ze_pci_ext_properties_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("address", ze_pci_address_ext_t),                              ## [out] The BDF address
+        ("maxSpeed", ze_pci_speed_ext_t)                                ## [out] Fastest port configuration supported by the device (sum of all
+                                                                        ## lanes)
+    ]
+
+###############################################################################
+## @brief sRGB Extension Name
+ZE_SRGB_EXT_NAME = "ZE_extension_srgb"
+
+###############################################################################
+## @brief sRGB Extension Version(s)
+class ze_srgb_ext_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class ze_srgb_ext_version_t(c_int):
+    def __str__(self):
+        return str(ze_srgb_ext_version_v(self.value))
+
+
+###############################################################################
+## @brief sRGB image descriptor
+## 
+## @details
+##     - This structure may be passed to ::zeImageCreate via the `pNext` member
+##       of ::ze_image_desc_t
+##     - Used for specifying that the image is in sRGB format.
+class ze_srgb_ext_desc_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("sRGB", ze_bool_t)                                             ## [in] Is sRGB.
+    ]
+
+###############################################################################
+## @brief Image Copy Extension Name
+ZE_IMAGE_COPY_EXT_NAME = "ZE_extension_image_copy"
+
+###############################################################################
+## @brief Image Copy Extension Version(s)
+class ze_image_copy_ext_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class ze_image_copy_ext_version_t(c_int):
+    def __str__(self):
+        return str(ze_image_copy_ext_version_v(self.value))
+
+
+###############################################################################
+## @brief Image Query Allocation Properties Extension Name
+ZE_IMAGE_QUERY_ALLOC_PROPERTIES_EXT_NAME = "ZE_extension_image_query_alloc_properties"
+
+###############################################################################
+## @brief Image Query Allocation Properties Extension Version(s)
+class ze_image_query_alloc_properties_ext_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class ze_image_query_alloc_properties_ext_version_t(c_int):
+    def __str__(self):
+        return str(ze_image_query_alloc_properties_ext_version_v(self.value))
+
+
+###############################################################################
+## @brief Image allocation properties queried using
+##        ::zeImageGetAllocPropertiesExt
+class ze_image_allocation_ext_properties_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("id", c_ulonglong)                                             ## [out] identifier for this allocation
+    ]
+
+###############################################################################
+## @brief Linkage Inspection Extension Name
+ZE_LINKAGE_INSPECTION_EXT_NAME = "ZE_extension_linkage_inspection"
+
+###############################################################################
+## @brief Linkage Inspection Extension Version(s)
+class ze_linkage_inspection_ext_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class ze_linkage_inspection_ext_version_t(c_int):
+    def __str__(self):
+        return str(ze_linkage_inspection_ext_version_v(self.value))
+
+
+###############################################################################
+## @brief Supported module linkage inspection flags
+class ze_linkage_inspection_ext_flags_v(IntEnum):
+    IMPORTS = ZE_BIT(0)                                                     ## List all imports of modules
+    UNRESOLVABLE_IMPORTS = ZE_BIT(1)                                        ## List all imports of modules that do not have a corresponding export
+    EXPORTS = ZE_BIT(2)                                                     ## List all exports of modules
+
+class ze_linkage_inspection_ext_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Module linkage inspection descriptor
+## 
+## @details
+##     - This structure may be passed to ::zeModuleInspectLinkageExt.
+class ze_linkage_inspection_ext_desc_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("flags", ze_linkage_inspection_ext_flags_t)                    ## [in] flags specifying module linkage inspection.
+                                                                        ## must be 0 (default) or a valid combination of ::ze_linkage_inspection_ext_flag_t.
+    ]
+
+###############################################################################
+## @brief Memory Compression Hints Extension Name
+ZE_MEMORY_COMPRESSION_HINTS_EXT_NAME = "ZE_extension_memory_compression_hints"
+
+###############################################################################
+## @brief Memory Compression Hints Extension Version(s)
+class ze_memory_compression_hints_ext_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class ze_memory_compression_hints_ext_version_t(c_int):
+    def __str__(self):
+        return str(ze_memory_compression_hints_ext_version_v(self.value))
+
+
+###############################################################################
+## @brief Supported memory compression hints flags
+class ze_memory_compression_hints_ext_flags_v(IntEnum):
+    COMPRESSED = ZE_BIT(0)                                                  ## Hint Driver implementation to make allocation compressible
+    UNCOMPRESSED = ZE_BIT(1)                                                ## Hint Driver implementation to make allocation not compressible
+
+class ze_memory_compression_hints_ext_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Compression hints memory allocation descriptor
+## 
+## @details
+##     - This structure may be passed to ::zeMemAllocShared or
+##       ::zeMemAllocDevice, via the `pNext` member of
+##       ::ze_device_mem_alloc_desc_t.
+##     - This structure may be passed to ::zeMemAllocHost, via the `pNext`
+##       member of ::ze_host_mem_alloc_desc_t.
+##     - This structure may be passed to ::zeImageCreate, via the `pNext`
+##       member of ::ze_image_desc_t.
+class ze_memory_compression_hints_ext_desc_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("flags", ze_memory_compression_hints_ext_flags_t)              ## [in] flags specifying if allocation should be compressible or not.
+                                                                        ## Must be set to one of the ::ze_memory_compression_hints_ext_flag_t;
+    ]
+
+###############################################################################
+## @brief Memory Free Policies Extension Name
+ZE_MEMORY_FREE_POLICIES_EXT_NAME = "ZE_extension_memory_free_policies"
+
+###############################################################################
+## @brief Memory Free Policies Extension Version(s)
+class ze_memory_free_policies_ext_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class ze_memory_free_policies_ext_version_t(c_int):
+    def __str__(self):
+        return str(ze_memory_free_policies_ext_version_v(self.value))
+
+
+###############################################################################
+## @brief Supported memory free policy capability flags
+class ze_driver_memory_free_policy_ext_flags_v(IntEnum):
+    BLOCKING_FREE = ZE_BIT(0)                                               ## blocks until all commands using the memory are complete before freeing
+    DEFER_FREE = ZE_BIT(1)                                                  ## schedules the memory to be freed but does not free immediately
+
+class ze_driver_memory_free_policy_ext_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Driver memory free properties queried using ::zeDriverGetProperties
+## 
+## @details
+##     - All drivers must support an immediate free policy, which is the
+##       default free policy.
+##     - This structure may be returned from ::zeDriverGetProperties, via the
+##       `pNext` member of ::ze_driver_properties_t.
+class ze_driver_memory_free_ext_properties_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("freePolicies", ze_driver_memory_free_policy_ext_flags_t)      ## [out] Supported memory free policies.
+                                                                        ## must be 0 or a combination of ::ze_driver_memory_free_policy_ext_flag_t.
+    ]
+
+###############################################################################
+## @brief Memory free descriptor with free policy
+class ze_memory_free_ext_desc_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("freePolicy", ze_driver_memory_free_policy_ext_flags_t)        ## [in] flags specifying the memory free policy.
+                                                                        ## must be 0 (default) or a supported ::ze_driver_memory_free_policy_ext_flag_t;
+                                                                        ## default behavior is to free immediately.
+    ]
+
+###############################################################################
+## @brief Bandwidth Extension Name
+ZE_BANDWIDTH_PROPERTIES_EXP_NAME = "ZE_experimental_bandwidth_properties"
+
+###############################################################################
+## @brief P2P Bandwidth Properties
+## 
+## @details
+##     - This structure may be passed to ::zeDeviceGetP2PProperties by having
+##       the pNext member of ::ze_device_p2p_properties_t point at this struct.
+class ze_device_p2p_bandwidth_exp_properties_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("logicalBandwidth", c_ulong),                                  ## [out] total logical design bandwidth for all links connecting the two
+                                                                        ## devices
+        ("physicalBandwidth", c_ulong),                                 ## [out] total physical design bandwidth for all links connecting the two
+                                                                        ## devices
+        ("bandwidthUnit", ze_bandwidth_unit_t),                         ## [out] bandwidth unit
+        ("logicalLatency", c_ulong),                                    ## [out] average logical design latency for all links connecting the two
+                                                                        ## devices
+        ("physicalLatency", c_ulong),                                   ## [out] average physical design latency for all links connecting the two
+                                                                        ## devices
+        ("latencyUnit", ze_latency_unit_t)                              ## [out] latency unit
+    ]
+
+###############################################################################
+## @brief Copy Bandwidth Properties
+## 
+## @details
+##     - This structure may be passed to
+##       ::zeDeviceGetCommandQueueGroupProperties by having the pNext member of
+##       ::ze_command_queue_group_properties_t point at this struct.
+class ze_copy_bandwidth_exp_properties_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("copyBandwidth", c_ulong),                                     ## [out] design bandwidth supported by this engine type for copy
+                                                                        ## operations
+        ("copyBandwidthUnit", ze_bandwidth_unit_t)                      ## [out] copy bandwidth unit
+    ]
+
+###############################################################################
+## @brief Device Local Identifier (LUID) Extension Name
+ZE_DEVICE_LUID_EXT_NAME = "ZE_extension_device_luid"
+
+###############################################################################
+## @brief Device Local Identifier (LUID) Extension Version(s)
+class ze_device_luid_ext_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class ze_device_luid_ext_version_t(c_int):
+    def __str__(self):
+        return str(ze_device_luid_ext_version_v(self.value))
+
+
+###############################################################################
+## @brief Maximum device local identifier (LUID) size in bytes
+ZE_MAX_DEVICE_LUID_SIZE_EXT = 8
+
+###############################################################################
+## @brief Device local identifier (LUID)
+class ze_device_luid_ext_t(Structure):
+    _fields_ = [
+        ("id", c_ubyte * ZE_MAX_DEVICE_LUID_SIZE_EXT)                   ## [out] opaque data representing a device LUID
+    ]
+
+###############################################################################
+## @brief Device LUID properties queried using ::zeDeviceGetProperties
+## 
+## @details
+##     - This structure may be returned from ::zeDeviceGetProperties, via the
+##       `pNext` member of ::ze_device_properties_t.
+class ze_device_luid_ext_properties_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("luid", ze_device_luid_ext_t),                                 ## [out] locally unique identifier (LUID).
+                                                                        ## The returned LUID can be cast to a LUID object and must be equal to
+                                                                        ## the locally
+                                                                        ## unique identifier of an IDXGIAdapter1 object that corresponds to the device.
+        ("nodeMask", c_ulong)                                           ## [out] node mask.
+                                                                        ## The returned node mask must contain exactly one bit.
+                                                                        ## If the device is running on an operating system that supports the
+                                                                        ## Direct3D 12 API
+                                                                        ## and the device corresponds to an individual device in a linked device
+                                                                        ## adapter, the
+                                                                        ## returned node mask identifies the Direct3D 12 node corresponding to
+                                                                        ## the device.
+                                                                        ## Otherwise, the returned node mask must be 1.
+    ]
+
+###############################################################################
+## @brief Fabric Topology Discovery Extension Name
+ZE_FABRIC_EXP_NAME = "ZE_experimental_fabric"
+
+###############################################################################
+## @brief Maximum fabric edge model string size
+ZE_MAX_FABRIC_EDGE_MODEL_EXP_SIZE = 256
+
+###############################################################################
+## @brief Fabric Vertex types
+class ze_fabric_vertex_exp_type_v(IntEnum):
+    UNKNOWN = 0                                                             ## Fabric vertex type is unknown
+    DEVICE = 1                                                              ## Fabric vertex represents a device
+    SUBDEVICE = 2                                                           ## Fabric vertex represents a subdevice
+    SWITCH = 3                                                              ## Fabric vertex represents a switch
+
+class ze_fabric_vertex_exp_type_t(c_int):
+    def __str__(self):
+        return str(ze_fabric_vertex_exp_type_v(self.value))
+
+
+###############################################################################
+## @brief Fabric edge duplexity
+class ze_fabric_edge_exp_duplexity_v(IntEnum):
+    UNKNOWN = 0                                                             ## Fabric edge duplexity is unknown
+    HALF_DUPLEX = 1                                                         ## Fabric edge is half duplex, i.e. stated bandwidth is obtained in only
+                                                                            ## one direction at time
+    FULL_DUPLEX = 2                                                         ## Fabric edge is full duplex, i.e. stated bandwidth is supported in both
+                                                                            ## directions simultaneously
+
+class ze_fabric_edge_exp_duplexity_t(c_int):
+    def __str__(self):
+        return str(ze_fabric_edge_exp_duplexity_v(self.value))
+
+
+###############################################################################
+## @brief PCI address
+## 
+## @details
+##     - A PCI BDF address is the bus:device:function address of the device and
+##       is useful for locating the device in the PCI switch fabric.
+class ze_fabric_vertex_pci_exp_address_t(Structure):
+    _fields_ = [
+        ("domain", c_ulong),                                            ## [out] PCI domain number
+        ("bus", c_ulong),                                               ## [out] PCI BDF bus number
+        ("device", c_ulong),                                            ## [out] PCI BDF device number
+        ("function", c_ulong)                                           ## [out] PCI BDF function number
+    ]
+
+###############################################################################
+## @brief Fabric Vertex properties
+class ze_fabric_vertex_exp_properties_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("uuid", ze_uuid_t),                                            ## [out] universal unique identifier. If the vertex is co-located with a
+                                                                        ## device/subdevice, then this uuid will match that of the corresponding
+                                                                        ## device/subdevice
+        ("type", ze_fabric_vertex_exp_type_t),                          ## [out] does the fabric vertex represent a device, subdevice, or switch?
+        ("remote", ze_bool_t),                                          ## [out] does the fabric vertex live on the local node or on a remote
+                                                                        ## node?
+        ("address", ze_fabric_vertex_pci_exp_address_t)                 ## [out] B/D/F address of fabric vertex & associated device/subdevice if
+                                                                        ## available
+    ]
+
+###############################################################################
+## @brief Fabric Edge properties
+class ze_fabric_edge_exp_properties_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("uuid", ze_uuid_t),                                            ## [out] universal unique identifier.
+        ("model", c_char * ZE_MAX_FABRIC_EDGE_MODEL_EXP_SIZE),          ## [out] Description of fabric edge technology. Will be set to the string
+                                                                        ## "unkown" if this cannot be determined for this edge
+        ("bandwidth", c_ulong),                                         ## [out] design bandwidth
+        ("bandwidthUnit", ze_bandwidth_unit_t),                         ## [out] bandwidth unit
+        ("latency", c_ulong),                                           ## [out] design latency
+        ("latencyUnit", ze_latency_unit_t),                             ## [out] latency unit
+        ("duplexity", ze_fabric_edge_exp_duplexity_t)                   ## [out] Duplexity of the fabric edge
+    ]
+
+###############################################################################
+## @brief Device Memory Properties Extension Name
+ZE_DEVICE_MEMORY_PROPERTIES_EXT_NAME = "ZE_extension_device_memory_properties"
+
+###############################################################################
+## @brief Device Memory Properties Extension Version(s)
+class ze_device_memory_properties_ext_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class ze_device_memory_properties_ext_version_t(c_int):
+    def __str__(self):
+        return str(ze_device_memory_properties_ext_version_v(self.value))
+
+
+###############################################################################
+## @brief Memory module types
+class ze_device_memory_ext_type_v(IntEnum):
+    HBM = 0                                                                 ## HBM memory
+    HBM2 = 1                                                                ## HBM2 memory
+    DDR = 2                                                                 ## DDR memory
+    DDR2 = 3                                                                ## DDR2 memory
+    DDR3 = 4                                                                ## DDR3 memory
+    DDR4 = 5                                                                ## DDR4 memory
+    DDR5 = 6                                                                ## DDR5 memory
+    LPDDR = 7                                                               ## LPDDR memory
+    LPDDR3 = 8                                                              ## LPDDR3 memory
+    LPDDR4 = 9                                                              ## LPDDR4 memory
+    LPDDR5 = 10                                                             ## LPDDR5 memory
+    SRAM = 11                                                               ## SRAM memory
+    L1 = 12                                                                 ## L1 cache
+    L3 = 13                                                                 ## L3 cache
+    GRF = 14                                                                ## Execution unit register file
+    SLM = 15                                                                ## Execution unit shared local memory
+    GDDR4 = 16                                                              ## GDDR4 memory
+    GDDR5 = 17                                                              ## GDDR5 memory
+    GDDR5X = 18                                                             ## GDDR5X memory
+    GDDR6 = 19                                                              ## GDDR6 memory
+    GDDR6X = 20                                                             ## GDDR6X memory
+    GDDR7 = 21                                                              ## GDDR7 memory
+
+class ze_device_memory_ext_type_t(c_int):
+    def __str__(self):
+        return str(ze_device_memory_ext_type_v(self.value))
+
+
+###############################################################################
+## @brief Memory properties
+## 
+## @details
+##     - This structure may be returned from ::zeDeviceGetMemoryProperties via
+##       the `pNext` member of ::ze_device_memory_properties_t
+class ze_device_memory_ext_properties_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("type", ze_device_memory_ext_type_t),                          ## [out] The memory type
+        ("physicalSize", c_ulonglong),                                  ## [out] Physical memory size in bytes. A value of 0 indicates that this
+                                                                        ## property is not known. However, a call to ::zesMemoryGetState() will
+                                                                        ## correctly return the total size of usable memory.
+        ("readBandwidth", c_ulong),                                     ## [out] Design bandwidth for reads
+        ("writeBandwidth", c_ulong),                                    ## [out] Design bandwidth for writes
+        ("bandwidthUnit", ze_bandwidth_unit_t)                          ## [out] bandwidth unit
+    ]
+
+###############################################################################
+## @brief Bfloat16 Conversions Extension Name
+ZE_BFLOAT16_CONVERSIONS_EXT_NAME = "ZE_extension_bfloat16_conversions"
+
+###############################################################################
+## @brief Bfloat16 Conversions Extension Version(s)
+class ze_bfloat16_conversions_ext_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class ze_bfloat16_conversions_ext_version_t(c_int):
+    def __str__(self):
+        return str(ze_bfloat16_conversions_ext_version_v(self.value))
+
+
+###############################################################################
+## @brief Device IP Version Extension Name
+ZE_DEVICE_IP_VERSION_EXT_NAME = "ZE_extension_device_ip_version"
+
+###############################################################################
+## @brief Device IP Version Extension Version(s)
+class ze_device_ip_version_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class ze_device_ip_version_version_t(c_int):
+    def __str__(self):
+        return str(ze_device_ip_version_version_v(self.value))
+
+
+###############################################################################
+## @brief Device IP version queried using ::zeDeviceGetProperties
+## 
+## @details
+##     - This structure may be returned from ::zeDeviceGetProperties via the
+##       `pNext` member of ::ze_device_properties_t
+class ze_device_ip_version_ext_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("ipVersion", c_ulong)                                          ## [out] Device IP version. The meaning of the device IP version is
+                                                                        ## implementation-defined, but newer devices should have a higher
+                                                                        ## version than older devices.
+    ]
+
+###############################################################################
+## @brief Kernel Max Group Size Properties Extension Name
+ZE_KERNEL_MAX_GROUP_SIZE_PROPERTIES_EXT_NAME = "ZE_extension_kernel_max_group_size_properties"
+
+###############################################################################
+## @brief Kernel Max Group Size Properties Extension Version(s)
+class ze_kernel_max_group_size_properties_ext_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class ze_kernel_max_group_size_properties_ext_version_t(c_int):
+    def __str__(self):
+        return str(ze_kernel_max_group_size_properties_ext_version_v(self.value))
+
+
+###############################################################################
+## @brief Additional kernel max group size properties
+## 
+## @details
+##     - This structure may be passed to ::zeKernelGetProperties, via the
+##       `pNext` member of ::ze_kernel_properties_t, to query additional kernel
+##       max group size properties.
+class ze_kernel_max_group_size_properties_ext_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("maxGroupSize", c_ulong)                                       ## [out] maximum group size that can be used to execute the kernel. This
+                                                                        ## value may be less than or equal to the `maxTotalGroupSize` member of
+                                                                        ## ::ze_device_compute_properties_t.
+    ]
+
+###############################################################################
+## @brief compiler-independent type
+class ze_kernel_max_group_size_ext_properties_t(ze_kernel_max_group_size_properties_ext_t):
+    pass
+
+###############################################################################
+## @brief Sub-Allocations Properties Extension Name
+ZE_SUB_ALLOCATIONS_EXP_NAME = "ZE_experimental_sub_allocations"
+
+###############################################################################
+## @brief Sub-Allocations Properties Extension Version(s)
+class ze_sub_allocations_exp_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class ze_sub_allocations_exp_version_t(c_int):
+    def __str__(self):
+        return str(ze_sub_allocations_exp_version_v(self.value))
+
+
+###############################################################################
+## @brief Properties returned for a sub-allocation
+class ze_sub_allocation_t(Structure):
+    _fields_ = [
+        ("base", c_void_p),                                             ## [in,out][optional] base address of the sub-allocation
+        ("size", c_size_t)                                              ## [in,out][optional] size of the allocation
+    ]
+
+###############################################################################
+## @brief Sub-Allocations Properties
+## 
+## @details
+##     - This structure may be passed to ::zeMemGetAllocProperties, via the
+##       `pNext` member of ::ze_memory_allocation_properties_t.
+class ze_memory_sub_allocations_exp_properties_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("pCount", POINTER(c_ulong)),                                   ## [in,out] pointer to the number of sub-allocations.
+                                                                        ## if count is zero, then the driver shall update the value with the
+                                                                        ## total number of sub-allocations on which the allocation has been divided.
+                                                                        ## if count is greater than the number of sub-allocations, then the
+                                                                        ## driver shall update the value with the correct number of sub-allocations.
+        ("pSubAllocations", POINTER(ze_sub_allocation_t))               ## [in,out][optional][range(0, *pCount)] array of properties for sub-allocations.
+                                                                        ## if count is less than the number of sub-allocations available, then
+                                                                        ## driver shall only retrieve properties for that number of sub-allocations.
+    ]
+
+###############################################################################
+## @brief Event Query Kernel Timestamps Extension Name
+ZE_EVENT_QUERY_KERNEL_TIMESTAMPS_EXT_NAME = "ZE_extension_event_query_kernel_timestamps"
+
+###############################################################################
+## @brief Event Query Kernel Timestamps Extension Version(s)
+class ze_event_query_kernel_timestamps_ext_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class ze_event_query_kernel_timestamps_ext_version_t(c_int):
+    def __str__(self):
+        return str(ze_event_query_kernel_timestamps_ext_version_v(self.value))
+
+
+###############################################################################
+## @brief Event query kernel timestamps flags
+class ze_event_query_kernel_timestamps_ext_flags_v(IntEnum):
+    KERNEL = ZE_BIT(0)                                                      ## Kernel timestamp results
+    SYNCHRONIZED = ZE_BIT(1)                                                ## Device event timestamps synchronized to the host time domain
+
+class ze_event_query_kernel_timestamps_ext_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Event query kernel timestamps properties
+## 
+## @details
+##     - This structure may be returned from ::zeDeviceGetProperties, via the
+##       `pNext` member of ::ze_device_properties_t.
+class ze_event_query_kernel_timestamps_ext_properties_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("flags", ze_event_query_kernel_timestamps_ext_flags_t)         ## [out] 0 or some combination of
+                                                                        ## ::ze_event_query_kernel_timestamps_ext_flag_t flags
+    ]
+
+###############################################################################
+## @brief Kernel timestamp clock data synchronized to the host time domain
+class ze_synchronized_timestamp_data_ext_t(Structure):
+    _fields_ = [
+        ("kernelStart", c_ulonglong),                                   ## [out] synchronized clock at start of kernel execution
+        ("kernelEnd", c_ulonglong)                                      ## [out] synchronized clock at end of kernel execution
+    ]
+
+###############################################################################
+## @brief Synchronized kernel timestamp result
+class ze_synchronized_timestamp_result_ext_t(Structure):
+    _fields_ = [
+        ("global", ze_synchronized_timestamp_data_ext_t),               ## [out] wall-clock data
+        ("context", ze_synchronized_timestamp_data_ext_t)               ## [out] context-active data; only includes clocks while device context
+                                                                        ## was actively executing.
+    ]
+
+###############################################################################
+## @brief Event query kernel timestamps results properties
+class ze_event_query_kernel_timestamps_results_ext_properties_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("pKernelTimestampsBuffer", POINTER(ze_kernel_timestamp_result_t)), ## [in,out][optional][range(0, *pCount)] pointer to destination buffer of
+                                                                        ## kernel timestamp results
+        ("pSynchronizedTimestampsBuffer", POINTER(ze_synchronized_timestamp_result_ext_t))  ## [in,out][optional][range(0, *pCount)] pointer to destination buffer of
+                                                                        ## synchronized timestamp results
+    ]
+
+###############################################################################
+## @brief Ray Tracing Acceleration Structure Builder Extension Name
+ZE_RTAS_BUILDER_EXP_NAME = "ZE_experimental_rtas_builder"
+
+###############################################################################
+## @brief Ray Tracing Acceleration Structure Builder Extension Version(s)
+class ze_rtas_builder_exp_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class ze_rtas_builder_exp_version_t(c_int):
+    def __str__(self):
+        return str(ze_rtas_builder_exp_version_v(self.value))
+
+
+###############################################################################
+## @brief Ray tracing acceleration structure device flags
+class ze_rtas_device_exp_flags_v(IntEnum):
+    RESERVED = ZE_BIT(0)                                                    ## reserved for future use
+
+class ze_rtas_device_exp_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Ray tracing acceleration structure format
+## 
+## @details
+##     - This is an opaque ray tracing acceleration structure format
+##       identifier.
+class ze_rtas_format_exp_v(IntEnum):
+    INVALID = 0                                                             ## Invalid acceleration structure format
+
+class ze_rtas_format_exp_t(c_int):
+    def __str__(self):
+        return str(ze_rtas_format_exp_v(self.value))
+
+
+###############################################################################
+## @brief Ray tracing acceleration structure builder flags
+class ze_rtas_builder_exp_flags_v(IntEnum):
+    RESERVED = ZE_BIT(0)                                                    ## Reserved for future use
+
+class ze_rtas_builder_exp_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Ray tracing acceleration structure builder parallel operation flags
+class ze_rtas_parallel_operation_exp_flags_v(IntEnum):
+    RESERVED = ZE_BIT(0)                                                    ## Reserved for future use
+
+class ze_rtas_parallel_operation_exp_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Ray tracing acceleration structure builder geometry flags
+class ze_rtas_builder_geometry_exp_flags_v(IntEnum):
+    NON_OPAQUE = ZE_BIT(0)                                                  ## non-opaque geometries invoke an any-hit shader
+
+class ze_rtas_builder_geometry_exp_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Packed ray tracing acceleration structure builder geometry flags (see
+##        ::ze_rtas_builder_geometry_exp_flags_t)
+class ze_rtas_builder_packed_geometry_exp_flags_t(c_ubyte):
+    pass
+
+###############################################################################
+## @brief Ray tracing acceleration structure builder instance flags
+class ze_rtas_builder_instance_exp_flags_v(IntEnum):
+    TRIANGLE_CULL_DISABLE = ZE_BIT(0)                                       ## disables culling of front-facing and back-facing triangles
+    TRIANGLE_FRONT_COUNTERCLOCKWISE = ZE_BIT(1)                             ## reverses front and back face of triangles
+    TRIANGLE_FORCE_OPAQUE = ZE_BIT(2)                                       ## forces instanced geometry to be opaque, unless ray flag forces it to
+                                                                            ## be non-opaque
+    TRIANGLE_FORCE_NON_OPAQUE = ZE_BIT(3)                                   ## forces instanced geometry to be non-opaque, unless ray flag forces it
+                                                                            ## to be opaque
+
+class ze_rtas_builder_instance_exp_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Packed ray tracing acceleration structure builder instance flags (see
+##        ::ze_rtas_builder_instance_exp_flags_t)
+class ze_rtas_builder_packed_instance_exp_flags_t(c_ubyte):
+    pass
+
+###############################################################################
+## @brief Ray tracing acceleration structure builder build operation flags
+## 
+## @details
+##     - These flags allow the application to tune the acceleration structure
+##       build operation.
+##     - The acceleration structure builder implementation might choose to use
+##       spatial splitting to split large or long primitives into smaller
+##       pieces. This may result in any-hit shaders being invoked multiple
+##       times for non-opaque primitives, unless
+##       ::ZE_RTAS_BUILDER_BUILD_OP_EXP_FLAG_NO_DUPLICATE_ANYHIT_INVOCATION is specified.
+##     - Usage of any of these flags may reduce ray tracing performance.
+class ze_rtas_builder_build_op_exp_flags_v(IntEnum):
+    COMPACT = ZE_BIT(0)                                                     ## build more compact acceleration structure
+    NO_DUPLICATE_ANYHIT_INVOCATION = ZE_BIT(1)                              ## guarantees single any-hit shader invocation per primitive
+
+class ze_rtas_builder_build_op_exp_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Ray tracing acceleration structure builder build quality hint
+## 
+## @details
+##     - Depending on use case different quality modes for acceleration
+##       structure build are supported.
+##     - A low-quality build builds an acceleration structure fast, but at the
+##       cost of some reduction in ray tracing performance. This mode is
+##       recommended for dynamic content, such as animated characters.
+##     - A medium-quality build uses a compromise between build quality and ray
+##       tracing performance. This mode should be used by default.
+##     - Higher ray tracing performance can be achieved by using a high-quality
+##       build, but acceleration structure build performance might be
+##       significantly reduced.
+class ze_rtas_builder_build_quality_hint_exp_v(IntEnum):
+    LOW = 0                                                                 ## build low-quality acceleration structure (fast)
+    MEDIUM = 1                                                              ## build medium-quality acceleration structure (slower)
+    HIGH = 2                                                                ## build high-quality acceleration structure (slow)
+
+class ze_rtas_builder_build_quality_hint_exp_t(c_int):
+    def __str__(self):
+        return str(ze_rtas_builder_build_quality_hint_exp_v(self.value))
+
+
+###############################################################################
+## @brief Ray tracing acceleration structure builder geometry type
+class ze_rtas_builder_geometry_type_exp_v(IntEnum):
+    TRIANGLES = 0                                                           ## triangle mesh geometry type
+    QUADS = 1                                                               ## quad mesh geometry type
+    PROCEDURAL = 2                                                          ## procedural geometry type
+    INSTANCE = 3                                                            ## instance geometry type
+
+class ze_rtas_builder_geometry_type_exp_t(c_int):
+    def __str__(self):
+        return str(ze_rtas_builder_geometry_type_exp_v(self.value))
+
+
+###############################################################################
+## @brief Packed ray tracing acceleration structure builder geometry type (see
+##        ::ze_rtas_builder_geometry_type_exp_t)
+class ze_rtas_builder_packed_geometry_type_exp_t(c_ubyte):
+    pass
+
+###############################################################################
+## @brief Ray tracing acceleration structure data buffer element format
+## 
+## @details
+##     - Specifies the format of data buffer elements.
+##     - Data buffers may contain instancing transform matrices, triangle/quad
+##       vertex indices, etc...
+class ze_rtas_builder_input_data_format_exp_v(IntEnum):
+    FLOAT3 = 0                                                              ## 3-component float vector (see ::ze_rtas_float3_exp_t)
+    FLOAT3X4_COLUMN_MAJOR = 1                                               ## 3x4 affine transformation in column-major format (see
+                                                                            ## ::ze_rtas_transform_float3x4_column_major_exp_t)
+    FLOAT3X4_ALIGNED_COLUMN_MAJOR = 2                                       ## 3x4 affine transformation in column-major format (see
+                                                                            ## ::ze_rtas_transform_float3x4_aligned_column_major_exp_t)
+    FLOAT3X4_ROW_MAJOR = 3                                                  ## 3x4 affine transformation in row-major format (see
+                                                                            ## ::ze_rtas_transform_float3x4_row_major_exp_t)
+    AABB = 4                                                                ## 3-dimensional axis-aligned bounding-box (see ::ze_rtas_aabb_exp_t)
+    TRIANGLE_INDICES_UINT32 = 5                                             ## Unsigned 32-bit triangle indices (see
+                                                                            ## ::ze_rtas_triangle_indices_uint32_exp_t)
+    QUAD_INDICES_UINT32 = 6                                                 ## Unsigned 32-bit quad indices (see ::ze_rtas_quad_indices_uint32_exp_t)
+
+class ze_rtas_builder_input_data_format_exp_t(c_int):
+    def __str__(self):
+        return str(ze_rtas_builder_input_data_format_exp_v(self.value))
+
+
+###############################################################################
+## @brief Packed ray tracing acceleration structure data buffer element format
+##        (see ::ze_rtas_builder_input_data_format_exp_t)
+class ze_rtas_builder_packed_input_data_format_exp_t(c_ubyte):
+    pass
+
+###############################################################################
+## @brief Handle of ray tracing acceleration structure builder object
+class ze_rtas_builder_exp_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle of ray tracing acceleration structure builder parallel
+##        operation object
+class ze_rtas_parallel_operation_exp_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Ray tracing acceleration structure builder descriptor
+class ze_rtas_builder_exp_desc_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("builderVersion", ze_rtas_builder_exp_version_t)               ## [in] ray tracing acceleration structure builder version
+    ]
+
+###############################################################################
+## @brief Ray tracing acceleration structure builder properties
+class ze_rtas_builder_exp_properties_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("flags", ze_rtas_builder_exp_flags_t),                         ## [out] ray tracing acceleration structure builder flags
+        ("rtasBufferSizeBytesExpected", c_size_t),                      ## [out] expected size (in bytes) required for acceleration structure buffer
+                                                                        ##    - When using an acceleration structure buffer of this size, the
+                                                                        ## build is expected to succeed; however, it is possible that the build
+                                                                        ## may fail with ::ZE_RESULT_EXP_RTAS_BUILD_RETRY
+        ("rtasBufferSizeBytesMaxRequired", c_size_t),                   ## [out] worst-case size (in bytes) required for acceleration structure buffer
+                                                                        ##    - When using an acceleration structure buffer of this size, the
+                                                                        ## build is guaranteed to not run out of memory.
+        ("scratchBufferSizeBytes", c_size_t)                            ## [out] scratch buffer size (in bytes) required for acceleration
+                                                                        ## structure build.
+    ]
+
+###############################################################################
+## @brief Ray tracing acceleration structure builder parallel operation
+##        properties
+class ze_rtas_parallel_operation_exp_properties_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("flags", ze_rtas_parallel_operation_exp_flags_t),              ## [out] ray tracing acceleration structure builder parallel operation
+                                                                        ## flags
+        ("maxConcurrency", c_ulong)                                     ## [out] maximum number of threads that may join the parallel operation
+    ]
+
+###############################################################################
+## @brief Ray tracing acceleration structure device properties
+## 
+## @details
+##     - This structure may be passed to ::zeDeviceGetProperties, via `pNext`
+##       member of ::ze_device_properties_t.
+##     - The implementation shall populate `format` with a value other than
+##       ::ZE_RTAS_FORMAT_EXP_INVALID when the device supports ray tracing.
+class ze_rtas_device_exp_properties_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("flags", ze_rtas_device_exp_flags_t),                          ## [out] ray tracing acceleration structure device flags
+        ("rtasFormat", ze_rtas_format_exp_t),                           ## [out] ray tracing acceleration structure format
+        ("rtasBufferAlignment", c_ulong)                                ## [out] required alignment of acceleration structure buffer
+    ]
+
+###############################################################################
+## @brief A 3-component vector type
+class ze_rtas_float3_exp_t(Structure):
+    _fields_ = [
+        ("x", c_float),                                                 ## [in] x-coordinate of float3 vector
+        ("y", c_float),                                                 ## [in] y-coordinate of float3 vector
+        ("z", c_float)                                                  ## [in] z-coordinate of float3 vector
+    ]
+
+###############################################################################
+## @brief 3x4 affine transformation in column-major layout
+## 
+## @details
+##     - A 3x4 affine transformation in column major layout, consisting of vectors
+##          - vx=(vx_x, vx_y, vx_z),
+##          - vy=(vy_x, vy_y, vy_z),
+##          - vz=(vz_x, vz_y, vz_z), and
+##          - p=(p_x, p_y, p_z)
+##     - The transformation transforms a point (x, y, z) to: `x*vx + y*vy +
+##       z*vz + p`.
+class ze_rtas_transform_float3x4_column_major_exp_t(Structure):
+    _fields_ = [
+        ("vx_x", c_float),                                              ## [in] element 0 of column 0 of 3x4 matrix
+        ("vx_y", c_float),                                              ## [in] element 1 of column 0 of 3x4 matrix
+        ("vx_z", c_float),                                              ## [in] element 2 of column 0 of 3x4 matrix
+        ("vy_x", c_float),                                              ## [in] element 0 of column 1 of 3x4 matrix
+        ("vy_y", c_float),                                              ## [in] element 1 of column 1 of 3x4 matrix
+        ("vy_z", c_float),                                              ## [in] element 2 of column 1 of 3x4 matrix
+        ("vz_x", c_float),                                              ## [in] element 0 of column 2 of 3x4 matrix
+        ("vz_y", c_float),                                              ## [in] element 1 of column 2 of 3x4 matrix
+        ("vz_z", c_float),                                              ## [in] element 2 of column 2 of 3x4 matrix
+        ("p_x", c_float),                                               ## [in] element 0 of column 3 of 3x4 matrix
+        ("p_y", c_float),                                               ## [in] element 1 of column 3 of 3x4 matrix
+        ("p_z", c_float)                                                ## [in] element 2 of column 3 of 3x4 matrix
+    ]
+
+###############################################################################
+## @brief 3x4 affine transformation in column-major layout with aligned column
+##        vectors
+## 
+## @details
+##     - A 3x4 affine transformation in column major layout, consisting of vectors
+##        - vx=(vx_x, vx_y, vx_z),
+##        - vy=(vy_x, vy_y, vy_z),
+##        - vz=(vz_x, vz_y, vz_z), and
+##        - p=(p_x, p_y, p_z)
+##     - The transformation transforms a point (x, y, z) to: `x*vx + y*vy +
+##       z*vz + p`.
+##     - The column vectors are aligned to 16-bytes and pad members are
+##       ignored.
+class ze_rtas_transform_float3x4_aligned_column_major_exp_t(Structure):
+    _fields_ = [
+        ("vx_x", c_float),                                              ## [in] element 0 of column 0 of 3x4 matrix
+        ("vx_y", c_float),                                              ## [in] element 1 of column 0 of 3x4 matrix
+        ("vx_z", c_float),                                              ## [in] element 2 of column 0 of 3x4 matrix
+        ("pad0", c_float),                                              ## [in] ignored padding
+        ("vy_x", c_float),                                              ## [in] element 0 of column 1 of 3x4 matrix
+        ("vy_y", c_float),                                              ## [in] element 1 of column 1 of 3x4 matrix
+        ("vy_z", c_float),                                              ## [in] element 2 of column 1 of 3x4 matrix
+        ("pad1", c_float),                                              ## [in] ignored padding
+        ("vz_x", c_float),                                              ## [in] element 0 of column 2 of 3x4 matrix
+        ("vz_y", c_float),                                              ## [in] element 1 of column 2 of 3x4 matrix
+        ("vz_z", c_float),                                              ## [in] element 2 of column 2 of 3x4 matrix
+        ("pad2", c_float),                                              ## [in] ignored padding
+        ("p_x", c_float),                                               ## [in] element 0 of column 3 of 3x4 matrix
+        ("p_y", c_float),                                               ## [in] element 1 of column 3 of 3x4 matrix
+        ("p_z", c_float),                                               ## [in] element 2 of column 3 of 3x4 matrix
+        ("pad3", c_float)                                               ## [in] ignored padding
+    ]
+
+###############################################################################
+## @brief 3x4 affine transformation in row-major layout
+## 
+## @details
+##     - A 3x4 affine transformation in row-major layout, consisting of vectors
+##          - vx=(vx_x, vx_y, vx_z),
+##          - vy=(vy_x, vy_y, vy_z),
+##          - vz=(vz_x, vz_y, vz_z), and
+##          - p=(p_x, p_y, p_z)
+##     - The transformation transforms a point (x, y, z) to: `x*vx + y*vy +
+##       z*vz + p`.
+class ze_rtas_transform_float3x4_row_major_exp_t(Structure):
+    _fields_ = [
+        ("vx_x", c_float),                                              ## [in] element 0 of row 0 of 3x4 matrix
+        ("vy_x", c_float),                                              ## [in] element 1 of row 0 of 3x4 matrix
+        ("vz_x", c_float),                                              ## [in] element 2 of row 0 of 3x4 matrix
+        ("p_x", c_float),                                               ## [in] element 3 of row 0 of 3x4 matrix
+        ("vx_y", c_float),                                              ## [in] element 0 of row 1 of 3x4 matrix
+        ("vy_y", c_float),                                              ## [in] element 1 of row 1 of 3x4 matrix
+        ("vz_y", c_float),                                              ## [in] element 2 of row 1 of 3x4 matrix
+        ("p_y", c_float),                                               ## [in] element 3 of row 1 of 3x4 matrix
+        ("vx_z", c_float),                                              ## [in] element 0 of row 2 of 3x4 matrix
+        ("vy_z", c_float),                                              ## [in] element 1 of row 2 of 3x4 matrix
+        ("vz_z", c_float),                                              ## [in] element 2 of row 2 of 3x4 matrix
+        ("p_z", c_float)                                                ## [in] element 3 of row 2 of 3x4 matrix
+    ]
+
+###############################################################################
+## @brief A 3-dimensional axis-aligned bounding-box with lower and upper bounds
+##        in each dimension
+class ze_rtas_aabb_exp_t(Structure):
+    _fields_ = [
+        ("lower", ze_rtas_c_float3_exp_t),                              ## [in] lower bounds of AABB
+        ("upper", ze_rtas_c_float3_exp_t)                               ## [in] upper bounds of AABB
+    ]
+
+###############################################################################
+## @brief Triangle represented using 3 vertex indices
+## 
+## @details
+##     - Represents a triangle using 3 vertex indices that index into a vertex
+##       array that needs to be provided together with the index array.
+##     - The linear barycentric u/v parametrization of the triangle is defined as:
+##          - (u=0, v=0) at v0,
+##          - (u=1, v=0) at v1, and
+##          - (u=0, v=1) at v2
+class ze_rtas_triangle_indices_uint32_exp_t(Structure):
+    _fields_ = [
+        ("v0", c_ulong),                                                ## [in] first index pointing to the first triangle vertex in vertex array
+        ("v1", c_ulong),                                                ## [in] second index pointing to the second triangle vertex in vertex
+                                                                        ## array
+        ("v2", c_ulong)                                                 ## [in] third index pointing to the third triangle vertex in vertex array
+    ]
+
+###############################################################################
+## @brief Quad represented using 4 vertex indices
+## 
+## @details
+##     - Represents a quad composed of 4 indices that index into a vertex array
+##       that needs to be provided together with the index array.
+##     - A quad is a triangle pair represented using 4 vertex indices v0, v1,
+##       v2, v3.
+##       The first triangle is made out of indices v0, v1, v3 and the second triangle
+##       from indices v2, v3, v1. The piecewise linear barycentric u/v parametrization
+##       of the quad is defined as:
+##          - (u=0, v=0) at v0,
+##          - (u=1, v=0) at v1,
+##          - (u=0, v=1) at v3, and
+##          - (u=1, v=1) at v2
+##       This is achieved by correcting the u'/v' coordinates of the second
+##       triangle by
+##       *u = 1-u'* and *v = 1-v'*, yielding a piecewise linear parametrization.
+class ze_rtas_quad_indices_uint32_exp_t(Structure):
+    _fields_ = [
+        ("v0", c_ulong),                                                ## [in] first index pointing to the first quad vertex in vertex array
+        ("v1", c_ulong),                                                ## [in] second index pointing to the second quad vertex in vertex array
+        ("v2", c_ulong),                                                ## [in] third index pointing to the third quad vertex in vertex array
+        ("v3", c_ulong)                                                 ## [in] fourth index pointing to the fourth quad vertex in vertex array
+    ]
+
+###############################################################################
+## @brief Ray tracing acceleration structure builder geometry info
+class ze_rtas_builder_geometry_info_exp_t(Structure):
+    _fields_ = [
+        ("geometryType", ze_rtas_builder_packed_geometry_type_exp_t)    ## [in] geometry type
+    ]
+
+###############################################################################
+## @brief Ray tracing acceleration structure builder triangle mesh geometry info
+## 
+## @details
+##     - The linear barycentric u/v parametrization of the triangle is defined as:
+##          - (u=0, v=0) at v0,
+##          - (u=1, v=0) at v1, and
+##          - (u=0, v=1) at v2
+class ze_rtas_builder_triangles_geometry_info_exp_t(Structure):
+    _fields_ = [
+        ("geometryType", ze_rtas_builder_packed_geometry_type_exp_t),   ## [in] geometry type, must be
+                                                                        ## ::ZE_RTAS_BUILDER_GEOMETRY_TYPE_EXP_TRIANGLES
+        ("geometryFlags", ze_rtas_builder_packed_geometry_exp_flags_t), ## [in] 0 or some combination of ::ze_rtas_builder_geometry_exp_flag_t
+                                                                        ## bits representing the geometry flags for all primitives of this
+                                                                        ## geometry
+        ("geometryMask", c_ubyte),                                      ## [in] 8-bit geometry mask for ray masking
+        ("triangleFormat", ze_rtas_builder_packed_input_data_format_exp_t), ## [in] format of triangle buffer data, must be
+                                                                        ## ::ZE_RTAS_BUILDER_INPUT_DATA_FORMAT_EXP_TRIANGLE_INDICES_UINT32
+        ("vertexFormat", ze_rtas_builder_packed_input_data_format_exp_t),   ## [in] format of vertex buffer data, must be
+                                                                        ## ::ZE_RTAS_BUILDER_INPUT_DATA_FORMAT_EXP_FLOAT3
+        ("triangleCount", c_ulong),                                     ## [in] number of triangles in triangle buffer
+        ("vertexCount", c_ulong),                                       ## [in] number of vertices in vertex buffer
+        ("triangleStride", c_ulong),                                    ## [in] stride (in bytes) of triangles in triangle buffer
+        ("vertexStride", c_ulong),                                      ## [in] stride (in bytes) of vertices in vertex buffer
+        ("pTriangleBuffer", c_void_p),                                  ## [in] pointer to array of triangle indices in specified format
+        ("pVertexBuffer", c_void_p)                                     ## [in] pointer to array of triangle vertices in specified format
+    ]
+
+###############################################################################
+## @brief Ray tracing acceleration structure builder quad mesh geometry info
+## 
+## @details
+##     - A quad is a triangle pair represented using 4 vertex indices v0, v1,
+##       v2, v3.
+##       The first triangle is made out of indices v0, v1, v3 and the second triangle
+##       from indices v2, v3, v1. The piecewise linear barycentric u/v parametrization
+##       of the quad is defined as:
+##          - (u=0, v=0) at v0,
+##          - (u=1, v=0) at v1,
+##          - (u=0, v=1) at v3, and
+##          - (u=1, v=1) at v2
+##       This is achieved by correcting the u'/v' coordinates of the second
+##       triangle by
+##       *u = 1-u'* and *v = 1-v'*, yielding a piecewise linear parametrization.
+class ze_rtas_builder_quads_geometry_info_exp_t(Structure):
+    _fields_ = [
+        ("geometryType", ze_rtas_builder_packed_geometry_type_exp_t),   ## [in] geometry type, must be ::ZE_RTAS_BUILDER_GEOMETRY_TYPE_EXP_QUADS
+        ("geometryFlags", ze_rtas_builder_packed_geometry_exp_flags_t), ## [in] 0 or some combination of ::ze_rtas_builder_geometry_exp_flag_t
+                                                                        ## bits representing the geometry flags for all primitives of this
+                                                                        ## geometry
+        ("geometryMask", c_ubyte),                                      ## [in] 8-bit geometry mask for ray masking
+        ("quadFormat", ze_rtas_builder_packed_input_data_format_exp_t), ## [in] format of quad buffer data, must be
+                                                                        ## ::ZE_RTAS_BUILDER_INPUT_DATA_FORMAT_EXP_QUAD_INDICES_UINT32
+        ("vertexFormat", ze_rtas_builder_packed_input_data_format_exp_t),   ## [in] format of vertex buffer data, must be
+                                                                        ## ::ZE_RTAS_BUILDER_INPUT_DATA_FORMAT_EXP_FLOAT3
+        ("quadCount", c_ulong),                                         ## [in] number of quads in quad buffer
+        ("vertexCount", c_ulong),                                       ## [in] number of vertices in vertex buffer
+        ("quadStride", c_ulong),                                        ## [in] stride (in bytes) of quads in quad buffer
+        ("vertexStride", c_ulong),                                      ## [in] stride (in bytes) of vertices in vertex buffer
+        ("pQuadBuffer", c_void_p),                                      ## [in] pointer to array of quad indices in specified format
+        ("pVertexBuffer", c_void_p)                                     ## [in] pointer to array of quad vertices in specified format
+    ]
+
+###############################################################################
+## @brief AABB callback function parameters
+class ze_rtas_geometry_aabbs_exp_cb_params_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("primID", c_ulong),                                            ## [in] first primitive to return bounds for
+        ("primIDCount", c_ulong),                                       ## [in] number of primitives to return bounds for
+        ("pGeomUserPtr", c_void_p),                                     ## [in] pointer provided through geometry descriptor
+        ("pBuildUserPtr", c_void_p),                                    ## [in] pointer provided through ::zeRTASBuilderBuildExp function
+        ("pBoundsOut", POINTER(ze_rtas_aabb_exp_t))                     ## [out] destination buffer to write AABB bounds to
+    ]
+
+###############################################################################
+## @brief Callback function pointer type to return AABBs for a range of
+##        procedural primitives
+
+###############################################################################
+## @brief Ray tracing acceleration structure builder procedural primitives
+##        geometry info
+## 
+## @details
+##     - A host-side bounds callback function is invoked by the acceleration
+##       structure builder to query the bounds of procedural primitives on
+##       demand. The callback is passed some `pGeomUserPtr` that can point to
+##       an application-side representation of the procedural primitives.
+##       Further, a second `pBuildUserPtr`, which is set by a parameter to
+##       ::zeRTASBuilderBuildExp, is passed to the callback. This allows the
+##       build to change the bounds of the procedural geometry, for example, to
+##       build a BVH only over a short time range to implement multi-segment
+##       motion blur.
+class ze_rtas_builder_procedural_geometry_info_exp_t(Structure):
+    _fields_ = [
+        ("geometryType", ze_rtas_builder_packed_geometry_type_exp_t),   ## [in] geometry type, must be
+                                                                        ## ::ZE_RTAS_BUILDER_GEOMETRY_TYPE_EXP_PROCEDURAL
+        ("geometryFlags", ze_rtas_builder_packed_geometry_exp_flags_t), ## [in] 0 or some combination of ::ze_rtas_builder_geometry_exp_flag_t
+                                                                        ## bits representing the geometry flags for all primitives of this
+                                                                        ## geometry
+        ("geometryMask", c_ubyte),                                      ## [in] 8-bit geometry mask for ray masking
+        ("reserved", c_ubyte),                                          ## [in] reserved for future use
+        ("primCount", c_ulong),                                         ## [in] number of primitives in geometry
+        ("pfnGetBoundsCb", ze_rtas_geometry_aabbs_cb_exp_t),            ## [in] pointer to callback function to get the axis-aligned bounding-box
+                                                                        ## for a range of primitives
+        ("pGeomUserPtr", c_void_p)                                      ## [in] user data pointer passed to callback
+    ]
+
+###############################################################################
+## @brief Ray tracing acceleration structure builder instance geometry info
+class ze_rtas_builder_instance_geometry_info_exp_t(Structure):
+    _fields_ = [
+        ("geometryType", ze_rtas_builder_packed_geometry_type_exp_t),   ## [in] geometry type, must be
+                                                                        ## ::ZE_RTAS_BUILDER_GEOMETRY_TYPE_EXP_INSTANCE
+        ("instanceFlags", ze_rtas_builder_packed_instance_exp_flags_t), ## [in] 0 or some combination of ::ze_rtas_builder_geometry_exp_flag_t
+                                                                        ## bits representing the geometry flags for all primitives of this
+                                                                        ## geometry
+        ("geometryMask", c_ubyte),                                      ## [in] 8-bit geometry mask for ray masking
+        ("transformFormat", ze_rtas_builder_packed_input_data_format_exp_t),## [in] format of the specified transformation
+        ("instanceUserID", c_ulong),                                    ## [in] user-specified identifier for the instance
+        ("pTransform", c_void_p),                                       ## [in] object-to-world instance transformation in specified format
+        ("pBounds", POINTER(ze_rtas_aabb_exp_t)),                       ## [in] object-space axis-aligned bounding-box of the instanced
+                                                                        ## acceleration structure
+        ("pAccelerationStructure", c_void_p)                            ## [in] pointer to acceleration structure to instantiate
+    ]
+
+###############################################################################
+## @brief 
+class ze_rtas_builder_build_op_exp_desc_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("rtasFormat", ze_rtas_format_exp_t),                           ## [in] ray tracing acceleration structure format
+        ("buildQuality", ze_rtas_builder_build_quality_hint_exp_t),     ## [in] acceleration structure build quality hint
+        ("buildFlags", ze_rtas_builder_build_op_exp_flags_t),           ## [in] 0 or some combination of ::ze_rtas_builder_build_op_exp_flag_t
+                                                                        ## flags
+        ("ppGeometries", POINTER(ze_rtas_builder_geometry_info_exp_t*)),## [in][optional][range(0, `numGeometries`)] NULL or a valid array of
+                                                                        ## pointers to geometry infos
+        ("numGeometries", c_ulong)                                      ## [in] number of geometries in geometry infos array, can be zero when
+                                                                        ## `ppGeometries` is NULL
+    ]
+
+###############################################################################
+## @brief Counter-based Event Pools Extension Name
+ZE_EVENT_POOL_COUNTER_BASED_EXP_NAME = "ZE_experimental_event_pool_counter_based"
+
+###############################################################################
+## @brief Counter-based Event Pools Extension Version(s)
+class ze_event_pool_counter_based_exp_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class ze_event_pool_counter_based_exp_version_t(c_int):
+    def __str__(self):
+        return str(ze_event_pool_counter_based_exp_version_v(self.value))
+
+
+###############################################################################
+## @brief Supported event flags for defining counter-based event pools.
+class ze_event_pool_counter_based_exp_flags_v(IntEnum):
+    IMMEDIATE = ZE_BIT(0)                                                   ## Counter-based event pool is used for immediate command lists (default)
+    NON_IMMEDIATE = ZE_BIT(1)                                               ## Counter-based event pool is for non-immediate command lists
+
+class ze_event_pool_counter_based_exp_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Event pool descriptor for counter-based events. This structure may be
+##        passed to ::zeEventPoolCreate as pNext member of
+##        ::ze_event_pool_desc_t.
+class ze_event_pool_counter_based_exp_desc_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("flags", ze_event_pool_counter_based_exp_flags_t)              ## [in] mode flags.
+                                                                        ## must be 0 (default) or a valid value of ::ze_event_pool_counter_based_exp_flag_t
+                                                                        ## default behavior is counter-based event pool is only used for
+                                                                        ## immediate command lists.
+    ]
+
+###############################################################################
+## @brief Image Memory Properties Extension Name
+ZE_BINDLESS_IMAGE_EXP_NAME = "ZE_experimental_bindless_image"
+
+###############################################################################
+## @brief Bindless Image Extension Version(s)
+class ze_bindless_image_exp_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class ze_bindless_image_exp_version_t(c_int):
+    def __str__(self):
+        return str(ze_bindless_image_exp_version_v(self.value))
+
+
+###############################################################################
+## @brief Image flags for Bindless images
+class ze_image_bindless_exp_flags_v(IntEnum):
+    BINDLESS = ZE_BIT(0)                                                    ## Bindless images are created with ::zeImageCreate. The image handle
+                                                                            ## created with this flag is valid on both host and device.
+    SAMPLED_IMAGE = ZE_BIT(1)                                               ## Bindless sampled images are created with ::zeImageCreate by combining
+                                                                            ## BINDLESS and SAMPLED_IMAGE.
+                                                                            ## Create sampled image view from bindless unsampled image using SAMPLED_IMAGE.
+
+class ze_image_bindless_exp_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Image descriptor for bindless images. This structure may be passed to
+##        ::zeImageCreate via pNext member of ::ze_image_desc_t.
+class ze_image_bindless_exp_desc_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("flags", ze_image_bindless_exp_flags_t)                        ## [in] image flags.
+                                                                        ## must be 0 (default) or a valid value of ::ze_image_bindless_exp_flag_t
+                                                                        ## default behavior is bindless images are not used when creating handles
+                                                                        ## via ::zeImageCreate.
+                                                                        ## When the flag is passed to ::zeImageCreate, then only the memory for
+                                                                        ## the image is allocated.
+                                                                        ## Additional image handles can be created with ::zeImageViewCreateExt.
+                                                                        ## When ::ZE_IMAGE_BINDLESS_EXP_FLAG_SAMPLED_IMAGE flag is passed,
+                                                                        ## ::ze_sampler_desc_t must be attached via pNext member of ::ze_image_bindless_exp_desc_t.
+    ]
+
+###############################################################################
+## @brief Image descriptor for bindless images created from pitched allocations.
+##        This structure may be passed to ::zeImageCreate via pNext member of
+##        ::ze_image_desc_t.
+class ze_image_pitched_exp_desc_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("ptr", c_void_p)                                               ## [in] pointer to pitched device allocation allocated using ::zeMemAllocDevice
+    ]
+
+###############################################################################
+## @brief Device specific properties for pitched allocations
+## 
+## @details
+##     - This structure may be passed to ::zeDeviceGetImageProperties via the
+##       pNext member of ::ze_device_image_properties_t.
+class ze_device_pitched_alloc_exp_properties_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("maxImageLinearWidth", c_size_t),                              ## [out] Maximum image linear width.
+        ("maxImageLinearHeight", c_size_t)                              ## [out] Maximum image linear height.
+    ]
+
+###############################################################################
+## @brief Command List Clone Extension Name
+ZE_COMMAND_LIST_CLONE_EXP_NAME = "ZE_experimental_command_list_clone"
+
+###############################################################################
+## @brief Command List Clone Extension Version(s)
+class ze_command_list_clone_exp_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class ze_command_list_clone_exp_version_t(c_int):
+    def __str__(self):
+        return str(ze_command_list_clone_exp_version_v(self.value))
+
+
+###############################################################################
+## @brief Immediate Command List Append Extension Name
+ZE_IMMEDIATE_COMMAND_LIST_APPEND_EXP_NAME = "ZE_experimental_immediate_command_list_append"
+
+###############################################################################
+## @brief Immediate Command List Append Extension Version(s)
+class ze_immediate_command_list_append_exp_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class ze_immediate_command_list_append_exp_version_t(c_int):
+    def __str__(self):
+        return str(ze_immediate_command_list_append_exp_version_v(self.value))
+
+
+###############################################################################
+## @brief Mutable Command List Extension Name
+ZE_MUTABLE_COMMAND_LIST_EXP_NAME = "ZE_experimental_mutable_command_list"
+
+###############################################################################
+## @brief Mutable Command List Extension Version(s)
+class ze_mutable_command_list_exp_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    _1_1 = ZE_MAKE_VERSION( 1, 1 )                                          ## version 1.1
+    CURRENT = ZE_MAKE_VERSION( 1, 1 )                                       ## latest known version
+
+class ze_mutable_command_list_exp_version_t(c_int):
+    def __str__(self):
+        return str(ze_mutable_command_list_exp_version_v(self.value))
+
+
+###############################################################################
+## @brief Mutable command flags
+class ze_mutable_command_exp_flags_v(IntEnum):
+    KERNEL_ARGUMENTS = ZE_BIT(0)                                            ## kernel arguments
+    GROUP_COUNT = ZE_BIT(1)                                                 ## kernel group count
+    GROUP_SIZE = ZE_BIT(2)                                                  ## kernel group size
+    GLOBAL_OFFSET = ZE_BIT(3)                                               ## kernel global offset
+    SIGNAL_EVENT = ZE_BIT(4)                                                ## command signal event
+    WAIT_EVENTS = ZE_BIT(5)                                                 ## command wait events
+    KERNEL_INSTRUCTION = ZE_BIT(6)                                          ## command kernel
+    GRAPH_ARGUMENTS = ZE_BIT(7)                                             ## graph arguments
+
+class ze_mutable_command_exp_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Mutable command identifier descriptor
+class ze_mutable_command_id_exp_desc_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("flags", ze_mutable_command_exp_flags_t)                       ## [in] mutable command flags.
+                                                                        ##  - must be 0 (default, equivalent to setting all flags bar kernel
+                                                                        ## instruction), or a valid combination of ::ze_mutable_command_exp_flag_t
+                                                                        ##  - in order to include kernel instruction mutation,
+                                                                        ## ::ZE_MUTABLE_COMMAND_EXP_FLAG_KERNEL_INSTRUCTION must be explictly included
+    ]
+
+###############################################################################
+## @brief Mutable command list flags
+class ze_mutable_command_list_exp_flags_v(IntEnum):
+    RESERVED = ZE_BIT(0)                                                    ## reserved
+
+class ze_mutable_command_list_exp_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Mutable command list properties
+class ze_mutable_command_list_exp_properties_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("mutableCommandListFlags", ze_mutable_command_list_exp_flags_t),   ## [out] mutable command list flags
+        ("mutableCommandFlags", ze_mutable_command_exp_flags_t)         ## [out] mutable command flags
+    ]
+
+###############################################################################
+## @brief Mutable command list descriptor
+class ze_mutable_command_list_exp_desc_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("flags", ze_mutable_command_list_exp_flags_t)                  ## [in] mutable command list flags.
+                                                                        ##  - must be 0 (default) or a valid combination of ::ze_mutable_command_list_exp_flag_t
+    ]
+
+###############################################################################
+## @brief Mutable commands descriptor
+class ze_mutable_commands_exp_desc_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("flags", c_ulong)                                              ## [in] must be 0, this field is reserved for future use
+    ]
+
+###############################################################################
+## @brief Mutable kernel argument descriptor
+class ze_mutable_kernel_argument_exp_desc_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("commandId", c_ulonglong),                                     ## [in] command identifier
+        ("argIndex", c_ulong),                                          ## [in] kernel argument index
+        ("argSize", c_size_t),                                          ## [in] kernel argument size
+        ("pArgValue", c_void_p)                                         ## [in] pointer to kernel argument value
+    ]
+
+###############################################################################
+## @brief Mutable kernel group count descriptor
+class ze_mutable_group_count_exp_desc_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("commandId", c_ulonglong),                                     ## [in] command identifier
+        ("pGroupCount", POINTER(ze_group_count_t))                      ## [in] pointer to group count
+    ]
+
+###############################################################################
+## @brief Mutable kernel group size descriptor
+class ze_mutable_group_size_exp_desc_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("commandId", c_ulonglong),                                     ## [in] command identifier
+        ("groupSizeX", c_ulong),                                        ## [in] group size for X dimension to use for the kernel
+        ("groupSizeY", c_ulong),                                        ## [in] group size for Y dimension to use for the kernel
+        ("groupSizeZ", c_ulong)                                         ## [in] group size for Z dimension to use for the kernel
+    ]
+
+###############################################################################
+## @brief Mutable kernel global offset descriptor
+class ze_mutable_global_offset_exp_desc_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("commandId", c_ulonglong),                                     ## [in] command identifier
+        ("offsetX", c_ulong),                                           ## [in] global offset for X dimension to use for this kernel
+        ("offsetY", c_ulong),                                           ## [in] global offset for Y dimension to use for this kernel
+        ("offsetZ", c_ulong)                                            ## [in] global offset for Z dimension to use for this kernel
+    ]
+
+###############################################################################
+## @brief Mutable graph argument descriptor
+class ze_mutable_graph_argument_exp_desc_t(Structure):
+    _fields_ = [
+        ("stype", ze_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("commandId", c_ulonglong),                                     ## [in] command identifier
+        ("argIndex", c_ulong),                                          ## [in] graph argument index
+        ("pArgValue", c_void_p)                                         ## [in] pointer to graph argument value
+    ]
+
+###############################################################################
+__use_win_types = "Windows" == platform.uname()[0]
+
+###############################################################################
+## @brief Function-pointer for zeRTASBuilderCreateExp
+if __use_win_types:
+    _zeRTASBuilderCreateExp_t = WINFUNCTYPE( ze_result_t, ze_driver_handle_t, POINTER(ze_rtas_builder_exp_desc_t), POINTER(ze_rtas_builder_exp_handle_t) )
+else:
+    _zeRTASBuilderCreateExp_t = CFUNCTYPE( ze_result_t, ze_driver_handle_t, POINTER(ze_rtas_builder_exp_desc_t), POINTER(ze_rtas_builder_exp_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeRTASBuilderGetBuildPropertiesExp
+if __use_win_types:
+    _zeRTASBuilderGetBuildPropertiesExp_t = WINFUNCTYPE( ze_result_t, ze_rtas_builder_exp_handle_t, POINTER(ze_rtas_builder_build_op_exp_desc_t), POINTER(ze_rtas_builder_exp_properties_t) )
+else:
+    _zeRTASBuilderGetBuildPropertiesExp_t = CFUNCTYPE( ze_result_t, ze_rtas_builder_exp_handle_t, POINTER(ze_rtas_builder_build_op_exp_desc_t), POINTER(ze_rtas_builder_exp_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zeRTASBuilderBuildExp
+if __use_win_types:
+    _zeRTASBuilderBuildExp_t = WINFUNCTYPE( ze_result_t, ze_rtas_builder_exp_handle_t, POINTER(ze_rtas_builder_build_op_exp_desc_t), c_void_p, c_size_t, c_void_p, c_size_t, ze_rtas_parallel_operation_exp_handle_t, c_void_p, POINTER(ze_rtas_aabb_exp_t), POINTER(c_size_t) )
+else:
+    _zeRTASBuilderBuildExp_t = CFUNCTYPE( ze_result_t, ze_rtas_builder_exp_handle_t, POINTER(ze_rtas_builder_build_op_exp_desc_t), c_void_p, c_size_t, c_void_p, c_size_t, ze_rtas_parallel_operation_exp_handle_t, c_void_p, POINTER(ze_rtas_aabb_exp_t), POINTER(c_size_t) )
+
+###############################################################################
+## @brief Function-pointer for zeRTASBuilderDestroyExp
+if __use_win_types:
+    _zeRTASBuilderDestroyExp_t = WINFUNCTYPE( ze_result_t, ze_rtas_builder_exp_handle_t )
+else:
+    _zeRTASBuilderDestroyExp_t = CFUNCTYPE( ze_result_t, ze_rtas_builder_exp_handle_t )
+
+
+###############################################################################
+## @brief Table of RTASBuilderExp functions pointers
+class _ze_rtas_builder_exp_dditable_t(Structure):
+    _fields_ = [
+        ("pfnCreateExp", c_void_p),                                     ## _zeRTASBuilderCreateExp_t
+        ("pfnGetBuildPropertiesExp", c_void_p),                         ## _zeRTASBuilderGetBuildPropertiesExp_t
+        ("pfnBuildExp", c_void_p),                                      ## _zeRTASBuilderBuildExp_t
+        ("pfnDestroyExp", c_void_p)                                     ## _zeRTASBuilderDestroyExp_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zeRTASParallelOperationCreateExp
+if __use_win_types:
+    _zeRTASParallelOperationCreateExp_t = WINFUNCTYPE( ze_result_t, ze_driver_handle_t, POINTER(ze_rtas_parallel_operation_exp_handle_t) )
+else:
+    _zeRTASParallelOperationCreateExp_t = CFUNCTYPE( ze_result_t, ze_driver_handle_t, POINTER(ze_rtas_parallel_operation_exp_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeRTASParallelOperationGetPropertiesExp
+if __use_win_types:
+    _zeRTASParallelOperationGetPropertiesExp_t = WINFUNCTYPE( ze_result_t, ze_rtas_parallel_operation_exp_handle_t, POINTER(ze_rtas_parallel_operation_exp_properties_t) )
+else:
+    _zeRTASParallelOperationGetPropertiesExp_t = CFUNCTYPE( ze_result_t, ze_rtas_parallel_operation_exp_handle_t, POINTER(ze_rtas_parallel_operation_exp_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zeRTASParallelOperationJoinExp
+if __use_win_types:
+    _zeRTASParallelOperationJoinExp_t = WINFUNCTYPE( ze_result_t, ze_rtas_parallel_operation_exp_handle_t )
+else:
+    _zeRTASParallelOperationJoinExp_t = CFUNCTYPE( ze_result_t, ze_rtas_parallel_operation_exp_handle_t )
+
+###############################################################################
+## @brief Function-pointer for zeRTASParallelOperationDestroyExp
+if __use_win_types:
+    _zeRTASParallelOperationDestroyExp_t = WINFUNCTYPE( ze_result_t, ze_rtas_parallel_operation_exp_handle_t )
+else:
+    _zeRTASParallelOperationDestroyExp_t = CFUNCTYPE( ze_result_t, ze_rtas_parallel_operation_exp_handle_t )
+
+
+###############################################################################
+## @brief Table of RTASParallelOperationExp functions pointers
+class _ze_rtas_parallel_operation_exp_dditable_t(Structure):
+    _fields_ = [
+        ("pfnCreateExp", c_void_p),                                     ## _zeRTASParallelOperationCreateExp_t
+        ("pfnGetPropertiesExp", c_void_p),                              ## _zeRTASParallelOperationGetPropertiesExp_t
+        ("pfnJoinExp", c_void_p),                                       ## _zeRTASParallelOperationJoinExp_t
+        ("pfnDestroyExp", c_void_p)                                     ## _zeRTASParallelOperationDestroyExp_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zeInit
+if __use_win_types:
+    _zeInit_t = WINFUNCTYPE( ze_result_t, ze_init_flags_t )
+else:
+    _zeInit_t = CFUNCTYPE( ze_result_t, ze_init_flags_t )
+
+###############################################################################
+## @brief Function-pointer for zeInitDrivers
+if __use_win_types:
+    _zeInitDrivers_t = WINFUNCTYPE( ze_result_t, POINTER(c_ulong), POINTER(ze_driver_handle_t), POINTER(ze_init_driver_type_desc_t) )
+else:
+    _zeInitDrivers_t = CFUNCTYPE( ze_result_t, POINTER(c_ulong), POINTER(ze_driver_handle_t), POINTER(ze_init_driver_type_desc_t) )
+
+
+###############################################################################
+## @brief Table of Global functions pointers
+class _ze_global_dditable_t(Structure):
+    _fields_ = [
+        ("pfnInit", c_void_p),                                          ## _zeInit_t
+        ("pfnInitDrivers", c_void_p)                                    ## _zeInitDrivers_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zeDriverGet
+if __use_win_types:
+    _zeDriverGet_t = WINFUNCTYPE( ze_result_t, POINTER(c_ulong), POINTER(ze_driver_handle_t) )
+else:
+    _zeDriverGet_t = CFUNCTYPE( ze_result_t, POINTER(c_ulong), POINTER(ze_driver_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeDriverGetApiVersion
+if __use_win_types:
+    _zeDriverGetApiVersion_t = WINFUNCTYPE( ze_result_t, ze_driver_handle_t, POINTER(ze_api_version_t) )
+else:
+    _zeDriverGetApiVersion_t = CFUNCTYPE( ze_result_t, ze_driver_handle_t, POINTER(ze_api_version_t) )
+
+###############################################################################
+## @brief Function-pointer for zeDriverGetProperties
+if __use_win_types:
+    _zeDriverGetProperties_t = WINFUNCTYPE( ze_result_t, ze_driver_handle_t, POINTER(ze_driver_properties_t) )
+else:
+    _zeDriverGetProperties_t = CFUNCTYPE( ze_result_t, ze_driver_handle_t, POINTER(ze_driver_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zeDriverGetIpcProperties
+if __use_win_types:
+    _zeDriverGetIpcProperties_t = WINFUNCTYPE( ze_result_t, ze_driver_handle_t, POINTER(ze_driver_ipc_properties_t) )
+else:
+    _zeDriverGetIpcProperties_t = CFUNCTYPE( ze_result_t, ze_driver_handle_t, POINTER(ze_driver_ipc_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zeDriverGetExtensionProperties
+if __use_win_types:
+    _zeDriverGetExtensionProperties_t = WINFUNCTYPE( ze_result_t, ze_driver_handle_t, POINTER(c_ulong), POINTER(ze_driver_extension_properties_t) )
+else:
+    _zeDriverGetExtensionProperties_t = CFUNCTYPE( ze_result_t, ze_driver_handle_t, POINTER(c_ulong), POINTER(ze_driver_extension_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zeDriverGetExtensionFunctionAddress
+if __use_win_types:
+    _zeDriverGetExtensionFunctionAddress_t = WINFUNCTYPE( ze_result_t, ze_driver_handle_t, c_char_p, POINTER(c_void_p) )
+else:
+    _zeDriverGetExtensionFunctionAddress_t = CFUNCTYPE( ze_result_t, ze_driver_handle_t, c_char_p, POINTER(c_void_p) )
+
+###############################################################################
+## @brief Function-pointer for zeDriverGetLastErrorDescription
+if __use_win_types:
+    _zeDriverGetLastErrorDescription_t = WINFUNCTYPE( ze_result_t, ze_driver_handle_t, POINTER(c_char_p) )
+else:
+    _zeDriverGetLastErrorDescription_t = CFUNCTYPE( ze_result_t, ze_driver_handle_t, POINTER(c_char_p) )
+
+
+###############################################################################
+## @brief Table of Driver functions pointers
+class _ze_driver_dditable_t(Structure):
+    _fields_ = [
+        ("pfnGet", c_void_p),                                           ## _zeDriverGet_t
+        ("pfnGetApiVersion", c_void_p),                                 ## _zeDriverGetApiVersion_t
+        ("pfnGetProperties", c_void_p),                                 ## _zeDriverGetProperties_t
+        ("pfnGetIpcProperties", c_void_p),                              ## _zeDriverGetIpcProperties_t
+        ("pfnGetExtensionProperties", c_void_p),                        ## _zeDriverGetExtensionProperties_t
+        ("pfnGetExtensionFunctionAddress", c_void_p),                   ## _zeDriverGetExtensionFunctionAddress_t
+        ("pfnGetLastErrorDescription", c_void_p)                        ## _zeDriverGetLastErrorDescription_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zeDriverRTASFormatCompatibilityCheckExp
+if __use_win_types:
+    _zeDriverRTASFormatCompatibilityCheckExp_t = WINFUNCTYPE( ze_result_t, ze_driver_handle_t, ze_rtas_format_exp_t, ze_rtas_format_exp_t )
+else:
+    _zeDriverRTASFormatCompatibilityCheckExp_t = CFUNCTYPE( ze_result_t, ze_driver_handle_t, ze_rtas_format_exp_t, ze_rtas_format_exp_t )
+
+
+###############################################################################
+## @brief Table of DriverExp functions pointers
+class _ze_driver_exp_dditable_t(Structure):
+    _fields_ = [
+        ("pfnRTASFormatCompatibilityCheckExp", c_void_p)                ## _zeDriverRTASFormatCompatibilityCheckExp_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zeDeviceGet
+if __use_win_types:
+    _zeDeviceGet_t = WINFUNCTYPE( ze_result_t, ze_driver_handle_t, POINTER(c_ulong), POINTER(ze_device_handle_t) )
+else:
+    _zeDeviceGet_t = CFUNCTYPE( ze_result_t, ze_driver_handle_t, POINTER(c_ulong), POINTER(ze_device_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeDeviceGetSubDevices
+if __use_win_types:
+    _zeDeviceGetSubDevices_t = WINFUNCTYPE( ze_result_t, ze_device_handle_t, POINTER(c_ulong), POINTER(ze_device_handle_t) )
+else:
+    _zeDeviceGetSubDevices_t = CFUNCTYPE( ze_result_t, ze_device_handle_t, POINTER(c_ulong), POINTER(ze_device_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeDeviceGetProperties
+if __use_win_types:
+    _zeDeviceGetProperties_t = WINFUNCTYPE( ze_result_t, ze_device_handle_t, POINTER(ze_device_properties_t) )
+else:
+    _zeDeviceGetProperties_t = CFUNCTYPE( ze_result_t, ze_device_handle_t, POINTER(ze_device_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zeDeviceGetComputeProperties
+if __use_win_types:
+    _zeDeviceGetComputeProperties_t = WINFUNCTYPE( ze_result_t, ze_device_handle_t, POINTER(ze_device_compute_properties_t) )
+else:
+    _zeDeviceGetComputeProperties_t = CFUNCTYPE( ze_result_t, ze_device_handle_t, POINTER(ze_device_compute_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zeDeviceGetModuleProperties
+if __use_win_types:
+    _zeDeviceGetModuleProperties_t = WINFUNCTYPE( ze_result_t, ze_device_handle_t, POINTER(ze_device_module_properties_t) )
+else:
+    _zeDeviceGetModuleProperties_t = CFUNCTYPE( ze_result_t, ze_device_handle_t, POINTER(ze_device_module_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zeDeviceGetCommandQueueGroupProperties
+if __use_win_types:
+    _zeDeviceGetCommandQueueGroupProperties_t = WINFUNCTYPE( ze_result_t, ze_device_handle_t, POINTER(c_ulong), POINTER(ze_command_queue_group_properties_t) )
+else:
+    _zeDeviceGetCommandQueueGroupProperties_t = CFUNCTYPE( ze_result_t, ze_device_handle_t, POINTER(c_ulong), POINTER(ze_command_queue_group_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zeDeviceGetMemoryProperties
+if __use_win_types:
+    _zeDeviceGetMemoryProperties_t = WINFUNCTYPE( ze_result_t, ze_device_handle_t, POINTER(c_ulong), POINTER(ze_device_memory_properties_t) )
+else:
+    _zeDeviceGetMemoryProperties_t = CFUNCTYPE( ze_result_t, ze_device_handle_t, POINTER(c_ulong), POINTER(ze_device_memory_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zeDeviceGetMemoryAccessProperties
+if __use_win_types:
+    _zeDeviceGetMemoryAccessProperties_t = WINFUNCTYPE( ze_result_t, ze_device_handle_t, POINTER(ze_device_memory_access_properties_t) )
+else:
+    _zeDeviceGetMemoryAccessProperties_t = CFUNCTYPE( ze_result_t, ze_device_handle_t, POINTER(ze_device_memory_access_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zeDeviceGetCacheProperties
+if __use_win_types:
+    _zeDeviceGetCacheProperties_t = WINFUNCTYPE( ze_result_t, ze_device_handle_t, POINTER(c_ulong), POINTER(ze_device_cache_properties_t) )
+else:
+    _zeDeviceGetCacheProperties_t = CFUNCTYPE( ze_result_t, ze_device_handle_t, POINTER(c_ulong), POINTER(ze_device_cache_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zeDeviceGetImageProperties
+if __use_win_types:
+    _zeDeviceGetImageProperties_t = WINFUNCTYPE( ze_result_t, ze_device_handle_t, POINTER(ze_device_image_properties_t) )
+else:
+    _zeDeviceGetImageProperties_t = CFUNCTYPE( ze_result_t, ze_device_handle_t, POINTER(ze_device_image_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zeDeviceGetExternalMemoryProperties
+if __use_win_types:
+    _zeDeviceGetExternalMemoryProperties_t = WINFUNCTYPE( ze_result_t, ze_device_handle_t, POINTER(ze_device_external_memory_properties_t) )
+else:
+    _zeDeviceGetExternalMemoryProperties_t = CFUNCTYPE( ze_result_t, ze_device_handle_t, POINTER(ze_device_external_memory_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zeDeviceGetP2PProperties
+if __use_win_types:
+    _zeDeviceGetP2PProperties_t = WINFUNCTYPE( ze_result_t, ze_device_handle_t, ze_device_handle_t, POINTER(ze_device_p2p_properties_t) )
+else:
+    _zeDeviceGetP2PProperties_t = CFUNCTYPE( ze_result_t, ze_device_handle_t, ze_device_handle_t, POINTER(ze_device_p2p_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zeDeviceCanAccessPeer
+if __use_win_types:
+    _zeDeviceCanAccessPeer_t = WINFUNCTYPE( ze_result_t, ze_device_handle_t, ze_device_handle_t, POINTER(ze_bool_t) )
+else:
+    _zeDeviceCanAccessPeer_t = CFUNCTYPE( ze_result_t, ze_device_handle_t, ze_device_handle_t, POINTER(ze_bool_t) )
+
+###############################################################################
+## @brief Function-pointer for zeDeviceGetStatus
+if __use_win_types:
+    _zeDeviceGetStatus_t = WINFUNCTYPE( ze_result_t, ze_device_handle_t )
+else:
+    _zeDeviceGetStatus_t = CFUNCTYPE( ze_result_t, ze_device_handle_t )
+
+###############################################################################
+## @brief Function-pointer for zeDeviceGetGlobalTimestamps
+if __use_win_types:
+    _zeDeviceGetGlobalTimestamps_t = WINFUNCTYPE( ze_result_t, ze_device_handle_t, POINTER(c_ulonglong), POINTER(c_ulonglong) )
+else:
+    _zeDeviceGetGlobalTimestamps_t = CFUNCTYPE( ze_result_t, ze_device_handle_t, POINTER(c_ulonglong), POINTER(c_ulonglong) )
+
+###############################################################################
+## @brief Function-pointer for zeDeviceReserveCacheExt
+if __use_win_types:
+    _zeDeviceReserveCacheExt_t = WINFUNCTYPE( ze_result_t, ze_device_handle_t, c_size_t, c_size_t )
+else:
+    _zeDeviceReserveCacheExt_t = CFUNCTYPE( ze_result_t, ze_device_handle_t, c_size_t, c_size_t )
+
+###############################################################################
+## @brief Function-pointer for zeDeviceSetCacheAdviceExt
+if __use_win_types:
+    _zeDeviceSetCacheAdviceExt_t = WINFUNCTYPE( ze_result_t, ze_device_handle_t, c_void_p, c_size_t, ze_cache_ext_region_t )
+else:
+    _zeDeviceSetCacheAdviceExt_t = CFUNCTYPE( ze_result_t, ze_device_handle_t, c_void_p, c_size_t, ze_cache_ext_region_t )
+
+###############################################################################
+## @brief Function-pointer for zeDevicePciGetPropertiesExt
+if __use_win_types:
+    _zeDevicePciGetPropertiesExt_t = WINFUNCTYPE( ze_result_t, ze_device_handle_t, POINTER(ze_pci_ext_properties_t) )
+else:
+    _zeDevicePciGetPropertiesExt_t = CFUNCTYPE( ze_result_t, ze_device_handle_t, POINTER(ze_pci_ext_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zeDeviceGetRootDevice
+if __use_win_types:
+    _zeDeviceGetRootDevice_t = WINFUNCTYPE( ze_result_t, ze_device_handle_t, POINTER(ze_device_handle_t) )
+else:
+    _zeDeviceGetRootDevice_t = CFUNCTYPE( ze_result_t, ze_device_handle_t, POINTER(ze_device_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeDeviceImportExternalSemaphoreExt
+if __use_win_types:
+    _zeDeviceImportExternalSemaphoreExt_t = WINFUNCTYPE( ze_result_t, ze_device_handle_t, POINTER(ze_external_semaphore_ext_desc_t), POINTER(ze_external_semaphore_ext_handle_t) )
+else:
+    _zeDeviceImportExternalSemaphoreExt_t = CFUNCTYPE( ze_result_t, ze_device_handle_t, POINTER(ze_external_semaphore_ext_desc_t), POINTER(ze_external_semaphore_ext_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeDeviceReleaseExternalSemaphoreExt
+if __use_win_types:
+    _zeDeviceReleaseExternalSemaphoreExt_t = WINFUNCTYPE( ze_result_t, ze_external_semaphore_ext_handle_t )
+else:
+    _zeDeviceReleaseExternalSemaphoreExt_t = CFUNCTYPE( ze_result_t, ze_external_semaphore_ext_handle_t )
+
+
+###############################################################################
+## @brief Table of Device functions pointers
+class _ze_device_dditable_t(Structure):
+    _fields_ = [
+        ("pfnGet", c_void_p),                                           ## _zeDeviceGet_t
+        ("pfnGetSubDevices", c_void_p),                                 ## _zeDeviceGetSubDevices_t
+        ("pfnGetProperties", c_void_p),                                 ## _zeDeviceGetProperties_t
+        ("pfnGetComputeProperties", c_void_p),                          ## _zeDeviceGetComputeProperties_t
+        ("pfnGetModuleProperties", c_void_p),                           ## _zeDeviceGetModuleProperties_t
+        ("pfnGetCommandQueueGroupProperties", c_void_p),                ## _zeDeviceGetCommandQueueGroupProperties_t
+        ("pfnGetMemoryProperties", c_void_p),                           ## _zeDeviceGetMemoryProperties_t
+        ("pfnGetMemoryAccessProperties", c_void_p),                     ## _zeDeviceGetMemoryAccessProperties_t
+        ("pfnGetCacheProperties", c_void_p),                            ## _zeDeviceGetCacheProperties_t
+        ("pfnGetImageProperties", c_void_p),                            ## _zeDeviceGetImageProperties_t
+        ("pfnGetExternalMemoryProperties", c_void_p),                   ## _zeDeviceGetExternalMemoryProperties_t
+        ("pfnGetP2PProperties", c_void_p),                              ## _zeDeviceGetP2PProperties_t
+        ("pfnCanAccessPeer", c_void_p),                                 ## _zeDeviceCanAccessPeer_t
+        ("pfnGetStatus", c_void_p),                                     ## _zeDeviceGetStatus_t
+        ("pfnGetGlobalTimestamps", c_void_p),                           ## _zeDeviceGetGlobalTimestamps_t
+        ("pfnReserveCacheExt", c_void_p),                               ## _zeDeviceReserveCacheExt_t
+        ("pfnSetCacheAdviceExt", c_void_p),                             ## _zeDeviceSetCacheAdviceExt_t
+        ("pfnPciGetPropertiesExt", c_void_p),                           ## _zeDevicePciGetPropertiesExt_t
+        ("pfnGetRootDevice", c_void_p),                                 ## _zeDeviceGetRootDevice_t
+        ("pfnImportExternalSemaphoreExt", c_void_p),                    ## _zeDeviceImportExternalSemaphoreExt_t
+        ("pfnReleaseExternalSemaphoreExt", c_void_p)                    ## _zeDeviceReleaseExternalSemaphoreExt_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zeDeviceGetFabricVertexExp
+if __use_win_types:
+    _zeDeviceGetFabricVertexExp_t = WINFUNCTYPE( ze_result_t, ze_device_handle_t, POINTER(ze_fabric_vertex_handle_t) )
+else:
+    _zeDeviceGetFabricVertexExp_t = CFUNCTYPE( ze_result_t, ze_device_handle_t, POINTER(ze_fabric_vertex_handle_t) )
+
+
+###############################################################################
+## @brief Table of DeviceExp functions pointers
+class _ze_device_exp_dditable_t(Structure):
+    _fields_ = [
+        ("pfnGetFabricVertexExp", c_void_p)                             ## _zeDeviceGetFabricVertexExp_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zeContextCreate
+if __use_win_types:
+    _zeContextCreate_t = WINFUNCTYPE( ze_result_t, ze_driver_handle_t, POINTER(ze_context_desc_t), POINTER(ze_context_handle_t) )
+else:
+    _zeContextCreate_t = CFUNCTYPE( ze_result_t, ze_driver_handle_t, POINTER(ze_context_desc_t), POINTER(ze_context_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeContextDestroy
+if __use_win_types:
+    _zeContextDestroy_t = WINFUNCTYPE( ze_result_t, ze_context_handle_t )
+else:
+    _zeContextDestroy_t = CFUNCTYPE( ze_result_t, ze_context_handle_t )
+
+###############################################################################
+## @brief Function-pointer for zeContextGetStatus
+if __use_win_types:
+    _zeContextGetStatus_t = WINFUNCTYPE( ze_result_t, ze_context_handle_t )
+else:
+    _zeContextGetStatus_t = CFUNCTYPE( ze_result_t, ze_context_handle_t )
+
+###############################################################################
+## @brief Function-pointer for zeContextSystemBarrier
+if __use_win_types:
+    _zeContextSystemBarrier_t = WINFUNCTYPE( ze_result_t, ze_context_handle_t, ze_device_handle_t )
+else:
+    _zeContextSystemBarrier_t = CFUNCTYPE( ze_result_t, ze_context_handle_t, ze_device_handle_t )
+
+###############################################################################
+## @brief Function-pointer for zeContextMakeMemoryResident
+if __use_win_types:
+    _zeContextMakeMemoryResident_t = WINFUNCTYPE( ze_result_t, ze_context_handle_t, ze_device_handle_t, c_void_p, c_size_t )
+else:
+    _zeContextMakeMemoryResident_t = CFUNCTYPE( ze_result_t, ze_context_handle_t, ze_device_handle_t, c_void_p, c_size_t )
+
+###############################################################################
+## @brief Function-pointer for zeContextEvictMemory
+if __use_win_types:
+    _zeContextEvictMemory_t = WINFUNCTYPE( ze_result_t, ze_context_handle_t, ze_device_handle_t, c_void_p, c_size_t )
+else:
+    _zeContextEvictMemory_t = CFUNCTYPE( ze_result_t, ze_context_handle_t, ze_device_handle_t, c_void_p, c_size_t )
+
+###############################################################################
+## @brief Function-pointer for zeContextMakeImageResident
+if __use_win_types:
+    _zeContextMakeImageResident_t = WINFUNCTYPE( ze_result_t, ze_context_handle_t, ze_device_handle_t, ze_image_handle_t )
+else:
+    _zeContextMakeImageResident_t = CFUNCTYPE( ze_result_t, ze_context_handle_t, ze_device_handle_t, ze_image_handle_t )
+
+###############################################################################
+## @brief Function-pointer for zeContextEvictImage
+if __use_win_types:
+    _zeContextEvictImage_t = WINFUNCTYPE( ze_result_t, ze_context_handle_t, ze_device_handle_t, ze_image_handle_t )
+else:
+    _zeContextEvictImage_t = CFUNCTYPE( ze_result_t, ze_context_handle_t, ze_device_handle_t, ze_image_handle_t )
+
+###############################################################################
+## @brief Function-pointer for zeContextCreateEx
+if __use_win_types:
+    _zeContextCreateEx_t = WINFUNCTYPE( ze_result_t, ze_driver_handle_t, POINTER(ze_context_desc_t), c_ulong, POINTER(ze_device_handle_t), POINTER(ze_context_handle_t) )
+else:
+    _zeContextCreateEx_t = CFUNCTYPE( ze_result_t, ze_driver_handle_t, POINTER(ze_context_desc_t), c_ulong, POINTER(ze_device_handle_t), POINTER(ze_context_handle_t) )
+
+
+###############################################################################
+## @brief Table of Context functions pointers
+class _ze_context_dditable_t(Structure):
+    _fields_ = [
+        ("pfnCreate", c_void_p),                                        ## _zeContextCreate_t
+        ("pfnDestroy", c_void_p),                                       ## _zeContextDestroy_t
+        ("pfnGetStatus", c_void_p),                                     ## _zeContextGetStatus_t
+        ("pfnSystemBarrier", c_void_p),                                 ## _zeContextSystemBarrier_t
+        ("pfnMakeMemoryResident", c_void_p),                            ## _zeContextMakeMemoryResident_t
+        ("pfnEvictMemory", c_void_p),                                   ## _zeContextEvictMemory_t
+        ("pfnMakeImageResident", c_void_p),                             ## _zeContextMakeImageResident_t
+        ("pfnEvictImage", c_void_p),                                    ## _zeContextEvictImage_t
+        ("pfnCreateEx", c_void_p)                                       ## _zeContextCreateEx_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zeCommandQueueCreate
+if __use_win_types:
+    _zeCommandQueueCreate_t = WINFUNCTYPE( ze_result_t, ze_context_handle_t, ze_device_handle_t, POINTER(ze_command_queue_desc_t), POINTER(ze_command_queue_handle_t) )
+else:
+    _zeCommandQueueCreate_t = CFUNCTYPE( ze_result_t, ze_context_handle_t, ze_device_handle_t, POINTER(ze_command_queue_desc_t), POINTER(ze_command_queue_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeCommandQueueDestroy
+if __use_win_types:
+    _zeCommandQueueDestroy_t = WINFUNCTYPE( ze_result_t, ze_command_queue_handle_t )
+else:
+    _zeCommandQueueDestroy_t = CFUNCTYPE( ze_result_t, ze_command_queue_handle_t )
+
+###############################################################################
+## @brief Function-pointer for zeCommandQueueExecuteCommandLists
+if __use_win_types:
+    _zeCommandQueueExecuteCommandLists_t = WINFUNCTYPE( ze_result_t, ze_command_queue_handle_t, c_ulong, POINTER(ze_command_list_handle_t), ze_fence_handle_t )
+else:
+    _zeCommandQueueExecuteCommandLists_t = CFUNCTYPE( ze_result_t, ze_command_queue_handle_t, c_ulong, POINTER(ze_command_list_handle_t), ze_fence_handle_t )
+
+###############################################################################
+## @brief Function-pointer for zeCommandQueueSynchronize
+if __use_win_types:
+    _zeCommandQueueSynchronize_t = WINFUNCTYPE( ze_result_t, ze_command_queue_handle_t, c_ulonglong )
+else:
+    _zeCommandQueueSynchronize_t = CFUNCTYPE( ze_result_t, ze_command_queue_handle_t, c_ulonglong )
+
+###############################################################################
+## @brief Function-pointer for zeCommandQueueGetOrdinal
+if __use_win_types:
+    _zeCommandQueueGetOrdinal_t = WINFUNCTYPE( ze_result_t, ze_command_queue_handle_t, POINTER(c_ulong) )
+else:
+    _zeCommandQueueGetOrdinal_t = CFUNCTYPE( ze_result_t, ze_command_queue_handle_t, POINTER(c_ulong) )
+
+###############################################################################
+## @brief Function-pointer for zeCommandQueueGetIndex
+if __use_win_types:
+    _zeCommandQueueGetIndex_t = WINFUNCTYPE( ze_result_t, ze_command_queue_handle_t, POINTER(c_ulong) )
+else:
+    _zeCommandQueueGetIndex_t = CFUNCTYPE( ze_result_t, ze_command_queue_handle_t, POINTER(c_ulong) )
+
+
+###############################################################################
+## @brief Table of CommandQueue functions pointers
+class _ze_command_queue_dditable_t(Structure):
+    _fields_ = [
+        ("pfnCreate", c_void_p),                                        ## _zeCommandQueueCreate_t
+        ("pfnDestroy", c_void_p),                                       ## _zeCommandQueueDestroy_t
+        ("pfnExecuteCommandLists", c_void_p),                           ## _zeCommandQueueExecuteCommandLists_t
+        ("pfnSynchronize", c_void_p),                                   ## _zeCommandQueueSynchronize_t
+        ("pfnGetOrdinal", c_void_p),                                    ## _zeCommandQueueGetOrdinal_t
+        ("pfnGetIndex", c_void_p)                                       ## _zeCommandQueueGetIndex_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zeCommandListCreate
+if __use_win_types:
+    _zeCommandListCreate_t = WINFUNCTYPE( ze_result_t, ze_context_handle_t, ze_device_handle_t, POINTER(ze_command_list_desc_t), POINTER(ze_command_list_handle_t) )
+else:
+    _zeCommandListCreate_t = CFUNCTYPE( ze_result_t, ze_context_handle_t, ze_device_handle_t, POINTER(ze_command_list_desc_t), POINTER(ze_command_list_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeCommandListCreateImmediate
+if __use_win_types:
+    _zeCommandListCreateImmediate_t = WINFUNCTYPE( ze_result_t, ze_context_handle_t, ze_device_handle_t, POINTER(ze_command_queue_desc_t), POINTER(ze_command_list_handle_t) )
+else:
+    _zeCommandListCreateImmediate_t = CFUNCTYPE( ze_result_t, ze_context_handle_t, ze_device_handle_t, POINTER(ze_command_queue_desc_t), POINTER(ze_command_list_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeCommandListDestroy
+if __use_win_types:
+    _zeCommandListDestroy_t = WINFUNCTYPE( ze_result_t, ze_command_list_handle_t )
+else:
+    _zeCommandListDestroy_t = CFUNCTYPE( ze_result_t, ze_command_list_handle_t )
+
+###############################################################################
+## @brief Function-pointer for zeCommandListClose
+if __use_win_types:
+    _zeCommandListClose_t = WINFUNCTYPE( ze_result_t, ze_command_list_handle_t )
+else:
+    _zeCommandListClose_t = CFUNCTYPE( ze_result_t, ze_command_list_handle_t )
+
+###############################################################################
+## @brief Function-pointer for zeCommandListReset
+if __use_win_types:
+    _zeCommandListReset_t = WINFUNCTYPE( ze_result_t, ze_command_list_handle_t )
+else:
+    _zeCommandListReset_t = CFUNCTYPE( ze_result_t, ze_command_list_handle_t )
+
+###############################################################################
+## @brief Function-pointer for zeCommandListAppendWriteGlobalTimestamp
+if __use_win_types:
+    _zeCommandListAppendWriteGlobalTimestamp_t = WINFUNCTYPE( ze_result_t, ze_command_list_handle_t, POINTER(c_ulonglong), ze_event_handle_t, c_ulong, POINTER(ze_event_handle_t) )
+else:
+    _zeCommandListAppendWriteGlobalTimestamp_t = CFUNCTYPE( ze_result_t, ze_command_list_handle_t, POINTER(c_ulonglong), ze_event_handle_t, c_ulong, POINTER(ze_event_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeCommandListAppendBarrier
+if __use_win_types:
+    _zeCommandListAppendBarrier_t = WINFUNCTYPE( ze_result_t, ze_command_list_handle_t, ze_event_handle_t, c_ulong, POINTER(ze_event_handle_t) )
+else:
+    _zeCommandListAppendBarrier_t = CFUNCTYPE( ze_result_t, ze_command_list_handle_t, ze_event_handle_t, c_ulong, POINTER(ze_event_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeCommandListAppendMemoryRangesBarrier
+if __use_win_types:
+    _zeCommandListAppendMemoryRangesBarrier_t = WINFUNCTYPE( ze_result_t, ze_command_list_handle_t, c_ulong, POINTER(c_size_t), POINTER(c_void_p), ze_event_handle_t, c_ulong, POINTER(ze_event_handle_t) )
+else:
+    _zeCommandListAppendMemoryRangesBarrier_t = CFUNCTYPE( ze_result_t, ze_command_list_handle_t, c_ulong, POINTER(c_size_t), POINTER(c_void_p), ze_event_handle_t, c_ulong, POINTER(ze_event_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeCommandListAppendMemoryCopy
+if __use_win_types:
+    _zeCommandListAppendMemoryCopy_t = WINFUNCTYPE( ze_result_t, ze_command_list_handle_t, c_void_p, c_void_p, c_size_t, ze_event_handle_t, c_ulong, POINTER(ze_event_handle_t) )
+else:
+    _zeCommandListAppendMemoryCopy_t = CFUNCTYPE( ze_result_t, ze_command_list_handle_t, c_void_p, c_void_p, c_size_t, ze_event_handle_t, c_ulong, POINTER(ze_event_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeCommandListAppendMemoryFill
+if __use_win_types:
+    _zeCommandListAppendMemoryFill_t = WINFUNCTYPE( ze_result_t, ze_command_list_handle_t, c_void_p, c_void_p, c_size_t, c_size_t, ze_event_handle_t, c_ulong, POINTER(ze_event_handle_t) )
+else:
+    _zeCommandListAppendMemoryFill_t = CFUNCTYPE( ze_result_t, ze_command_list_handle_t, c_void_p, c_void_p, c_size_t, c_size_t, ze_event_handle_t, c_ulong, POINTER(ze_event_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeCommandListAppendMemoryCopyRegion
+if __use_win_types:
+    _zeCommandListAppendMemoryCopyRegion_t = WINFUNCTYPE( ze_result_t, ze_command_list_handle_t, c_void_p, POINTER(ze_copy_region_t), c_ulong, c_ulong, c_void_p, POINTER(ze_copy_region_t), c_ulong, c_ulong, ze_event_handle_t, c_ulong, POINTER(ze_event_handle_t) )
+else:
+    _zeCommandListAppendMemoryCopyRegion_t = CFUNCTYPE( ze_result_t, ze_command_list_handle_t, c_void_p, POINTER(ze_copy_region_t), c_ulong, c_ulong, c_void_p, POINTER(ze_copy_region_t), c_ulong, c_ulong, ze_event_handle_t, c_ulong, POINTER(ze_event_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeCommandListAppendMemoryCopyFromContext
+if __use_win_types:
+    _zeCommandListAppendMemoryCopyFromContext_t = WINFUNCTYPE( ze_result_t, ze_command_list_handle_t, c_void_p, ze_context_handle_t, c_void_p, c_size_t, ze_event_handle_t, c_ulong, POINTER(ze_event_handle_t) )
+else:
+    _zeCommandListAppendMemoryCopyFromContext_t = CFUNCTYPE( ze_result_t, ze_command_list_handle_t, c_void_p, ze_context_handle_t, c_void_p, c_size_t, ze_event_handle_t, c_ulong, POINTER(ze_event_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeCommandListAppendImageCopy
+if __use_win_types:
+    _zeCommandListAppendImageCopy_t = WINFUNCTYPE( ze_result_t, ze_command_list_handle_t, ze_image_handle_t, ze_image_handle_t, ze_event_handle_t, c_ulong, POINTER(ze_event_handle_t) )
+else:
+    _zeCommandListAppendImageCopy_t = CFUNCTYPE( ze_result_t, ze_command_list_handle_t, ze_image_handle_t, ze_image_handle_t, ze_event_handle_t, c_ulong, POINTER(ze_event_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeCommandListAppendImageCopyRegion
+if __use_win_types:
+    _zeCommandListAppendImageCopyRegion_t = WINFUNCTYPE( ze_result_t, ze_command_list_handle_t, ze_image_handle_t, ze_image_handle_t, POINTER(ze_image_region_t), POINTER(ze_image_region_t), ze_event_handle_t, c_ulong, POINTER(ze_event_handle_t) )
+else:
+    _zeCommandListAppendImageCopyRegion_t = CFUNCTYPE( ze_result_t, ze_command_list_handle_t, ze_image_handle_t, ze_image_handle_t, POINTER(ze_image_region_t), POINTER(ze_image_region_t), ze_event_handle_t, c_ulong, POINTER(ze_event_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeCommandListAppendImageCopyToMemory
+if __use_win_types:
+    _zeCommandListAppendImageCopyToMemory_t = WINFUNCTYPE( ze_result_t, ze_command_list_handle_t, c_void_p, ze_image_handle_t, POINTER(ze_image_region_t), ze_event_handle_t, c_ulong, POINTER(ze_event_handle_t) )
+else:
+    _zeCommandListAppendImageCopyToMemory_t = CFUNCTYPE( ze_result_t, ze_command_list_handle_t, c_void_p, ze_image_handle_t, POINTER(ze_image_region_t), ze_event_handle_t, c_ulong, POINTER(ze_event_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeCommandListAppendImageCopyFromMemory
+if __use_win_types:
+    _zeCommandListAppendImageCopyFromMemory_t = WINFUNCTYPE( ze_result_t, ze_command_list_handle_t, ze_image_handle_t, c_void_p, POINTER(ze_image_region_t), ze_event_handle_t, c_ulong, POINTER(ze_event_handle_t) )
+else:
+    _zeCommandListAppendImageCopyFromMemory_t = CFUNCTYPE( ze_result_t, ze_command_list_handle_t, ze_image_handle_t, c_void_p, POINTER(ze_image_region_t), ze_event_handle_t, c_ulong, POINTER(ze_event_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeCommandListAppendMemoryPrefetch
+if __use_win_types:
+    _zeCommandListAppendMemoryPrefetch_t = WINFUNCTYPE( ze_result_t, ze_command_list_handle_t, c_void_p, c_size_t )
+else:
+    _zeCommandListAppendMemoryPrefetch_t = CFUNCTYPE( ze_result_t, ze_command_list_handle_t, c_void_p, c_size_t )
+
+###############################################################################
+## @brief Function-pointer for zeCommandListAppendMemAdvise
+if __use_win_types:
+    _zeCommandListAppendMemAdvise_t = WINFUNCTYPE( ze_result_t, ze_command_list_handle_t, ze_device_handle_t, c_void_p, c_size_t, ze_memory_advice_t )
+else:
+    _zeCommandListAppendMemAdvise_t = CFUNCTYPE( ze_result_t, ze_command_list_handle_t, ze_device_handle_t, c_void_p, c_size_t, ze_memory_advice_t )
+
+###############################################################################
+## @brief Function-pointer for zeCommandListAppendSignalEvent
+if __use_win_types:
+    _zeCommandListAppendSignalEvent_t = WINFUNCTYPE( ze_result_t, ze_command_list_handle_t, ze_event_handle_t )
+else:
+    _zeCommandListAppendSignalEvent_t = CFUNCTYPE( ze_result_t, ze_command_list_handle_t, ze_event_handle_t )
+
+###############################################################################
+## @brief Function-pointer for zeCommandListAppendWaitOnEvents
+if __use_win_types:
+    _zeCommandListAppendWaitOnEvents_t = WINFUNCTYPE( ze_result_t, ze_command_list_handle_t, c_ulong, POINTER(ze_event_handle_t) )
+else:
+    _zeCommandListAppendWaitOnEvents_t = CFUNCTYPE( ze_result_t, ze_command_list_handle_t, c_ulong, POINTER(ze_event_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeCommandListAppendEventReset
+if __use_win_types:
+    _zeCommandListAppendEventReset_t = WINFUNCTYPE( ze_result_t, ze_command_list_handle_t, ze_event_handle_t )
+else:
+    _zeCommandListAppendEventReset_t = CFUNCTYPE( ze_result_t, ze_command_list_handle_t, ze_event_handle_t )
+
+###############################################################################
+## @brief Function-pointer for zeCommandListAppendQueryKernelTimestamps
+if __use_win_types:
+    _zeCommandListAppendQueryKernelTimestamps_t = WINFUNCTYPE( ze_result_t, ze_command_list_handle_t, c_ulong, POINTER(ze_event_handle_t), c_void_p, POINTER(c_size_t), ze_event_handle_t, c_ulong, POINTER(ze_event_handle_t) )
+else:
+    _zeCommandListAppendQueryKernelTimestamps_t = CFUNCTYPE( ze_result_t, ze_command_list_handle_t, c_ulong, POINTER(ze_event_handle_t), c_void_p, POINTER(c_size_t), ze_event_handle_t, c_ulong, POINTER(ze_event_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeCommandListAppendLaunchKernel
+if __use_win_types:
+    _zeCommandListAppendLaunchKernel_t = WINFUNCTYPE( ze_result_t, ze_command_list_handle_t, ze_kernel_handle_t, POINTER(ze_group_count_t), ze_event_handle_t, c_ulong, POINTER(ze_event_handle_t) )
+else:
+    _zeCommandListAppendLaunchKernel_t = CFUNCTYPE( ze_result_t, ze_command_list_handle_t, ze_kernel_handle_t, POINTER(ze_group_count_t), ze_event_handle_t, c_ulong, POINTER(ze_event_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeCommandListAppendLaunchCooperativeKernel
+if __use_win_types:
+    _zeCommandListAppendLaunchCooperativeKernel_t = WINFUNCTYPE( ze_result_t, ze_command_list_handle_t, ze_kernel_handle_t, POINTER(ze_group_count_t), ze_event_handle_t, c_ulong, POINTER(ze_event_handle_t) )
+else:
+    _zeCommandListAppendLaunchCooperativeKernel_t = CFUNCTYPE( ze_result_t, ze_command_list_handle_t, ze_kernel_handle_t, POINTER(ze_group_count_t), ze_event_handle_t, c_ulong, POINTER(ze_event_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeCommandListAppendLaunchKernelIndirect
+if __use_win_types:
+    _zeCommandListAppendLaunchKernelIndirect_t = WINFUNCTYPE( ze_result_t, ze_command_list_handle_t, ze_kernel_handle_t, POINTER(ze_group_count_t), ze_event_handle_t, c_ulong, POINTER(ze_event_handle_t) )
+else:
+    _zeCommandListAppendLaunchKernelIndirect_t = CFUNCTYPE( ze_result_t, ze_command_list_handle_t, ze_kernel_handle_t, POINTER(ze_group_count_t), ze_event_handle_t, c_ulong, POINTER(ze_event_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeCommandListAppendLaunchMultipleKernelsIndirect
+if __use_win_types:
+    _zeCommandListAppendLaunchMultipleKernelsIndirect_t = WINFUNCTYPE( ze_result_t, ze_command_list_handle_t, c_ulong, POINTER(ze_kernel_handle_t), POINTER(c_ulong), POINTER(ze_group_count_t), ze_event_handle_t, c_ulong, POINTER(ze_event_handle_t) )
+else:
+    _zeCommandListAppendLaunchMultipleKernelsIndirect_t = CFUNCTYPE( ze_result_t, ze_command_list_handle_t, c_ulong, POINTER(ze_kernel_handle_t), POINTER(c_ulong), POINTER(ze_group_count_t), ze_event_handle_t, c_ulong, POINTER(ze_event_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeCommandListAppendImageCopyToMemoryExt
+if __use_win_types:
+    _zeCommandListAppendImageCopyToMemoryExt_t = WINFUNCTYPE( ze_result_t, ze_command_list_handle_t, c_void_p, ze_image_handle_t, POINTER(ze_image_region_t), c_ulong, c_ulong, ze_event_handle_t, c_ulong, POINTER(ze_event_handle_t) )
+else:
+    _zeCommandListAppendImageCopyToMemoryExt_t = CFUNCTYPE( ze_result_t, ze_command_list_handle_t, c_void_p, ze_image_handle_t, POINTER(ze_image_region_t), c_ulong, c_ulong, ze_event_handle_t, c_ulong, POINTER(ze_event_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeCommandListAppendImageCopyFromMemoryExt
+if __use_win_types:
+    _zeCommandListAppendImageCopyFromMemoryExt_t = WINFUNCTYPE( ze_result_t, ze_command_list_handle_t, ze_image_handle_t, c_void_p, POINTER(ze_image_region_t), c_ulong, c_ulong, ze_event_handle_t, c_ulong, POINTER(ze_event_handle_t) )
+else:
+    _zeCommandListAppendImageCopyFromMemoryExt_t = CFUNCTYPE( ze_result_t, ze_command_list_handle_t, ze_image_handle_t, c_void_p, POINTER(ze_image_region_t), c_ulong, c_ulong, ze_event_handle_t, c_ulong, POINTER(ze_event_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeCommandListHostSynchronize
+if __use_win_types:
+    _zeCommandListHostSynchronize_t = WINFUNCTYPE( ze_result_t, ze_command_list_handle_t, c_ulonglong )
+else:
+    _zeCommandListHostSynchronize_t = CFUNCTYPE( ze_result_t, ze_command_list_handle_t, c_ulonglong )
+
+###############################################################################
+## @brief Function-pointer for zeCommandListGetDeviceHandle
+if __use_win_types:
+    _zeCommandListGetDeviceHandle_t = WINFUNCTYPE( ze_result_t, ze_command_list_handle_t, POINTER(ze_device_handle_t) )
+else:
+    _zeCommandListGetDeviceHandle_t = CFUNCTYPE( ze_result_t, ze_command_list_handle_t, POINTER(ze_device_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeCommandListGetContextHandle
+if __use_win_types:
+    _zeCommandListGetContextHandle_t = WINFUNCTYPE( ze_result_t, ze_command_list_handle_t, POINTER(ze_context_handle_t) )
+else:
+    _zeCommandListGetContextHandle_t = CFUNCTYPE( ze_result_t, ze_command_list_handle_t, POINTER(ze_context_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeCommandListGetOrdinal
+if __use_win_types:
+    _zeCommandListGetOrdinal_t = WINFUNCTYPE( ze_result_t, ze_command_list_handle_t, POINTER(c_ulong) )
+else:
+    _zeCommandListGetOrdinal_t = CFUNCTYPE( ze_result_t, ze_command_list_handle_t, POINTER(c_ulong) )
+
+###############################################################################
+## @brief Function-pointer for zeCommandListImmediateGetIndex
+if __use_win_types:
+    _zeCommandListImmediateGetIndex_t = WINFUNCTYPE( ze_result_t, ze_command_list_handle_t, POINTER(c_ulong) )
+else:
+    _zeCommandListImmediateGetIndex_t = CFUNCTYPE( ze_result_t, ze_command_list_handle_t, POINTER(c_ulong) )
+
+###############################################################################
+## @brief Function-pointer for zeCommandListIsImmediate
+if __use_win_types:
+    _zeCommandListIsImmediate_t = WINFUNCTYPE( ze_result_t, ze_command_list_handle_t, POINTER(ze_bool_t) )
+else:
+    _zeCommandListIsImmediate_t = CFUNCTYPE( ze_result_t, ze_command_list_handle_t, POINTER(ze_bool_t) )
+
+###############################################################################
+## @brief Function-pointer for zeCommandListAppendSignalExternalSemaphoreExt
+if __use_win_types:
+    _zeCommandListAppendSignalExternalSemaphoreExt_t = WINFUNCTYPE( ze_result_t, ze_command_list_handle_t, c_ulong, POINTER(ze_external_semaphore_ext_handle_t), POINTER(ze_external_semaphore_signal_params_ext_t), ze_event_handle_t, c_ulong, POINTER(ze_event_handle_t) )
+else:
+    _zeCommandListAppendSignalExternalSemaphoreExt_t = CFUNCTYPE( ze_result_t, ze_command_list_handle_t, c_ulong, POINTER(ze_external_semaphore_ext_handle_t), POINTER(ze_external_semaphore_signal_params_ext_t), ze_event_handle_t, c_ulong, POINTER(ze_event_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeCommandListAppendWaitExternalSemaphoreExt
+if __use_win_types:
+    _zeCommandListAppendWaitExternalSemaphoreExt_t = WINFUNCTYPE( ze_result_t, ze_command_list_handle_t, c_ulong, POINTER(ze_external_semaphore_ext_handle_t), POINTER(ze_external_semaphore_wait_params_ext_t), ze_event_handle_t, c_ulong, POINTER(ze_event_handle_t) )
+else:
+    _zeCommandListAppendWaitExternalSemaphoreExt_t = CFUNCTYPE( ze_result_t, ze_command_list_handle_t, c_ulong, POINTER(ze_external_semaphore_ext_handle_t), POINTER(ze_external_semaphore_wait_params_ext_t), ze_event_handle_t, c_ulong, POINTER(ze_event_handle_t) )
+
+
+###############################################################################
+## @brief Table of CommandList functions pointers
+class _ze_command_list_dditable_t(Structure):
+    _fields_ = [
+        ("pfnCreate", c_void_p),                                        ## _zeCommandListCreate_t
+        ("pfnCreateImmediate", c_void_p),                               ## _zeCommandListCreateImmediate_t
+        ("pfnDestroy", c_void_p),                                       ## _zeCommandListDestroy_t
+        ("pfnClose", c_void_p),                                         ## _zeCommandListClose_t
+        ("pfnReset", c_void_p),                                         ## _zeCommandListReset_t
+        ("pfnAppendWriteGlobalTimestamp", c_void_p),                    ## _zeCommandListAppendWriteGlobalTimestamp_t
+        ("pfnAppendBarrier", c_void_p),                                 ## _zeCommandListAppendBarrier_t
+        ("pfnAppendMemoryRangesBarrier", c_void_p),                     ## _zeCommandListAppendMemoryRangesBarrier_t
+        ("pfnAppendMemoryCopy", c_void_p),                              ## _zeCommandListAppendMemoryCopy_t
+        ("pfnAppendMemoryFill", c_void_p),                              ## _zeCommandListAppendMemoryFill_t
+        ("pfnAppendMemoryCopyRegion", c_void_p),                        ## _zeCommandListAppendMemoryCopyRegion_t
+        ("pfnAppendMemoryCopyFromContext", c_void_p),                   ## _zeCommandListAppendMemoryCopyFromContext_t
+        ("pfnAppendImageCopy", c_void_p),                               ## _zeCommandListAppendImageCopy_t
+        ("pfnAppendImageCopyRegion", c_void_p),                         ## _zeCommandListAppendImageCopyRegion_t
+        ("pfnAppendImageCopyToMemory", c_void_p),                       ## _zeCommandListAppendImageCopyToMemory_t
+        ("pfnAppendImageCopyFromMemory", c_void_p),                     ## _zeCommandListAppendImageCopyFromMemory_t
+        ("pfnAppendMemoryPrefetch", c_void_p),                          ## _zeCommandListAppendMemoryPrefetch_t
+        ("pfnAppendMemAdvise", c_void_p),                               ## _zeCommandListAppendMemAdvise_t
+        ("pfnAppendSignalEvent", c_void_p),                             ## _zeCommandListAppendSignalEvent_t
+        ("pfnAppendWaitOnEvents", c_void_p),                            ## _zeCommandListAppendWaitOnEvents_t
+        ("pfnAppendEventReset", c_void_p),                              ## _zeCommandListAppendEventReset_t
+        ("pfnAppendQueryKernelTimestamps", c_void_p),                   ## _zeCommandListAppendQueryKernelTimestamps_t
+        ("pfnAppendLaunchKernel", c_void_p),                            ## _zeCommandListAppendLaunchKernel_t
+        ("pfnAppendLaunchCooperativeKernel", c_void_p),                 ## _zeCommandListAppendLaunchCooperativeKernel_t
+        ("pfnAppendLaunchKernelIndirect", c_void_p),                    ## _zeCommandListAppendLaunchKernelIndirect_t
+        ("pfnAppendLaunchMultipleKernelsIndirect", c_void_p),           ## _zeCommandListAppendLaunchMultipleKernelsIndirect_t
+        ("pfnAppendImageCopyToMemoryExt", c_void_p),                    ## _zeCommandListAppendImageCopyToMemoryExt_t
+        ("pfnAppendImageCopyFromMemoryExt", c_void_p),                  ## _zeCommandListAppendImageCopyFromMemoryExt_t
+        ("pfnHostSynchronize", c_void_p),                               ## _zeCommandListHostSynchronize_t
+        ("pfnGetDeviceHandle", c_void_p),                               ## _zeCommandListGetDeviceHandle_t
+        ("pfnGetContextHandle", c_void_p),                              ## _zeCommandListGetContextHandle_t
+        ("pfnGetOrdinal", c_void_p),                                    ## _zeCommandListGetOrdinal_t
+        ("pfnImmediateGetIndex", c_void_p),                             ## _zeCommandListImmediateGetIndex_t
+        ("pfnIsImmediate", c_void_p),                                   ## _zeCommandListIsImmediate_t
+        ("pfnAppendSignalExternalSemaphoreExt", c_void_p),              ## _zeCommandListAppendSignalExternalSemaphoreExt_t
+        ("pfnAppendWaitExternalSemaphoreExt", c_void_p)                 ## _zeCommandListAppendWaitExternalSemaphoreExt_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zeCommandListCreateCloneExp
+if __use_win_types:
+    _zeCommandListCreateCloneExp_t = WINFUNCTYPE( ze_result_t, ze_command_list_handle_t, POINTER(ze_command_list_handle_t) )
+else:
+    _zeCommandListCreateCloneExp_t = CFUNCTYPE( ze_result_t, ze_command_list_handle_t, POINTER(ze_command_list_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeCommandListImmediateAppendCommandListsExp
+if __use_win_types:
+    _zeCommandListImmediateAppendCommandListsExp_t = WINFUNCTYPE( ze_result_t, ze_command_list_handle_t, c_ulong, POINTER(ze_command_list_handle_t), ze_event_handle_t, c_ulong, POINTER(ze_event_handle_t) )
+else:
+    _zeCommandListImmediateAppendCommandListsExp_t = CFUNCTYPE( ze_result_t, ze_command_list_handle_t, c_ulong, POINTER(ze_command_list_handle_t), ze_event_handle_t, c_ulong, POINTER(ze_event_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeCommandListGetNextCommandIdExp
+if __use_win_types:
+    _zeCommandListGetNextCommandIdExp_t = WINFUNCTYPE( ze_result_t, ze_command_list_handle_t, POINTER(ze_mutable_command_id_exp_desc_t), POINTER(c_ulonglong) )
+else:
+    _zeCommandListGetNextCommandIdExp_t = CFUNCTYPE( ze_result_t, ze_command_list_handle_t, POINTER(ze_mutable_command_id_exp_desc_t), POINTER(c_ulonglong) )
+
+###############################################################################
+## @brief Function-pointer for zeCommandListUpdateMutableCommandsExp
+if __use_win_types:
+    _zeCommandListUpdateMutableCommandsExp_t = WINFUNCTYPE( ze_result_t, ze_command_list_handle_t, POINTER(ze_mutable_commands_exp_desc_t) )
+else:
+    _zeCommandListUpdateMutableCommandsExp_t = CFUNCTYPE( ze_result_t, ze_command_list_handle_t, POINTER(ze_mutable_commands_exp_desc_t) )
+
+###############################################################################
+## @brief Function-pointer for zeCommandListUpdateMutableCommandSignalEventExp
+if __use_win_types:
+    _zeCommandListUpdateMutableCommandSignalEventExp_t = WINFUNCTYPE( ze_result_t, ze_command_list_handle_t, c_ulonglong, ze_event_handle_t )
+else:
+    _zeCommandListUpdateMutableCommandSignalEventExp_t = CFUNCTYPE( ze_result_t, ze_command_list_handle_t, c_ulonglong, ze_event_handle_t )
+
+###############################################################################
+## @brief Function-pointer for zeCommandListUpdateMutableCommandWaitEventsExp
+if __use_win_types:
+    _zeCommandListUpdateMutableCommandWaitEventsExp_t = WINFUNCTYPE( ze_result_t, ze_command_list_handle_t, c_ulonglong, c_ulong, POINTER(ze_event_handle_t) )
+else:
+    _zeCommandListUpdateMutableCommandWaitEventsExp_t = CFUNCTYPE( ze_result_t, ze_command_list_handle_t, c_ulonglong, c_ulong, POINTER(ze_event_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeCommandListGetNextCommandIdWithKernelsExp
+if __use_win_types:
+    _zeCommandListGetNextCommandIdWithKernelsExp_t = WINFUNCTYPE( ze_result_t, ze_command_list_handle_t, POINTER(ze_mutable_command_id_exp_desc_t), c_ulong, POINTER(ze_kernel_handle_t), POINTER(c_ulonglong) )
+else:
+    _zeCommandListGetNextCommandIdWithKernelsExp_t = CFUNCTYPE( ze_result_t, ze_command_list_handle_t, POINTER(ze_mutable_command_id_exp_desc_t), c_ulong, POINTER(ze_kernel_handle_t), POINTER(c_ulonglong) )
+
+###############################################################################
+## @brief Function-pointer for zeCommandListUpdateMutableCommandKernelsExp
+if __use_win_types:
+    _zeCommandListUpdateMutableCommandKernelsExp_t = WINFUNCTYPE( ze_result_t, ze_command_list_handle_t, c_ulong, POINTER(c_ulonglong), POINTER(ze_kernel_handle_t) )
+else:
+    _zeCommandListUpdateMutableCommandKernelsExp_t = CFUNCTYPE( ze_result_t, ze_command_list_handle_t, c_ulong, POINTER(c_ulonglong), POINTER(ze_kernel_handle_t) )
+
+
+###############################################################################
+## @brief Table of CommandListExp functions pointers
+class _ze_command_list_exp_dditable_t(Structure):
+    _fields_ = [
+        ("pfnCreateCloneExp", c_void_p),                                ## _zeCommandListCreateCloneExp_t
+        ("pfnImmediateAppendCommandListsExp", c_void_p),                ## _zeCommandListImmediateAppendCommandListsExp_t
+        ("pfnGetNextCommandIdExp", c_void_p),                           ## _zeCommandListGetNextCommandIdExp_t
+        ("pfnUpdateMutableCommandsExp", c_void_p),                      ## _zeCommandListUpdateMutableCommandsExp_t
+        ("pfnUpdateMutableCommandSignalEventExp", c_void_p),            ## _zeCommandListUpdateMutableCommandSignalEventExp_t
+        ("pfnUpdateMutableCommandWaitEventsExp", c_void_p),             ## _zeCommandListUpdateMutableCommandWaitEventsExp_t
+        ("pfnGetNextCommandIdWithKernelsExp", c_void_p),                ## _zeCommandListGetNextCommandIdWithKernelsExp_t
+        ("pfnUpdateMutableCommandKernelsExp", c_void_p)                 ## _zeCommandListUpdateMutableCommandKernelsExp_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zeImageGetProperties
+if __use_win_types:
+    _zeImageGetProperties_t = WINFUNCTYPE( ze_result_t, ze_device_handle_t, POINTER(ze_image_desc_t), POINTER(ze_image_properties_t) )
+else:
+    _zeImageGetProperties_t = CFUNCTYPE( ze_result_t, ze_device_handle_t, POINTER(ze_image_desc_t), POINTER(ze_image_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zeImageCreate
+if __use_win_types:
+    _zeImageCreate_t = WINFUNCTYPE( ze_result_t, ze_context_handle_t, ze_device_handle_t, POINTER(ze_image_desc_t), POINTER(ze_image_handle_t) )
+else:
+    _zeImageCreate_t = CFUNCTYPE( ze_result_t, ze_context_handle_t, ze_device_handle_t, POINTER(ze_image_desc_t), POINTER(ze_image_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeImageDestroy
+if __use_win_types:
+    _zeImageDestroy_t = WINFUNCTYPE( ze_result_t, ze_image_handle_t )
+else:
+    _zeImageDestroy_t = CFUNCTYPE( ze_result_t, ze_image_handle_t )
+
+###############################################################################
+## @brief Function-pointer for zeImageGetAllocPropertiesExt
+if __use_win_types:
+    _zeImageGetAllocPropertiesExt_t = WINFUNCTYPE( ze_result_t, ze_context_handle_t, ze_image_handle_t, POINTER(ze_image_allocation_ext_properties_t) )
+else:
+    _zeImageGetAllocPropertiesExt_t = CFUNCTYPE( ze_result_t, ze_context_handle_t, ze_image_handle_t, POINTER(ze_image_allocation_ext_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zeImageViewCreateExt
+if __use_win_types:
+    _zeImageViewCreateExt_t = WINFUNCTYPE( ze_result_t, ze_context_handle_t, ze_device_handle_t, POINTER(ze_image_desc_t), ze_image_handle_t, POINTER(ze_image_handle_t) )
+else:
+    _zeImageViewCreateExt_t = CFUNCTYPE( ze_result_t, ze_context_handle_t, ze_device_handle_t, POINTER(ze_image_desc_t), ze_image_handle_t, POINTER(ze_image_handle_t) )
+
+
+###############################################################################
+## @brief Table of Image functions pointers
+class _ze_image_dditable_t(Structure):
+    _fields_ = [
+        ("pfnGetProperties", c_void_p),                                 ## _zeImageGetProperties_t
+        ("pfnCreate", c_void_p),                                        ## _zeImageCreate_t
+        ("pfnDestroy", c_void_p),                                       ## _zeImageDestroy_t
+        ("pfnGetAllocPropertiesExt", c_void_p),                         ## _zeImageGetAllocPropertiesExt_t
+        ("pfnViewCreateExt", c_void_p)                                  ## _zeImageViewCreateExt_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zeImageGetMemoryPropertiesExp
+if __use_win_types:
+    _zeImageGetMemoryPropertiesExp_t = WINFUNCTYPE( ze_result_t, ze_image_handle_t, POINTER(ze_image_memory_properties_exp_t) )
+else:
+    _zeImageGetMemoryPropertiesExp_t = CFUNCTYPE( ze_result_t, ze_image_handle_t, POINTER(ze_image_memory_properties_exp_t) )
+
+###############################################################################
+## @brief Function-pointer for zeImageViewCreateExp
+if __use_win_types:
+    _zeImageViewCreateExp_t = WINFUNCTYPE( ze_result_t, ze_context_handle_t, ze_device_handle_t, POINTER(ze_image_desc_t), ze_image_handle_t, POINTER(ze_image_handle_t) )
+else:
+    _zeImageViewCreateExp_t = CFUNCTYPE( ze_result_t, ze_context_handle_t, ze_device_handle_t, POINTER(ze_image_desc_t), ze_image_handle_t, POINTER(ze_image_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeImageGetDeviceOffsetExp
+if __use_win_types:
+    _zeImageGetDeviceOffsetExp_t = WINFUNCTYPE( ze_result_t, ze_image_handle_t, POINTER(c_ulonglong) )
+else:
+    _zeImageGetDeviceOffsetExp_t = CFUNCTYPE( ze_result_t, ze_image_handle_t, POINTER(c_ulonglong) )
+
+
+###############################################################################
+## @brief Table of ImageExp functions pointers
+class _ze_image_exp_dditable_t(Structure):
+    _fields_ = [
+        ("pfnGetMemoryPropertiesExp", c_void_p),                        ## _zeImageGetMemoryPropertiesExp_t
+        ("pfnViewCreateExp", c_void_p),                                 ## _zeImageViewCreateExp_t
+        ("pfnGetDeviceOffsetExp", c_void_p)                             ## _zeImageGetDeviceOffsetExp_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zeMemAllocShared
+if __use_win_types:
+    _zeMemAllocShared_t = WINFUNCTYPE( ze_result_t, ze_context_handle_t, POINTER(ze_device_mem_alloc_desc_t), POINTER(ze_host_mem_alloc_desc_t), c_size_t, c_size_t, ze_device_handle_t, POINTER(c_void_p) )
+else:
+    _zeMemAllocShared_t = CFUNCTYPE( ze_result_t, ze_context_handle_t, POINTER(ze_device_mem_alloc_desc_t), POINTER(ze_host_mem_alloc_desc_t), c_size_t, c_size_t, ze_device_handle_t, POINTER(c_void_p) )
+
+###############################################################################
+## @brief Function-pointer for zeMemAllocDevice
+if __use_win_types:
+    _zeMemAllocDevice_t = WINFUNCTYPE( ze_result_t, ze_context_handle_t, POINTER(ze_device_mem_alloc_desc_t), c_size_t, c_size_t, ze_device_handle_t, POINTER(c_void_p) )
+else:
+    _zeMemAllocDevice_t = CFUNCTYPE( ze_result_t, ze_context_handle_t, POINTER(ze_device_mem_alloc_desc_t), c_size_t, c_size_t, ze_device_handle_t, POINTER(c_void_p) )
+
+###############################################################################
+## @brief Function-pointer for zeMemAllocHost
+if __use_win_types:
+    _zeMemAllocHost_t = WINFUNCTYPE( ze_result_t, ze_context_handle_t, POINTER(ze_host_mem_alloc_desc_t), c_size_t, c_size_t, POINTER(c_void_p) )
+else:
+    _zeMemAllocHost_t = CFUNCTYPE( ze_result_t, ze_context_handle_t, POINTER(ze_host_mem_alloc_desc_t), c_size_t, c_size_t, POINTER(c_void_p) )
+
+###############################################################################
+## @brief Function-pointer for zeMemFree
+if __use_win_types:
+    _zeMemFree_t = WINFUNCTYPE( ze_result_t, ze_context_handle_t, c_void_p )
+else:
+    _zeMemFree_t = CFUNCTYPE( ze_result_t, ze_context_handle_t, c_void_p )
+
+###############################################################################
+## @brief Function-pointer for zeMemGetAllocProperties
+if __use_win_types:
+    _zeMemGetAllocProperties_t = WINFUNCTYPE( ze_result_t, ze_context_handle_t, c_void_p, POINTER(ze_memory_allocation_properties_t), POINTER(ze_device_handle_t) )
+else:
+    _zeMemGetAllocProperties_t = CFUNCTYPE( ze_result_t, ze_context_handle_t, c_void_p, POINTER(ze_memory_allocation_properties_t), POINTER(ze_device_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeMemGetAddressRange
+if __use_win_types:
+    _zeMemGetAddressRange_t = WINFUNCTYPE( ze_result_t, ze_context_handle_t, c_void_p, POINTER(c_void_p), POINTER(c_size_t) )
+else:
+    _zeMemGetAddressRange_t = CFUNCTYPE( ze_result_t, ze_context_handle_t, c_void_p, POINTER(c_void_p), POINTER(c_size_t) )
+
+###############################################################################
+## @brief Function-pointer for zeMemGetIpcHandle
+if __use_win_types:
+    _zeMemGetIpcHandle_t = WINFUNCTYPE( ze_result_t, ze_context_handle_t, c_void_p, POINTER(ze_ipc_mem_handle_t) )
+else:
+    _zeMemGetIpcHandle_t = CFUNCTYPE( ze_result_t, ze_context_handle_t, c_void_p, POINTER(ze_ipc_mem_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeMemOpenIpcHandle
+if __use_win_types:
+    _zeMemOpenIpcHandle_t = WINFUNCTYPE( ze_result_t, ze_context_handle_t, ze_device_handle_t, ze_ipc_mem_handle_t, ze_ipc_memory_flags_t, POINTER(c_void_p) )
+else:
+    _zeMemOpenIpcHandle_t = CFUNCTYPE( ze_result_t, ze_context_handle_t, ze_device_handle_t, ze_ipc_mem_handle_t, ze_ipc_memory_flags_t, POINTER(c_void_p) )
+
+###############################################################################
+## @brief Function-pointer for zeMemCloseIpcHandle
+if __use_win_types:
+    _zeMemCloseIpcHandle_t = WINFUNCTYPE( ze_result_t, ze_context_handle_t, c_void_p )
+else:
+    _zeMemCloseIpcHandle_t = CFUNCTYPE( ze_result_t, ze_context_handle_t, c_void_p )
+
+###############################################################################
+## @brief Function-pointer for zeMemFreeExt
+if __use_win_types:
+    _zeMemFreeExt_t = WINFUNCTYPE( ze_result_t, ze_context_handle_t, POINTER(ze_memory_free_ext_desc_t), c_void_p )
+else:
+    _zeMemFreeExt_t = CFUNCTYPE( ze_result_t, ze_context_handle_t, POINTER(ze_memory_free_ext_desc_t), c_void_p )
+
+###############################################################################
+## @brief Function-pointer for zeMemPutIpcHandle
+if __use_win_types:
+    _zeMemPutIpcHandle_t = WINFUNCTYPE( ze_result_t, ze_context_handle_t, ze_ipc_mem_handle_t )
+else:
+    _zeMemPutIpcHandle_t = CFUNCTYPE( ze_result_t, ze_context_handle_t, ze_ipc_mem_handle_t )
+
+###############################################################################
+## @brief Function-pointer for zeMemGetPitchFor2dImage
+if __use_win_types:
+    _zeMemGetPitchFor2dImage_t = WINFUNCTYPE( ze_result_t, ze_context_handle_t, ze_device_handle_t, c_size_t, c_size_t, c_int, * )
+else:
+    _zeMemGetPitchFor2dImage_t = CFUNCTYPE( ze_result_t, ze_context_handle_t, ze_device_handle_t, c_size_t, c_size_t, c_int, * )
+
+
+###############################################################################
+## @brief Table of Mem functions pointers
+class _ze_mem_dditable_t(Structure):
+    _fields_ = [
+        ("pfnAllocShared", c_void_p),                                   ## _zeMemAllocShared_t
+        ("pfnAllocDevice", c_void_p),                                   ## _zeMemAllocDevice_t
+        ("pfnAllocHost", c_void_p),                                     ## _zeMemAllocHost_t
+        ("pfnFree", c_void_p),                                          ## _zeMemFree_t
+        ("pfnGetAllocProperties", c_void_p),                            ## _zeMemGetAllocProperties_t
+        ("pfnGetAddressRange", c_void_p),                               ## _zeMemGetAddressRange_t
+        ("pfnGetIpcHandle", c_void_p),                                  ## _zeMemGetIpcHandle_t
+        ("pfnOpenIpcHandle", c_void_p),                                 ## _zeMemOpenIpcHandle_t
+        ("pfnCloseIpcHandle", c_void_p),                                ## _zeMemCloseIpcHandle_t
+        ("pfnFreeExt", c_void_p),                                       ## _zeMemFreeExt_t
+        ("pfnPutIpcHandle", c_void_p),                                  ## _zeMemPutIpcHandle_t
+        ("pfnGetPitchFor2dImage", c_void_p)                             ## _zeMemGetPitchFor2dImage_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zeMemGetIpcHandleFromFileDescriptorExp
+if __use_win_types:
+    _zeMemGetIpcHandleFromFileDescriptorExp_t = WINFUNCTYPE( ze_result_t, ze_context_handle_t, c_ulonglong, POINTER(ze_ipc_mem_handle_t) )
+else:
+    _zeMemGetIpcHandleFromFileDescriptorExp_t = CFUNCTYPE( ze_result_t, ze_context_handle_t, c_ulonglong, POINTER(ze_ipc_mem_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeMemGetFileDescriptorFromIpcHandleExp
+if __use_win_types:
+    _zeMemGetFileDescriptorFromIpcHandleExp_t = WINFUNCTYPE( ze_result_t, ze_context_handle_t, ze_ipc_mem_handle_t, POINTER(c_ulonglong) )
+else:
+    _zeMemGetFileDescriptorFromIpcHandleExp_t = CFUNCTYPE( ze_result_t, ze_context_handle_t, ze_ipc_mem_handle_t, POINTER(c_ulonglong) )
+
+###############################################################################
+## @brief Function-pointer for zeMemSetAtomicAccessAttributeExp
+if __use_win_types:
+    _zeMemSetAtomicAccessAttributeExp_t = WINFUNCTYPE( ze_result_t, ze_context_handle_t, ze_device_handle_t, c_void_p, c_size_t, ze_memory_atomic_attr_exp_flags_t )
+else:
+    _zeMemSetAtomicAccessAttributeExp_t = CFUNCTYPE( ze_result_t, ze_context_handle_t, ze_device_handle_t, c_void_p, c_size_t, ze_memory_atomic_attr_exp_flags_t )
+
+###############################################################################
+## @brief Function-pointer for zeMemGetAtomicAccessAttributeExp
+if __use_win_types:
+    _zeMemGetAtomicAccessAttributeExp_t = WINFUNCTYPE( ze_result_t, ze_context_handle_t, ze_device_handle_t, c_void_p, c_size_t, POINTER(ze_memory_atomic_attr_exp_flags_t) )
+else:
+    _zeMemGetAtomicAccessAttributeExp_t = CFUNCTYPE( ze_result_t, ze_context_handle_t, ze_device_handle_t, c_void_p, c_size_t, POINTER(ze_memory_atomic_attr_exp_flags_t) )
+
+
+###############################################################################
+## @brief Table of MemExp functions pointers
+class _ze_mem_exp_dditable_t(Structure):
+    _fields_ = [
+        ("pfnGetIpcHandleFromFileDescriptorExp", c_void_p),             ## _zeMemGetIpcHandleFromFileDescriptorExp_t
+        ("pfnGetFileDescriptorFromIpcHandleExp", c_void_p),             ## _zeMemGetFileDescriptorFromIpcHandleExp_t
+        ("pfnSetAtomicAccessAttributeExp", c_void_p),                   ## _zeMemSetAtomicAccessAttributeExp_t
+        ("pfnGetAtomicAccessAttributeExp", c_void_p)                    ## _zeMemGetAtomicAccessAttributeExp_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zeFenceCreate
+if __use_win_types:
+    _zeFenceCreate_t = WINFUNCTYPE( ze_result_t, ze_command_queue_handle_t, POINTER(ze_fence_desc_t), POINTER(ze_fence_handle_t) )
+else:
+    _zeFenceCreate_t = CFUNCTYPE( ze_result_t, ze_command_queue_handle_t, POINTER(ze_fence_desc_t), POINTER(ze_fence_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeFenceDestroy
+if __use_win_types:
+    _zeFenceDestroy_t = WINFUNCTYPE( ze_result_t, ze_fence_handle_t )
+else:
+    _zeFenceDestroy_t = CFUNCTYPE( ze_result_t, ze_fence_handle_t )
+
+###############################################################################
+## @brief Function-pointer for zeFenceHostSynchronize
+if __use_win_types:
+    _zeFenceHostSynchronize_t = WINFUNCTYPE( ze_result_t, ze_fence_handle_t, c_ulonglong )
+else:
+    _zeFenceHostSynchronize_t = CFUNCTYPE( ze_result_t, ze_fence_handle_t, c_ulonglong )
+
+###############################################################################
+## @brief Function-pointer for zeFenceQueryStatus
+if __use_win_types:
+    _zeFenceQueryStatus_t = WINFUNCTYPE( ze_result_t, ze_fence_handle_t )
+else:
+    _zeFenceQueryStatus_t = CFUNCTYPE( ze_result_t, ze_fence_handle_t )
+
+###############################################################################
+## @brief Function-pointer for zeFenceReset
+if __use_win_types:
+    _zeFenceReset_t = WINFUNCTYPE( ze_result_t, ze_fence_handle_t )
+else:
+    _zeFenceReset_t = CFUNCTYPE( ze_result_t, ze_fence_handle_t )
+
+
+###############################################################################
+## @brief Table of Fence functions pointers
+class _ze_fence_dditable_t(Structure):
+    _fields_ = [
+        ("pfnCreate", c_void_p),                                        ## _zeFenceCreate_t
+        ("pfnDestroy", c_void_p),                                       ## _zeFenceDestroy_t
+        ("pfnHostSynchronize", c_void_p),                               ## _zeFenceHostSynchronize_t
+        ("pfnQueryStatus", c_void_p),                                   ## _zeFenceQueryStatus_t
+        ("pfnReset", c_void_p)                                          ## _zeFenceReset_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zeEventPoolCreate
+if __use_win_types:
+    _zeEventPoolCreate_t = WINFUNCTYPE( ze_result_t, ze_context_handle_t, POINTER(ze_event_pool_desc_t), c_ulong, POINTER(ze_device_handle_t), POINTER(ze_event_pool_handle_t) )
+else:
+    _zeEventPoolCreate_t = CFUNCTYPE( ze_result_t, ze_context_handle_t, POINTER(ze_event_pool_desc_t), c_ulong, POINTER(ze_device_handle_t), POINTER(ze_event_pool_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeEventPoolDestroy
+if __use_win_types:
+    _zeEventPoolDestroy_t = WINFUNCTYPE( ze_result_t, ze_event_pool_handle_t )
+else:
+    _zeEventPoolDestroy_t = CFUNCTYPE( ze_result_t, ze_event_pool_handle_t )
+
+###############################################################################
+## @brief Function-pointer for zeEventPoolGetIpcHandle
+if __use_win_types:
+    _zeEventPoolGetIpcHandle_t = WINFUNCTYPE( ze_result_t, ze_event_pool_handle_t, POINTER(ze_ipc_event_pool_handle_t) )
+else:
+    _zeEventPoolGetIpcHandle_t = CFUNCTYPE( ze_result_t, ze_event_pool_handle_t, POINTER(ze_ipc_event_pool_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeEventPoolOpenIpcHandle
+if __use_win_types:
+    _zeEventPoolOpenIpcHandle_t = WINFUNCTYPE( ze_result_t, ze_context_handle_t, ze_ipc_event_pool_handle_t, POINTER(ze_event_pool_handle_t) )
+else:
+    _zeEventPoolOpenIpcHandle_t = CFUNCTYPE( ze_result_t, ze_context_handle_t, ze_ipc_event_pool_handle_t, POINTER(ze_event_pool_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeEventPoolCloseIpcHandle
+if __use_win_types:
+    _zeEventPoolCloseIpcHandle_t = WINFUNCTYPE( ze_result_t, ze_event_pool_handle_t )
+else:
+    _zeEventPoolCloseIpcHandle_t = CFUNCTYPE( ze_result_t, ze_event_pool_handle_t )
+
+###############################################################################
+## @brief Function-pointer for zeEventPoolPutIpcHandle
+if __use_win_types:
+    _zeEventPoolPutIpcHandle_t = WINFUNCTYPE( ze_result_t, ze_context_handle_t, ze_ipc_event_pool_handle_t )
+else:
+    _zeEventPoolPutIpcHandle_t = CFUNCTYPE( ze_result_t, ze_context_handle_t, ze_ipc_event_pool_handle_t )
+
+###############################################################################
+## @brief Function-pointer for zeEventPoolGetContextHandle
+if __use_win_types:
+    _zeEventPoolGetContextHandle_t = WINFUNCTYPE( ze_result_t, ze_event_pool_handle_t, POINTER(ze_context_handle_t) )
+else:
+    _zeEventPoolGetContextHandle_t = CFUNCTYPE( ze_result_t, ze_event_pool_handle_t, POINTER(ze_context_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeEventPoolGetFlags
+if __use_win_types:
+    _zeEventPoolGetFlags_t = WINFUNCTYPE( ze_result_t, ze_event_pool_handle_t, POINTER(ze_event_pool_flags_t) )
+else:
+    _zeEventPoolGetFlags_t = CFUNCTYPE( ze_result_t, ze_event_pool_handle_t, POINTER(ze_event_pool_flags_t) )
+
+
+###############################################################################
+## @brief Table of EventPool functions pointers
+class _ze_event_pool_dditable_t(Structure):
+    _fields_ = [
+        ("pfnCreate", c_void_p),                                        ## _zeEventPoolCreate_t
+        ("pfnDestroy", c_void_p),                                       ## _zeEventPoolDestroy_t
+        ("pfnGetIpcHandle", c_void_p),                                  ## _zeEventPoolGetIpcHandle_t
+        ("pfnOpenIpcHandle", c_void_p),                                 ## _zeEventPoolOpenIpcHandle_t
+        ("pfnCloseIpcHandle", c_void_p),                                ## _zeEventPoolCloseIpcHandle_t
+        ("pfnPutIpcHandle", c_void_p),                                  ## _zeEventPoolPutIpcHandle_t
+        ("pfnGetContextHandle", c_void_p),                              ## _zeEventPoolGetContextHandle_t
+        ("pfnGetFlags", c_void_p)                                       ## _zeEventPoolGetFlags_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zeEventCreate
+if __use_win_types:
+    _zeEventCreate_t = WINFUNCTYPE( ze_result_t, ze_event_pool_handle_t, POINTER(ze_event_desc_t), POINTER(ze_event_handle_t) )
+else:
+    _zeEventCreate_t = CFUNCTYPE( ze_result_t, ze_event_pool_handle_t, POINTER(ze_event_desc_t), POINTER(ze_event_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeEventDestroy
+if __use_win_types:
+    _zeEventDestroy_t = WINFUNCTYPE( ze_result_t, ze_event_handle_t )
+else:
+    _zeEventDestroy_t = CFUNCTYPE( ze_result_t, ze_event_handle_t )
+
+###############################################################################
+## @brief Function-pointer for zeEventHostSignal
+if __use_win_types:
+    _zeEventHostSignal_t = WINFUNCTYPE( ze_result_t, ze_event_handle_t )
+else:
+    _zeEventHostSignal_t = CFUNCTYPE( ze_result_t, ze_event_handle_t )
+
+###############################################################################
+## @brief Function-pointer for zeEventHostSynchronize
+if __use_win_types:
+    _zeEventHostSynchronize_t = WINFUNCTYPE( ze_result_t, ze_event_handle_t, c_ulonglong )
+else:
+    _zeEventHostSynchronize_t = CFUNCTYPE( ze_result_t, ze_event_handle_t, c_ulonglong )
+
+###############################################################################
+## @brief Function-pointer for zeEventQueryStatus
+if __use_win_types:
+    _zeEventQueryStatus_t = WINFUNCTYPE( ze_result_t, ze_event_handle_t )
+else:
+    _zeEventQueryStatus_t = CFUNCTYPE( ze_result_t, ze_event_handle_t )
+
+###############################################################################
+## @brief Function-pointer for zeEventHostReset
+if __use_win_types:
+    _zeEventHostReset_t = WINFUNCTYPE( ze_result_t, ze_event_handle_t )
+else:
+    _zeEventHostReset_t = CFUNCTYPE( ze_result_t, ze_event_handle_t )
+
+###############################################################################
+## @brief Function-pointer for zeEventQueryKernelTimestamp
+if __use_win_types:
+    _zeEventQueryKernelTimestamp_t = WINFUNCTYPE( ze_result_t, ze_event_handle_t, POINTER(ze_kernel_timestamp_result_t) )
+else:
+    _zeEventQueryKernelTimestamp_t = CFUNCTYPE( ze_result_t, ze_event_handle_t, POINTER(ze_kernel_timestamp_result_t) )
+
+###############################################################################
+## @brief Function-pointer for zeEventQueryKernelTimestampsExt
+if __use_win_types:
+    _zeEventQueryKernelTimestampsExt_t = WINFUNCTYPE( ze_result_t, ze_event_handle_t, ze_device_handle_t, POINTER(c_ulong), POINTER(ze_event_query_kernel_timestamps_results_ext_properties_t) )
+else:
+    _zeEventQueryKernelTimestampsExt_t = CFUNCTYPE( ze_result_t, ze_event_handle_t, ze_device_handle_t, POINTER(c_ulong), POINTER(ze_event_query_kernel_timestamps_results_ext_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zeEventGetEventPool
+if __use_win_types:
+    _zeEventGetEventPool_t = WINFUNCTYPE( ze_result_t, ze_event_handle_t, POINTER(ze_event_pool_handle_t) )
+else:
+    _zeEventGetEventPool_t = CFUNCTYPE( ze_result_t, ze_event_handle_t, POINTER(ze_event_pool_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeEventGetSignalScope
+if __use_win_types:
+    _zeEventGetSignalScope_t = WINFUNCTYPE( ze_result_t, ze_event_handle_t, POINTER(ze_event_scope_flags_t) )
+else:
+    _zeEventGetSignalScope_t = CFUNCTYPE( ze_result_t, ze_event_handle_t, POINTER(ze_event_scope_flags_t) )
+
+###############################################################################
+## @brief Function-pointer for zeEventGetWaitScope
+if __use_win_types:
+    _zeEventGetWaitScope_t = WINFUNCTYPE( ze_result_t, ze_event_handle_t, POINTER(ze_event_scope_flags_t) )
+else:
+    _zeEventGetWaitScope_t = CFUNCTYPE( ze_result_t, ze_event_handle_t, POINTER(ze_event_scope_flags_t) )
+
+
+###############################################################################
+## @brief Table of Event functions pointers
+class _ze_event_dditable_t(Structure):
+    _fields_ = [
+        ("pfnCreate", c_void_p),                                        ## _zeEventCreate_t
+        ("pfnDestroy", c_void_p),                                       ## _zeEventDestroy_t
+        ("pfnHostSignal", c_void_p),                                    ## _zeEventHostSignal_t
+        ("pfnHostSynchronize", c_void_p),                               ## _zeEventHostSynchronize_t
+        ("pfnQueryStatus", c_void_p),                                   ## _zeEventQueryStatus_t
+        ("pfnHostReset", c_void_p),                                     ## _zeEventHostReset_t
+        ("pfnQueryKernelTimestamp", c_void_p),                          ## _zeEventQueryKernelTimestamp_t
+        ("pfnQueryKernelTimestampsExt", c_void_p),                      ## _zeEventQueryKernelTimestampsExt_t
+        ("pfnGetEventPool", c_void_p),                                  ## _zeEventGetEventPool_t
+        ("pfnGetSignalScope", c_void_p),                                ## _zeEventGetSignalScope_t
+        ("pfnGetWaitScope", c_void_p)                                   ## _zeEventGetWaitScope_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zeEventQueryTimestampsExp
+if __use_win_types:
+    _zeEventQueryTimestampsExp_t = WINFUNCTYPE( ze_result_t, ze_event_handle_t, ze_device_handle_t, POINTER(c_ulong), POINTER(ze_kernel_timestamp_result_t) )
+else:
+    _zeEventQueryTimestampsExp_t = CFUNCTYPE( ze_result_t, ze_event_handle_t, ze_device_handle_t, POINTER(c_ulong), POINTER(ze_kernel_timestamp_result_t) )
+
+
+###############################################################################
+## @brief Table of EventExp functions pointers
+class _ze_event_exp_dditable_t(Structure):
+    _fields_ = [
+        ("pfnQueryTimestampsExp", c_void_p)                             ## _zeEventQueryTimestampsExp_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zeModuleCreate
+if __use_win_types:
+    _zeModuleCreate_t = WINFUNCTYPE( ze_result_t, ze_context_handle_t, ze_device_handle_t, POINTER(ze_module_desc_t), POINTER(ze_module_handle_t), POINTER(ze_module_build_log_handle_t) )
+else:
+    _zeModuleCreate_t = CFUNCTYPE( ze_result_t, ze_context_handle_t, ze_device_handle_t, POINTER(ze_module_desc_t), POINTER(ze_module_handle_t), POINTER(ze_module_build_log_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeModuleDestroy
+if __use_win_types:
+    _zeModuleDestroy_t = WINFUNCTYPE( ze_result_t, ze_module_handle_t )
+else:
+    _zeModuleDestroy_t = CFUNCTYPE( ze_result_t, ze_module_handle_t )
+
+###############################################################################
+## @brief Function-pointer for zeModuleDynamicLink
+if __use_win_types:
+    _zeModuleDynamicLink_t = WINFUNCTYPE( ze_result_t, c_ulong, POINTER(ze_module_handle_t), POINTER(ze_module_build_log_handle_t) )
+else:
+    _zeModuleDynamicLink_t = CFUNCTYPE( ze_result_t, c_ulong, POINTER(ze_module_handle_t), POINTER(ze_module_build_log_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeModuleGetNativeBinary
+if __use_win_types:
+    _zeModuleGetNativeBinary_t = WINFUNCTYPE( ze_result_t, ze_module_handle_t, POINTER(c_size_t), POINTER(c_ubyte) )
+else:
+    _zeModuleGetNativeBinary_t = CFUNCTYPE( ze_result_t, ze_module_handle_t, POINTER(c_size_t), POINTER(c_ubyte) )
+
+###############################################################################
+## @brief Function-pointer for zeModuleGetGlobalPointer
+if __use_win_types:
+    _zeModuleGetGlobalPointer_t = WINFUNCTYPE( ze_result_t, ze_module_handle_t, c_char_p, POINTER(c_size_t), POINTER(c_void_p) )
+else:
+    _zeModuleGetGlobalPointer_t = CFUNCTYPE( ze_result_t, ze_module_handle_t, c_char_p, POINTER(c_size_t), POINTER(c_void_p) )
+
+###############################################################################
+## @brief Function-pointer for zeModuleGetKernelNames
+if __use_win_types:
+    _zeModuleGetKernelNames_t = WINFUNCTYPE( ze_result_t, ze_module_handle_t, POINTER(c_ulong), POINTER(c_char_p) )
+else:
+    _zeModuleGetKernelNames_t = CFUNCTYPE( ze_result_t, ze_module_handle_t, POINTER(c_ulong), POINTER(c_char_p) )
+
+###############################################################################
+## @brief Function-pointer for zeModuleGetProperties
+if __use_win_types:
+    _zeModuleGetProperties_t = WINFUNCTYPE( ze_result_t, ze_module_handle_t, POINTER(ze_module_properties_t) )
+else:
+    _zeModuleGetProperties_t = CFUNCTYPE( ze_result_t, ze_module_handle_t, POINTER(ze_module_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zeModuleGetFunctionPointer
+if __use_win_types:
+    _zeModuleGetFunctionPointer_t = WINFUNCTYPE( ze_result_t, ze_module_handle_t, c_char_p, POINTER(c_void_p) )
+else:
+    _zeModuleGetFunctionPointer_t = CFUNCTYPE( ze_result_t, ze_module_handle_t, c_char_p, POINTER(c_void_p) )
+
+###############################################################################
+## @brief Function-pointer for zeModuleInspectLinkageExt
+if __use_win_types:
+    _zeModuleInspectLinkageExt_t = WINFUNCTYPE( ze_result_t, POINTER(ze_linkage_inspection_ext_desc_t), c_ulong, POINTER(ze_module_handle_t), POINTER(ze_module_build_log_handle_t) )
+else:
+    _zeModuleInspectLinkageExt_t = CFUNCTYPE( ze_result_t, POINTER(ze_linkage_inspection_ext_desc_t), c_ulong, POINTER(ze_module_handle_t), POINTER(ze_module_build_log_handle_t) )
+
+
+###############################################################################
+## @brief Table of Module functions pointers
+class _ze_module_dditable_t(Structure):
+    _fields_ = [
+        ("pfnCreate", c_void_p),                                        ## _zeModuleCreate_t
+        ("pfnDestroy", c_void_p),                                       ## _zeModuleDestroy_t
+        ("pfnDynamicLink", c_void_p),                                   ## _zeModuleDynamicLink_t
+        ("pfnGetNativeBinary", c_void_p),                               ## _zeModuleGetNativeBinary_t
+        ("pfnGetGlobalPointer", c_void_p),                              ## _zeModuleGetGlobalPointer_t
+        ("pfnGetKernelNames", c_void_p),                                ## _zeModuleGetKernelNames_t
+        ("pfnGetProperties", c_void_p),                                 ## _zeModuleGetProperties_t
+        ("pfnGetFunctionPointer", c_void_p),                            ## _zeModuleGetFunctionPointer_t
+        ("pfnInspectLinkageExt", c_void_p)                              ## _zeModuleInspectLinkageExt_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zeModuleBuildLogDestroy
+if __use_win_types:
+    _zeModuleBuildLogDestroy_t = WINFUNCTYPE( ze_result_t, ze_module_build_log_handle_t )
+else:
+    _zeModuleBuildLogDestroy_t = CFUNCTYPE( ze_result_t, ze_module_build_log_handle_t )
+
+###############################################################################
+## @brief Function-pointer for zeModuleBuildLogGetString
+if __use_win_types:
+    _zeModuleBuildLogGetString_t = WINFUNCTYPE( ze_result_t, ze_module_build_log_handle_t, POINTER(c_size_t), c_char_p )
+else:
+    _zeModuleBuildLogGetString_t = CFUNCTYPE( ze_result_t, ze_module_build_log_handle_t, POINTER(c_size_t), c_char_p )
+
+
+###############################################################################
+## @brief Table of ModuleBuildLog functions pointers
+class _ze_module_build_log_dditable_t(Structure):
+    _fields_ = [
+        ("pfnDestroy", c_void_p),                                       ## _zeModuleBuildLogDestroy_t
+        ("pfnGetString", c_void_p)                                      ## _zeModuleBuildLogGetString_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zeKernelCreate
+if __use_win_types:
+    _zeKernelCreate_t = WINFUNCTYPE( ze_result_t, ze_module_handle_t, POINTER(ze_kernel_desc_t), POINTER(ze_kernel_handle_t) )
+else:
+    _zeKernelCreate_t = CFUNCTYPE( ze_result_t, ze_module_handle_t, POINTER(ze_kernel_desc_t), POINTER(ze_kernel_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeKernelDestroy
+if __use_win_types:
+    _zeKernelDestroy_t = WINFUNCTYPE( ze_result_t, ze_kernel_handle_t )
+else:
+    _zeKernelDestroy_t = CFUNCTYPE( ze_result_t, ze_kernel_handle_t )
+
+###############################################################################
+## @brief Function-pointer for zeKernelSetCacheConfig
+if __use_win_types:
+    _zeKernelSetCacheConfig_t = WINFUNCTYPE( ze_result_t, ze_kernel_handle_t, ze_cache_config_flags_t )
+else:
+    _zeKernelSetCacheConfig_t = CFUNCTYPE( ze_result_t, ze_kernel_handle_t, ze_cache_config_flags_t )
+
+###############################################################################
+## @brief Function-pointer for zeKernelSetGroupSize
+if __use_win_types:
+    _zeKernelSetGroupSize_t = WINFUNCTYPE( ze_result_t, ze_kernel_handle_t, c_ulong, c_ulong, c_ulong )
+else:
+    _zeKernelSetGroupSize_t = CFUNCTYPE( ze_result_t, ze_kernel_handle_t, c_ulong, c_ulong, c_ulong )
+
+###############################################################################
+## @brief Function-pointer for zeKernelSuggestGroupSize
+if __use_win_types:
+    _zeKernelSuggestGroupSize_t = WINFUNCTYPE( ze_result_t, ze_kernel_handle_t, c_ulong, c_ulong, c_ulong, POINTER(c_ulong), POINTER(c_ulong), POINTER(c_ulong) )
+else:
+    _zeKernelSuggestGroupSize_t = CFUNCTYPE( ze_result_t, ze_kernel_handle_t, c_ulong, c_ulong, c_ulong, POINTER(c_ulong), POINTER(c_ulong), POINTER(c_ulong) )
+
+###############################################################################
+## @brief Function-pointer for zeKernelSuggestMaxCooperativeGroupCount
+if __use_win_types:
+    _zeKernelSuggestMaxCooperativeGroupCount_t = WINFUNCTYPE( ze_result_t, ze_kernel_handle_t, POINTER(c_ulong) )
+else:
+    _zeKernelSuggestMaxCooperativeGroupCount_t = CFUNCTYPE( ze_result_t, ze_kernel_handle_t, POINTER(c_ulong) )
+
+###############################################################################
+## @brief Function-pointer for zeKernelSetArgumentValue
+if __use_win_types:
+    _zeKernelSetArgumentValue_t = WINFUNCTYPE( ze_result_t, ze_kernel_handle_t, c_ulong, c_size_t, c_void_p )
+else:
+    _zeKernelSetArgumentValue_t = CFUNCTYPE( ze_result_t, ze_kernel_handle_t, c_ulong, c_size_t, c_void_p )
+
+###############################################################################
+## @brief Function-pointer for zeKernelSetIndirectAccess
+if __use_win_types:
+    _zeKernelSetIndirectAccess_t = WINFUNCTYPE( ze_result_t, ze_kernel_handle_t, ze_kernel_indirect_access_flags_t )
+else:
+    _zeKernelSetIndirectAccess_t = CFUNCTYPE( ze_result_t, ze_kernel_handle_t, ze_kernel_indirect_access_flags_t )
+
+###############################################################################
+## @brief Function-pointer for zeKernelGetIndirectAccess
+if __use_win_types:
+    _zeKernelGetIndirectAccess_t = WINFUNCTYPE( ze_result_t, ze_kernel_handle_t, POINTER(ze_kernel_indirect_access_flags_t) )
+else:
+    _zeKernelGetIndirectAccess_t = CFUNCTYPE( ze_result_t, ze_kernel_handle_t, POINTER(ze_kernel_indirect_access_flags_t) )
+
+###############################################################################
+## @brief Function-pointer for zeKernelGetSourceAttributes
+if __use_win_types:
+    _zeKernelGetSourceAttributes_t = WINFUNCTYPE( ze_result_t, ze_kernel_handle_t, POINTER(c_ulong), POINTER(c_char_p) )
+else:
+    _zeKernelGetSourceAttributes_t = CFUNCTYPE( ze_result_t, ze_kernel_handle_t, POINTER(c_ulong), POINTER(c_char_p) )
+
+###############################################################################
+## @brief Function-pointer for zeKernelGetProperties
+if __use_win_types:
+    _zeKernelGetProperties_t = WINFUNCTYPE( ze_result_t, ze_kernel_handle_t, POINTER(ze_kernel_properties_t) )
+else:
+    _zeKernelGetProperties_t = CFUNCTYPE( ze_result_t, ze_kernel_handle_t, POINTER(ze_kernel_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zeKernelGetName
+if __use_win_types:
+    _zeKernelGetName_t = WINFUNCTYPE( ze_result_t, ze_kernel_handle_t, POINTER(c_size_t), c_char_p )
+else:
+    _zeKernelGetName_t = CFUNCTYPE( ze_result_t, ze_kernel_handle_t, POINTER(c_size_t), c_char_p )
+
+
+###############################################################################
+## @brief Table of Kernel functions pointers
+class _ze_kernel_dditable_t(Structure):
+    _fields_ = [
+        ("pfnCreate", c_void_p),                                        ## _zeKernelCreate_t
+        ("pfnDestroy", c_void_p),                                       ## _zeKernelDestroy_t
+        ("pfnSetCacheConfig", c_void_p),                                ## _zeKernelSetCacheConfig_t
+        ("pfnSetGroupSize", c_void_p),                                  ## _zeKernelSetGroupSize_t
+        ("pfnSuggestGroupSize", c_void_p),                              ## _zeKernelSuggestGroupSize_t
+        ("pfnSuggestMaxCooperativeGroupCount", c_void_p),               ## _zeKernelSuggestMaxCooperativeGroupCount_t
+        ("pfnSetArgumentValue", c_void_p),                              ## _zeKernelSetArgumentValue_t
+        ("pfnSetIndirectAccess", c_void_p),                             ## _zeKernelSetIndirectAccess_t
+        ("pfnGetIndirectAccess", c_void_p),                             ## _zeKernelGetIndirectAccess_t
+        ("pfnGetSourceAttributes", c_void_p),                           ## _zeKernelGetSourceAttributes_t
+        ("pfnGetProperties", c_void_p),                                 ## _zeKernelGetProperties_t
+        ("pfnGetName", c_void_p)                                        ## _zeKernelGetName_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zeKernelSetGlobalOffsetExp
+if __use_win_types:
+    _zeKernelSetGlobalOffsetExp_t = WINFUNCTYPE( ze_result_t, ze_kernel_handle_t, c_ulong, c_ulong, c_ulong )
+else:
+    _zeKernelSetGlobalOffsetExp_t = CFUNCTYPE( ze_result_t, ze_kernel_handle_t, c_ulong, c_ulong, c_ulong )
+
+###############################################################################
+## @brief Function-pointer for zeKernelSchedulingHintExp
+if __use_win_types:
+    _zeKernelSchedulingHintExp_t = WINFUNCTYPE( ze_result_t, ze_kernel_handle_t, POINTER(ze_scheduling_hint_exp_desc_t) )
+else:
+    _zeKernelSchedulingHintExp_t = CFUNCTYPE( ze_result_t, ze_kernel_handle_t, POINTER(ze_scheduling_hint_exp_desc_t) )
+
+###############################################################################
+## @brief Function-pointer for zeKernelGetBinaryExp
+if __use_win_types:
+    _zeKernelGetBinaryExp_t = WINFUNCTYPE( ze_result_t, ze_kernel_handle_t, POINTER(c_size_t), POINTER(c_ubyte) )
+else:
+    _zeKernelGetBinaryExp_t = CFUNCTYPE( ze_result_t, ze_kernel_handle_t, POINTER(c_size_t), POINTER(c_ubyte) )
+
+
+###############################################################################
+## @brief Table of KernelExp functions pointers
+class _ze_kernel_exp_dditable_t(Structure):
+    _fields_ = [
+        ("pfnSetGlobalOffsetExp", c_void_p),                            ## _zeKernelSetGlobalOffsetExp_t
+        ("pfnSchedulingHintExp", c_void_p),                             ## _zeKernelSchedulingHintExp_t
+        ("pfnGetBinaryExp", c_void_p)                                   ## _zeKernelGetBinaryExp_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zeSamplerCreate
+if __use_win_types:
+    _zeSamplerCreate_t = WINFUNCTYPE( ze_result_t, ze_context_handle_t, ze_device_handle_t, POINTER(ze_sampler_desc_t), POINTER(ze_sampler_handle_t) )
+else:
+    _zeSamplerCreate_t = CFUNCTYPE( ze_result_t, ze_context_handle_t, ze_device_handle_t, POINTER(ze_sampler_desc_t), POINTER(ze_sampler_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeSamplerDestroy
+if __use_win_types:
+    _zeSamplerDestroy_t = WINFUNCTYPE( ze_result_t, ze_sampler_handle_t )
+else:
+    _zeSamplerDestroy_t = CFUNCTYPE( ze_result_t, ze_sampler_handle_t )
+
+
+###############################################################################
+## @brief Table of Sampler functions pointers
+class _ze_sampler_dditable_t(Structure):
+    _fields_ = [
+        ("pfnCreate", c_void_p),                                        ## _zeSamplerCreate_t
+        ("pfnDestroy", c_void_p)                                        ## _zeSamplerDestroy_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zePhysicalMemCreate
+if __use_win_types:
+    _zePhysicalMemCreate_t = WINFUNCTYPE( ze_result_t, ze_context_handle_t, ze_device_handle_t, POINTER(ze_physical_mem_desc_t), POINTER(ze_physical_mem_handle_t) )
+else:
+    _zePhysicalMemCreate_t = CFUNCTYPE( ze_result_t, ze_context_handle_t, ze_device_handle_t, POINTER(ze_physical_mem_desc_t), POINTER(ze_physical_mem_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zePhysicalMemDestroy
+if __use_win_types:
+    _zePhysicalMemDestroy_t = WINFUNCTYPE( ze_result_t, ze_context_handle_t, ze_physical_mem_handle_t )
+else:
+    _zePhysicalMemDestroy_t = CFUNCTYPE( ze_result_t, ze_context_handle_t, ze_physical_mem_handle_t )
+
+
+###############################################################################
+## @brief Table of PhysicalMem functions pointers
+class _ze_physical_mem_dditable_t(Structure):
+    _fields_ = [
+        ("pfnCreate", c_void_p),                                        ## _zePhysicalMemCreate_t
+        ("pfnDestroy", c_void_p)                                        ## _zePhysicalMemDestroy_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zeVirtualMemReserve
+if __use_win_types:
+    _zeVirtualMemReserve_t = WINFUNCTYPE( ze_result_t, ze_context_handle_t, c_void_p, c_size_t, POINTER(c_void_p) )
+else:
+    _zeVirtualMemReserve_t = CFUNCTYPE( ze_result_t, ze_context_handle_t, c_void_p, c_size_t, POINTER(c_void_p) )
+
+###############################################################################
+## @brief Function-pointer for zeVirtualMemFree
+if __use_win_types:
+    _zeVirtualMemFree_t = WINFUNCTYPE( ze_result_t, ze_context_handle_t, c_void_p, c_size_t )
+else:
+    _zeVirtualMemFree_t = CFUNCTYPE( ze_result_t, ze_context_handle_t, c_void_p, c_size_t )
+
+###############################################################################
+## @brief Function-pointer for zeVirtualMemQueryPageSize
+if __use_win_types:
+    _zeVirtualMemQueryPageSize_t = WINFUNCTYPE( ze_result_t, ze_context_handle_t, ze_device_handle_t, c_size_t, POINTER(c_size_t) )
+else:
+    _zeVirtualMemQueryPageSize_t = CFUNCTYPE( ze_result_t, ze_context_handle_t, ze_device_handle_t, c_size_t, POINTER(c_size_t) )
+
+###############################################################################
+## @brief Function-pointer for zeVirtualMemMap
+if __use_win_types:
+    _zeVirtualMemMap_t = WINFUNCTYPE( ze_result_t, ze_context_handle_t, c_void_p, c_size_t, ze_physical_mem_handle_t, c_size_t, ze_memory_access_attribute_t )
+else:
+    _zeVirtualMemMap_t = CFUNCTYPE( ze_result_t, ze_context_handle_t, c_void_p, c_size_t, ze_physical_mem_handle_t, c_size_t, ze_memory_access_attribute_t )
+
+###############################################################################
+## @brief Function-pointer for zeVirtualMemUnmap
+if __use_win_types:
+    _zeVirtualMemUnmap_t = WINFUNCTYPE( ze_result_t, ze_context_handle_t, c_void_p, c_size_t )
+else:
+    _zeVirtualMemUnmap_t = CFUNCTYPE( ze_result_t, ze_context_handle_t, c_void_p, c_size_t )
+
+###############################################################################
+## @brief Function-pointer for zeVirtualMemSetAccessAttribute
+if __use_win_types:
+    _zeVirtualMemSetAccessAttribute_t = WINFUNCTYPE( ze_result_t, ze_context_handle_t, c_void_p, c_size_t, ze_memory_access_attribute_t )
+else:
+    _zeVirtualMemSetAccessAttribute_t = CFUNCTYPE( ze_result_t, ze_context_handle_t, c_void_p, c_size_t, ze_memory_access_attribute_t )
+
+###############################################################################
+## @brief Function-pointer for zeVirtualMemGetAccessAttribute
+if __use_win_types:
+    _zeVirtualMemGetAccessAttribute_t = WINFUNCTYPE( ze_result_t, ze_context_handle_t, c_void_p, c_size_t, POINTER(ze_memory_access_attribute_t), POINTER(c_size_t) )
+else:
+    _zeVirtualMemGetAccessAttribute_t = CFUNCTYPE( ze_result_t, ze_context_handle_t, c_void_p, c_size_t, POINTER(ze_memory_access_attribute_t), POINTER(c_size_t) )
+
+
+###############################################################################
+## @brief Table of VirtualMem functions pointers
+class _ze_virtual_mem_dditable_t(Structure):
+    _fields_ = [
+        ("pfnReserve", c_void_p),                                       ## _zeVirtualMemReserve_t
+        ("pfnFree", c_void_p),                                          ## _zeVirtualMemFree_t
+        ("pfnQueryPageSize", c_void_p),                                 ## _zeVirtualMemQueryPageSize_t
+        ("pfnMap", c_void_p),                                           ## _zeVirtualMemMap_t
+        ("pfnUnmap", c_void_p),                                         ## _zeVirtualMemUnmap_t
+        ("pfnSetAccessAttribute", c_void_p),                            ## _zeVirtualMemSetAccessAttribute_t
+        ("pfnGetAccessAttribute", c_void_p)                             ## _zeVirtualMemGetAccessAttribute_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zeFabricVertexGetExp
+if __use_win_types:
+    _zeFabricVertexGetExp_t = WINFUNCTYPE( ze_result_t, ze_driver_handle_t, POINTER(c_ulong), POINTER(ze_fabric_vertex_handle_t) )
+else:
+    _zeFabricVertexGetExp_t = CFUNCTYPE( ze_result_t, ze_driver_handle_t, POINTER(c_ulong), POINTER(ze_fabric_vertex_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeFabricVertexGetSubVerticesExp
+if __use_win_types:
+    _zeFabricVertexGetSubVerticesExp_t = WINFUNCTYPE( ze_result_t, ze_fabric_vertex_handle_t, POINTER(c_ulong), POINTER(ze_fabric_vertex_handle_t) )
+else:
+    _zeFabricVertexGetSubVerticesExp_t = CFUNCTYPE( ze_result_t, ze_fabric_vertex_handle_t, POINTER(c_ulong), POINTER(ze_fabric_vertex_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeFabricVertexGetPropertiesExp
+if __use_win_types:
+    _zeFabricVertexGetPropertiesExp_t = WINFUNCTYPE( ze_result_t, ze_fabric_vertex_handle_t, POINTER(ze_fabric_vertex_exp_properties_t) )
+else:
+    _zeFabricVertexGetPropertiesExp_t = CFUNCTYPE( ze_result_t, ze_fabric_vertex_handle_t, POINTER(ze_fabric_vertex_exp_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zeFabricVertexGetDeviceExp
+if __use_win_types:
+    _zeFabricVertexGetDeviceExp_t = WINFUNCTYPE( ze_result_t, ze_fabric_vertex_handle_t, POINTER(ze_device_handle_t) )
+else:
+    _zeFabricVertexGetDeviceExp_t = CFUNCTYPE( ze_result_t, ze_fabric_vertex_handle_t, POINTER(ze_device_handle_t) )
+
+
+###############################################################################
+## @brief Table of FabricVertexExp functions pointers
+class _ze_fabric_vertex_exp_dditable_t(Structure):
+    _fields_ = [
+        ("pfnGetExp", c_void_p),                                        ## _zeFabricVertexGetExp_t
+        ("pfnGetSubVerticesExp", c_void_p),                             ## _zeFabricVertexGetSubVerticesExp_t
+        ("pfnGetPropertiesExp", c_void_p),                              ## _zeFabricVertexGetPropertiesExp_t
+        ("pfnGetDeviceExp", c_void_p)                                   ## _zeFabricVertexGetDeviceExp_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zeFabricEdgeGetExp
+if __use_win_types:
+    _zeFabricEdgeGetExp_t = WINFUNCTYPE( ze_result_t, ze_fabric_vertex_handle_t, ze_fabric_vertex_handle_t, POINTER(c_ulong), POINTER(ze_fabric_edge_handle_t) )
+else:
+    _zeFabricEdgeGetExp_t = CFUNCTYPE( ze_result_t, ze_fabric_vertex_handle_t, ze_fabric_vertex_handle_t, POINTER(c_ulong), POINTER(ze_fabric_edge_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeFabricEdgeGetVerticesExp
+if __use_win_types:
+    _zeFabricEdgeGetVerticesExp_t = WINFUNCTYPE( ze_result_t, ze_fabric_edge_handle_t, POINTER(ze_fabric_vertex_handle_t), POINTER(ze_fabric_vertex_handle_t) )
+else:
+    _zeFabricEdgeGetVerticesExp_t = CFUNCTYPE( ze_result_t, ze_fabric_edge_handle_t, POINTER(ze_fabric_vertex_handle_t), POINTER(ze_fabric_vertex_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zeFabricEdgeGetPropertiesExp
+if __use_win_types:
+    _zeFabricEdgeGetPropertiesExp_t = WINFUNCTYPE( ze_result_t, ze_fabric_edge_handle_t, POINTER(ze_fabric_edge_exp_properties_t) )
+else:
+    _zeFabricEdgeGetPropertiesExp_t = CFUNCTYPE( ze_result_t, ze_fabric_edge_handle_t, POINTER(ze_fabric_edge_exp_properties_t) )
+
+
+###############################################################################
+## @brief Table of FabricEdgeExp functions pointers
+class _ze_fabric_edge_exp_dditable_t(Structure):
+    _fields_ = [
+        ("pfnGetExp", c_void_p),                                        ## _zeFabricEdgeGetExp_t
+        ("pfnGetVerticesExp", c_void_p),                                ## _zeFabricEdgeGetVerticesExp_t
+        ("pfnGetPropertiesExp", c_void_p)                               ## _zeFabricEdgeGetPropertiesExp_t
+    ]
+
+###############################################################################
+class _ze_dditable_t(Structure):
+    _fields_ = [
+        ("RTASBuilderExp", _ze_rtas_builder_exp_dditable_t),
+        ("RTASParallelOperationExp", _ze_rtas_parallel_operation_exp_dditable_t),
+        ("Global", _ze_global_dditable_t),
+        ("Driver", _ze_driver_dditable_t),
+        ("DriverExp", _ze_driver_exp_dditable_t),
+        ("Device", _ze_device_dditable_t),
+        ("DeviceExp", _ze_device_exp_dditable_t),
+        ("Context", _ze_context_dditable_t),
+        ("CommandQueue", _ze_command_queue_dditable_t),
+        ("CommandList", _ze_command_list_dditable_t),
+        ("CommandListExp", _ze_command_list_exp_dditable_t),
+        ("Image", _ze_image_dditable_t),
+        ("ImageExp", _ze_image_exp_dditable_t),
+        ("Mem", _ze_mem_dditable_t),
+        ("MemExp", _ze_mem_exp_dditable_t),
+        ("Fence", _ze_fence_dditable_t),
+        ("EventPool", _ze_event_pool_dditable_t),
+        ("Event", _ze_event_dditable_t),
+        ("EventExp", _ze_event_exp_dditable_t),
+        ("Module", _ze_module_dditable_t),
+        ("ModuleBuildLog", _ze_module_build_log_dditable_t),
+        ("Kernel", _ze_kernel_dditable_t),
+        ("KernelExp", _ze_kernel_exp_dditable_t),
+        ("Sampler", _ze_sampler_dditable_t),
+        ("PhysicalMem", _ze_physical_mem_dditable_t),
+        ("VirtualMem", _ze_virtual_mem_dditable_t),
+        ("FabricVertexExp", _ze_fabric_vertex_exp_dditable_t),
+        ("FabricEdgeExp", _ze_fabric_edge_exp_dditable_t)
+    ]
+
+###############################################################################
+## @brief ze device-driver interfaces
+class ZE_DDI:
+    def __init__(self, version : ze_api_version_t):
+        # load the ze_loader library
+        if "Windows" == platform.uname()[0]:
+            self.__dll = WinDLL("ze_loader.dll")
+        else:
+            self.__dll = CDLL("ze_loader.so")
+
+        # fill the ddi tables
+        self.__dditable = _ze_dditable_t()
+
+        # call driver to get function pointers
+        _RTASBuilderExp = _ze_rtas_builder_exp_dditable_t()
+        r = ze_result_v(self.__dll.zeGetRTASBuilderExpProcAddrTable(version, byref(_RTASBuilderExp)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.RTASBuilderExp = _RTASBuilderExp
+
+        # attach function interface to function address
+        self.zeRTASBuilderCreateExp = _zeRTASBuilderCreateExp_t(self.__dditable.RTASBuilderExp.pfnCreateExp)
+        self.zeRTASBuilderGetBuildPropertiesExp = _zeRTASBuilderGetBuildPropertiesExp_t(self.__dditable.RTASBuilderExp.pfnGetBuildPropertiesExp)
+        self.zeRTASBuilderBuildExp = _zeRTASBuilderBuildExp_t(self.__dditable.RTASBuilderExp.pfnBuildExp)
+        self.zeRTASBuilderDestroyExp = _zeRTASBuilderDestroyExp_t(self.__dditable.RTASBuilderExp.pfnDestroyExp)
+
+        # call driver to get function pointers
+        _RTASParallelOperationExp = _ze_rtas_parallel_operation_exp_dditable_t()
+        r = ze_result_v(self.__dll.zeGetRTASParallelOperationExpProcAddrTable(version, byref(_RTASParallelOperationExp)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.RTASParallelOperationExp = _RTASParallelOperationExp
+
+        # attach function interface to function address
+        self.zeRTASParallelOperationCreateExp = _zeRTASParallelOperationCreateExp_t(self.__dditable.RTASParallelOperationExp.pfnCreateExp)
+        self.zeRTASParallelOperationGetPropertiesExp = _zeRTASParallelOperationGetPropertiesExp_t(self.__dditable.RTASParallelOperationExp.pfnGetPropertiesExp)
+        self.zeRTASParallelOperationJoinExp = _zeRTASParallelOperationJoinExp_t(self.__dditable.RTASParallelOperationExp.pfnJoinExp)
+        self.zeRTASParallelOperationDestroyExp = _zeRTASParallelOperationDestroyExp_t(self.__dditable.RTASParallelOperationExp.pfnDestroyExp)
+
+        # call driver to get function pointers
+        _Global = _ze_global_dditable_t()
+        r = ze_result_v(self.__dll.zeGetGlobalProcAddrTable(version, byref(_Global)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.Global = _Global
+
+        # attach function interface to function address
+        self.zeInit = _zeInit_t(self.__dditable.Global.pfnInit)
+        self.zeInitDrivers = _zeInitDrivers_t(self.__dditable.Global.pfnInitDrivers)
+
+        # call driver to get function pointers
+        _Driver = _ze_driver_dditable_t()
+        r = ze_result_v(self.__dll.zeGetDriverProcAddrTable(version, byref(_Driver)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.Driver = _Driver
+
+        # attach function interface to function address
+        self.zeDriverGet = _zeDriverGet_t(self.__dditable.Driver.pfnGet)
+        self.zeDriverGetApiVersion = _zeDriverGetApiVersion_t(self.__dditable.Driver.pfnGetApiVersion)
+        self.zeDriverGetProperties = _zeDriverGetProperties_t(self.__dditable.Driver.pfnGetProperties)
+        self.zeDriverGetIpcProperties = _zeDriverGetIpcProperties_t(self.__dditable.Driver.pfnGetIpcProperties)
+        self.zeDriverGetExtensionProperties = _zeDriverGetExtensionProperties_t(self.__dditable.Driver.pfnGetExtensionProperties)
+        self.zeDriverGetExtensionFunctionAddress = _zeDriverGetExtensionFunctionAddress_t(self.__dditable.Driver.pfnGetExtensionFunctionAddress)
+        self.zeDriverGetLastErrorDescription = _zeDriverGetLastErrorDescription_t(self.__dditable.Driver.pfnGetLastErrorDescription)
+
+        # call driver to get function pointers
+        _DriverExp = _ze_driver_exp_dditable_t()
+        r = ze_result_v(self.__dll.zeGetDriverExpProcAddrTable(version, byref(_DriverExp)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.DriverExp = _DriverExp
+
+        # attach function interface to function address
+        self.zeDriverRTASFormatCompatibilityCheckExp = _zeDriverRTASFormatCompatibilityCheckExp_t(self.__dditable.DriverExp.pfnRTASFormatCompatibilityCheckExp)
+
+        # call driver to get function pointers
+        _Device = _ze_device_dditable_t()
+        r = ze_result_v(self.__dll.zeGetDeviceProcAddrTable(version, byref(_Device)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.Device = _Device
+
+        # attach function interface to function address
+        self.zeDeviceGet = _zeDeviceGet_t(self.__dditable.Device.pfnGet)
+        self.zeDeviceGetSubDevices = _zeDeviceGetSubDevices_t(self.__dditable.Device.pfnGetSubDevices)
+        self.zeDeviceGetProperties = _zeDeviceGetProperties_t(self.__dditable.Device.pfnGetProperties)
+        self.zeDeviceGetComputeProperties = _zeDeviceGetComputeProperties_t(self.__dditable.Device.pfnGetComputeProperties)
+        self.zeDeviceGetModuleProperties = _zeDeviceGetModuleProperties_t(self.__dditable.Device.pfnGetModuleProperties)
+        self.zeDeviceGetCommandQueueGroupProperties = _zeDeviceGetCommandQueueGroupProperties_t(self.__dditable.Device.pfnGetCommandQueueGroupProperties)
+        self.zeDeviceGetMemoryProperties = _zeDeviceGetMemoryProperties_t(self.__dditable.Device.pfnGetMemoryProperties)
+        self.zeDeviceGetMemoryAccessProperties = _zeDeviceGetMemoryAccessProperties_t(self.__dditable.Device.pfnGetMemoryAccessProperties)
+        self.zeDeviceGetCacheProperties = _zeDeviceGetCacheProperties_t(self.__dditable.Device.pfnGetCacheProperties)
+        self.zeDeviceGetImageProperties = _zeDeviceGetImageProperties_t(self.__dditable.Device.pfnGetImageProperties)
+        self.zeDeviceGetExternalMemoryProperties = _zeDeviceGetExternalMemoryProperties_t(self.__dditable.Device.pfnGetExternalMemoryProperties)
+        self.zeDeviceGetP2PProperties = _zeDeviceGetP2PProperties_t(self.__dditable.Device.pfnGetP2PProperties)
+        self.zeDeviceCanAccessPeer = _zeDeviceCanAccessPeer_t(self.__dditable.Device.pfnCanAccessPeer)
+        self.zeDeviceGetStatus = _zeDeviceGetStatus_t(self.__dditable.Device.pfnGetStatus)
+        self.zeDeviceGetGlobalTimestamps = _zeDeviceGetGlobalTimestamps_t(self.__dditable.Device.pfnGetGlobalTimestamps)
+        self.zeDeviceReserveCacheExt = _zeDeviceReserveCacheExt_t(self.__dditable.Device.pfnReserveCacheExt)
+        self.zeDeviceSetCacheAdviceExt = _zeDeviceSetCacheAdviceExt_t(self.__dditable.Device.pfnSetCacheAdviceExt)
+        self.zeDevicePciGetPropertiesExt = _zeDevicePciGetPropertiesExt_t(self.__dditable.Device.pfnPciGetPropertiesExt)
+        self.zeDeviceGetRootDevice = _zeDeviceGetRootDevice_t(self.__dditable.Device.pfnGetRootDevice)
+        self.zeDeviceImportExternalSemaphoreExt = _zeDeviceImportExternalSemaphoreExt_t(self.__dditable.Device.pfnImportExternalSemaphoreExt)
+        self.zeDeviceReleaseExternalSemaphoreExt = _zeDeviceReleaseExternalSemaphoreExt_t(self.__dditable.Device.pfnReleaseExternalSemaphoreExt)
+
+        # call driver to get function pointers
+        _DeviceExp = _ze_device_exp_dditable_t()
+        r = ze_result_v(self.__dll.zeGetDeviceExpProcAddrTable(version, byref(_DeviceExp)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.DeviceExp = _DeviceExp
+
+        # attach function interface to function address
+        self.zeDeviceGetFabricVertexExp = _zeDeviceGetFabricVertexExp_t(self.__dditable.DeviceExp.pfnGetFabricVertexExp)
+
+        # call driver to get function pointers
+        _Context = _ze_context_dditable_t()
+        r = ze_result_v(self.__dll.zeGetContextProcAddrTable(version, byref(_Context)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.Context = _Context
+
+        # attach function interface to function address
+        self.zeContextCreate = _zeContextCreate_t(self.__dditable.Context.pfnCreate)
+        self.zeContextDestroy = _zeContextDestroy_t(self.__dditable.Context.pfnDestroy)
+        self.zeContextGetStatus = _zeContextGetStatus_t(self.__dditable.Context.pfnGetStatus)
+        self.zeContextSystemBarrier = _zeContextSystemBarrier_t(self.__dditable.Context.pfnSystemBarrier)
+        self.zeContextMakeMemoryResident = _zeContextMakeMemoryResident_t(self.__dditable.Context.pfnMakeMemoryResident)
+        self.zeContextEvictMemory = _zeContextEvictMemory_t(self.__dditable.Context.pfnEvictMemory)
+        self.zeContextMakeImageResident = _zeContextMakeImageResident_t(self.__dditable.Context.pfnMakeImageResident)
+        self.zeContextEvictImage = _zeContextEvictImage_t(self.__dditable.Context.pfnEvictImage)
+        self.zeContextCreateEx = _zeContextCreateEx_t(self.__dditable.Context.pfnCreateEx)
+
+        # call driver to get function pointers
+        _CommandQueue = _ze_command_queue_dditable_t()
+        r = ze_result_v(self.__dll.zeGetCommandQueueProcAddrTable(version, byref(_CommandQueue)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.CommandQueue = _CommandQueue
+
+        # attach function interface to function address
+        self.zeCommandQueueCreate = _zeCommandQueueCreate_t(self.__dditable.CommandQueue.pfnCreate)
+        self.zeCommandQueueDestroy = _zeCommandQueueDestroy_t(self.__dditable.CommandQueue.pfnDestroy)
+        self.zeCommandQueueExecuteCommandLists = _zeCommandQueueExecuteCommandLists_t(self.__dditable.CommandQueue.pfnExecuteCommandLists)
+        self.zeCommandQueueSynchronize = _zeCommandQueueSynchronize_t(self.__dditable.CommandQueue.pfnSynchronize)
+        self.zeCommandQueueGetOrdinal = _zeCommandQueueGetOrdinal_t(self.__dditable.CommandQueue.pfnGetOrdinal)
+        self.zeCommandQueueGetIndex = _zeCommandQueueGetIndex_t(self.__dditable.CommandQueue.pfnGetIndex)
+
+        # call driver to get function pointers
+        _CommandList = _ze_command_list_dditable_t()
+        r = ze_result_v(self.__dll.zeGetCommandListProcAddrTable(version, byref(_CommandList)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.CommandList = _CommandList
+
+        # attach function interface to function address
+        self.zeCommandListCreate = _zeCommandListCreate_t(self.__dditable.CommandList.pfnCreate)
+        self.zeCommandListCreateImmediate = _zeCommandListCreateImmediate_t(self.__dditable.CommandList.pfnCreateImmediate)
+        self.zeCommandListDestroy = _zeCommandListDestroy_t(self.__dditable.CommandList.pfnDestroy)
+        self.zeCommandListClose = _zeCommandListClose_t(self.__dditable.CommandList.pfnClose)
+        self.zeCommandListReset = _zeCommandListReset_t(self.__dditable.CommandList.pfnReset)
+        self.zeCommandListAppendWriteGlobalTimestamp = _zeCommandListAppendWriteGlobalTimestamp_t(self.__dditable.CommandList.pfnAppendWriteGlobalTimestamp)
+        self.zeCommandListAppendBarrier = _zeCommandListAppendBarrier_t(self.__dditable.CommandList.pfnAppendBarrier)
+        self.zeCommandListAppendMemoryRangesBarrier = _zeCommandListAppendMemoryRangesBarrier_t(self.__dditable.CommandList.pfnAppendMemoryRangesBarrier)
+        self.zeCommandListAppendMemoryCopy = _zeCommandListAppendMemoryCopy_t(self.__dditable.CommandList.pfnAppendMemoryCopy)
+        self.zeCommandListAppendMemoryFill = _zeCommandListAppendMemoryFill_t(self.__dditable.CommandList.pfnAppendMemoryFill)
+        self.zeCommandListAppendMemoryCopyRegion = _zeCommandListAppendMemoryCopyRegion_t(self.__dditable.CommandList.pfnAppendMemoryCopyRegion)
+        self.zeCommandListAppendMemoryCopyFromContext = _zeCommandListAppendMemoryCopyFromContext_t(self.__dditable.CommandList.pfnAppendMemoryCopyFromContext)
+        self.zeCommandListAppendImageCopy = _zeCommandListAppendImageCopy_t(self.__dditable.CommandList.pfnAppendImageCopy)
+        self.zeCommandListAppendImageCopyRegion = _zeCommandListAppendImageCopyRegion_t(self.__dditable.CommandList.pfnAppendImageCopyRegion)
+        self.zeCommandListAppendImageCopyToMemory = _zeCommandListAppendImageCopyToMemory_t(self.__dditable.CommandList.pfnAppendImageCopyToMemory)
+        self.zeCommandListAppendImageCopyFromMemory = _zeCommandListAppendImageCopyFromMemory_t(self.__dditable.CommandList.pfnAppendImageCopyFromMemory)
+        self.zeCommandListAppendMemoryPrefetch = _zeCommandListAppendMemoryPrefetch_t(self.__dditable.CommandList.pfnAppendMemoryPrefetch)
+        self.zeCommandListAppendMemAdvise = _zeCommandListAppendMemAdvise_t(self.__dditable.CommandList.pfnAppendMemAdvise)
+        self.zeCommandListAppendSignalEvent = _zeCommandListAppendSignalEvent_t(self.__dditable.CommandList.pfnAppendSignalEvent)
+        self.zeCommandListAppendWaitOnEvents = _zeCommandListAppendWaitOnEvents_t(self.__dditable.CommandList.pfnAppendWaitOnEvents)
+        self.zeCommandListAppendEventReset = _zeCommandListAppendEventReset_t(self.__dditable.CommandList.pfnAppendEventReset)
+        self.zeCommandListAppendQueryKernelTimestamps = _zeCommandListAppendQueryKernelTimestamps_t(self.__dditable.CommandList.pfnAppendQueryKernelTimestamps)
+        self.zeCommandListAppendLaunchKernel = _zeCommandListAppendLaunchKernel_t(self.__dditable.CommandList.pfnAppendLaunchKernel)
+        self.zeCommandListAppendLaunchCooperativeKernel = _zeCommandListAppendLaunchCooperativeKernel_t(self.__dditable.CommandList.pfnAppendLaunchCooperativeKernel)
+        self.zeCommandListAppendLaunchKernelIndirect = _zeCommandListAppendLaunchKernelIndirect_t(self.__dditable.CommandList.pfnAppendLaunchKernelIndirect)
+        self.zeCommandListAppendLaunchMultipleKernelsIndirect = _zeCommandListAppendLaunchMultipleKernelsIndirect_t(self.__dditable.CommandList.pfnAppendLaunchMultipleKernelsIndirect)
+        self.zeCommandListAppendImageCopyToMemoryExt = _zeCommandListAppendImageCopyToMemoryExt_t(self.__dditable.CommandList.pfnAppendImageCopyToMemoryExt)
+        self.zeCommandListAppendImageCopyFromMemoryExt = _zeCommandListAppendImageCopyFromMemoryExt_t(self.__dditable.CommandList.pfnAppendImageCopyFromMemoryExt)
+        self.zeCommandListHostSynchronize = _zeCommandListHostSynchronize_t(self.__dditable.CommandList.pfnHostSynchronize)
+        self.zeCommandListGetDeviceHandle = _zeCommandListGetDeviceHandle_t(self.__dditable.CommandList.pfnGetDeviceHandle)
+        self.zeCommandListGetContextHandle = _zeCommandListGetContextHandle_t(self.__dditable.CommandList.pfnGetContextHandle)
+        self.zeCommandListGetOrdinal = _zeCommandListGetOrdinal_t(self.__dditable.CommandList.pfnGetOrdinal)
+        self.zeCommandListImmediateGetIndex = _zeCommandListImmediateGetIndex_t(self.__dditable.CommandList.pfnImmediateGetIndex)
+        self.zeCommandListIsImmediate = _zeCommandListIsImmediate_t(self.__dditable.CommandList.pfnIsImmediate)
+        self.zeCommandListAppendSignalExternalSemaphoreExt = _zeCommandListAppendSignalExternalSemaphoreExt_t(self.__dditable.CommandList.pfnAppendSignalExternalSemaphoreExt)
+        self.zeCommandListAppendWaitExternalSemaphoreExt = _zeCommandListAppendWaitExternalSemaphoreExt_t(self.__dditable.CommandList.pfnAppendWaitExternalSemaphoreExt)
+
+        # call driver to get function pointers
+        _CommandListExp = _ze_command_list_exp_dditable_t()
+        r = ze_result_v(self.__dll.zeGetCommandListExpProcAddrTable(version, byref(_CommandListExp)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.CommandListExp = _CommandListExp
+
+        # attach function interface to function address
+        self.zeCommandListCreateCloneExp = _zeCommandListCreateCloneExp_t(self.__dditable.CommandListExp.pfnCreateCloneExp)
+        self.zeCommandListImmediateAppendCommandListsExp = _zeCommandListImmediateAppendCommandListsExp_t(self.__dditable.CommandListExp.pfnImmediateAppendCommandListsExp)
+        self.zeCommandListGetNextCommandIdExp = _zeCommandListGetNextCommandIdExp_t(self.__dditable.CommandListExp.pfnGetNextCommandIdExp)
+        self.zeCommandListUpdateMutableCommandsExp = _zeCommandListUpdateMutableCommandsExp_t(self.__dditable.CommandListExp.pfnUpdateMutableCommandsExp)
+        self.zeCommandListUpdateMutableCommandSignalEventExp = _zeCommandListUpdateMutableCommandSignalEventExp_t(self.__dditable.CommandListExp.pfnUpdateMutableCommandSignalEventExp)
+        self.zeCommandListUpdateMutableCommandWaitEventsExp = _zeCommandListUpdateMutableCommandWaitEventsExp_t(self.__dditable.CommandListExp.pfnUpdateMutableCommandWaitEventsExp)
+        self.zeCommandListGetNextCommandIdWithKernelsExp = _zeCommandListGetNextCommandIdWithKernelsExp_t(self.__dditable.CommandListExp.pfnGetNextCommandIdWithKernelsExp)
+        self.zeCommandListUpdateMutableCommandKernelsExp = _zeCommandListUpdateMutableCommandKernelsExp_t(self.__dditable.CommandListExp.pfnUpdateMutableCommandKernelsExp)
+
+        # call driver to get function pointers
+        _Image = _ze_image_dditable_t()
+        r = ze_result_v(self.__dll.zeGetImageProcAddrTable(version, byref(_Image)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.Image = _Image
+
+        # attach function interface to function address
+        self.zeImageGetProperties = _zeImageGetProperties_t(self.__dditable.Image.pfnGetProperties)
+        self.zeImageCreate = _zeImageCreate_t(self.__dditable.Image.pfnCreate)
+        self.zeImageDestroy = _zeImageDestroy_t(self.__dditable.Image.pfnDestroy)
+        self.zeImageGetAllocPropertiesExt = _zeImageGetAllocPropertiesExt_t(self.__dditable.Image.pfnGetAllocPropertiesExt)
+        self.zeImageViewCreateExt = _zeImageViewCreateExt_t(self.__dditable.Image.pfnViewCreateExt)
+
+        # call driver to get function pointers
+        _ImageExp = _ze_image_exp_dditable_t()
+        r = ze_result_v(self.__dll.zeGetImageExpProcAddrTable(version, byref(_ImageExp)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.ImageExp = _ImageExp
+
+        # attach function interface to function address
+        self.zeImageGetMemoryPropertiesExp = _zeImageGetMemoryPropertiesExp_t(self.__dditable.ImageExp.pfnGetMemoryPropertiesExp)
+        self.zeImageViewCreateExp = _zeImageViewCreateExp_t(self.__dditable.ImageExp.pfnViewCreateExp)
+        self.zeImageGetDeviceOffsetExp = _zeImageGetDeviceOffsetExp_t(self.__dditable.ImageExp.pfnGetDeviceOffsetExp)
+
+        # call driver to get function pointers
+        _Mem = _ze_mem_dditable_t()
+        r = ze_result_v(self.__dll.zeGetMemProcAddrTable(version, byref(_Mem)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.Mem = _Mem
+
+        # attach function interface to function address
+        self.zeMemAllocShared = _zeMemAllocShared_t(self.__dditable.Mem.pfnAllocShared)
+        self.zeMemAllocDevice = _zeMemAllocDevice_t(self.__dditable.Mem.pfnAllocDevice)
+        self.zeMemAllocHost = _zeMemAllocHost_t(self.__dditable.Mem.pfnAllocHost)
+        self.zeMemFree = _zeMemFree_t(self.__dditable.Mem.pfnFree)
+        self.zeMemGetAllocProperties = _zeMemGetAllocProperties_t(self.__dditable.Mem.pfnGetAllocProperties)
+        self.zeMemGetAddressRange = _zeMemGetAddressRange_t(self.__dditable.Mem.pfnGetAddressRange)
+        self.zeMemGetIpcHandle = _zeMemGetIpcHandle_t(self.__dditable.Mem.pfnGetIpcHandle)
+        self.zeMemOpenIpcHandle = _zeMemOpenIpcHandle_t(self.__dditable.Mem.pfnOpenIpcHandle)
+        self.zeMemCloseIpcHandle = _zeMemCloseIpcHandle_t(self.__dditable.Mem.pfnCloseIpcHandle)
+        self.zeMemFreeExt = _zeMemFreeExt_t(self.__dditable.Mem.pfnFreeExt)
+        self.zeMemPutIpcHandle = _zeMemPutIpcHandle_t(self.__dditable.Mem.pfnPutIpcHandle)
+        self.zeMemGetPitchFor2dImage = _zeMemGetPitchFor2dImage_t(self.__dditable.Mem.pfnGetPitchFor2dImage)
+
+        # call driver to get function pointers
+        _MemExp = _ze_mem_exp_dditable_t()
+        r = ze_result_v(self.__dll.zeGetMemExpProcAddrTable(version, byref(_MemExp)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.MemExp = _MemExp
+
+        # attach function interface to function address
+        self.zeMemGetIpcHandleFromFileDescriptorExp = _zeMemGetIpcHandleFromFileDescriptorExp_t(self.__dditable.MemExp.pfnGetIpcHandleFromFileDescriptorExp)
+        self.zeMemGetFileDescriptorFromIpcHandleExp = _zeMemGetFileDescriptorFromIpcHandleExp_t(self.__dditable.MemExp.pfnGetFileDescriptorFromIpcHandleExp)
+        self.zeMemSetAtomicAccessAttributeExp = _zeMemSetAtomicAccessAttributeExp_t(self.__dditable.MemExp.pfnSetAtomicAccessAttributeExp)
+        self.zeMemGetAtomicAccessAttributeExp = _zeMemGetAtomicAccessAttributeExp_t(self.__dditable.MemExp.pfnGetAtomicAccessAttributeExp)
+
+        # call driver to get function pointers
+        _Fence = _ze_fence_dditable_t()
+        r = ze_result_v(self.__dll.zeGetFenceProcAddrTable(version, byref(_Fence)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.Fence = _Fence
+
+        # attach function interface to function address
+        self.zeFenceCreate = _zeFenceCreate_t(self.__dditable.Fence.pfnCreate)
+        self.zeFenceDestroy = _zeFenceDestroy_t(self.__dditable.Fence.pfnDestroy)
+        self.zeFenceHostSynchronize = _zeFenceHostSynchronize_t(self.__dditable.Fence.pfnHostSynchronize)
+        self.zeFenceQueryStatus = _zeFenceQueryStatus_t(self.__dditable.Fence.pfnQueryStatus)
+        self.zeFenceReset = _zeFenceReset_t(self.__dditable.Fence.pfnReset)
+
+        # call driver to get function pointers
+        _EventPool = _ze_event_pool_dditable_t()
+        r = ze_result_v(self.__dll.zeGetEventPoolProcAddrTable(version, byref(_EventPool)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.EventPool = _EventPool
+
+        # attach function interface to function address
+        self.zeEventPoolCreate = _zeEventPoolCreate_t(self.__dditable.EventPool.pfnCreate)
+        self.zeEventPoolDestroy = _zeEventPoolDestroy_t(self.__dditable.EventPool.pfnDestroy)
+        self.zeEventPoolGetIpcHandle = _zeEventPoolGetIpcHandle_t(self.__dditable.EventPool.pfnGetIpcHandle)
+        self.zeEventPoolOpenIpcHandle = _zeEventPoolOpenIpcHandle_t(self.__dditable.EventPool.pfnOpenIpcHandle)
+        self.zeEventPoolCloseIpcHandle = _zeEventPoolCloseIpcHandle_t(self.__dditable.EventPool.pfnCloseIpcHandle)
+        self.zeEventPoolPutIpcHandle = _zeEventPoolPutIpcHandle_t(self.__dditable.EventPool.pfnPutIpcHandle)
+        self.zeEventPoolGetContextHandle = _zeEventPoolGetContextHandle_t(self.__dditable.EventPool.pfnGetContextHandle)
+        self.zeEventPoolGetFlags = _zeEventPoolGetFlags_t(self.__dditable.EventPool.pfnGetFlags)
+
+        # call driver to get function pointers
+        _Event = _ze_event_dditable_t()
+        r = ze_result_v(self.__dll.zeGetEventProcAddrTable(version, byref(_Event)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.Event = _Event
+
+        # attach function interface to function address
+        self.zeEventCreate = _zeEventCreate_t(self.__dditable.Event.pfnCreate)
+        self.zeEventDestroy = _zeEventDestroy_t(self.__dditable.Event.pfnDestroy)
+        self.zeEventHostSignal = _zeEventHostSignal_t(self.__dditable.Event.pfnHostSignal)
+        self.zeEventHostSynchronize = _zeEventHostSynchronize_t(self.__dditable.Event.pfnHostSynchronize)
+        self.zeEventQueryStatus = _zeEventQueryStatus_t(self.__dditable.Event.pfnQueryStatus)
+        self.zeEventHostReset = _zeEventHostReset_t(self.__dditable.Event.pfnHostReset)
+        self.zeEventQueryKernelTimestamp = _zeEventQueryKernelTimestamp_t(self.__dditable.Event.pfnQueryKernelTimestamp)
+        self.zeEventQueryKernelTimestampsExt = _zeEventQueryKernelTimestampsExt_t(self.__dditable.Event.pfnQueryKernelTimestampsExt)
+        self.zeEventGetEventPool = _zeEventGetEventPool_t(self.__dditable.Event.pfnGetEventPool)
+        self.zeEventGetSignalScope = _zeEventGetSignalScope_t(self.__dditable.Event.pfnGetSignalScope)
+        self.zeEventGetWaitScope = _zeEventGetWaitScope_t(self.__dditable.Event.pfnGetWaitScope)
+
+        # call driver to get function pointers
+        _EventExp = _ze_event_exp_dditable_t()
+        r = ze_result_v(self.__dll.zeGetEventExpProcAddrTable(version, byref(_EventExp)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.EventExp = _EventExp
+
+        # attach function interface to function address
+        self.zeEventQueryTimestampsExp = _zeEventQueryTimestampsExp_t(self.__dditable.EventExp.pfnQueryTimestampsExp)
+
+        # call driver to get function pointers
+        _Module = _ze_module_dditable_t()
+        r = ze_result_v(self.__dll.zeGetModuleProcAddrTable(version, byref(_Module)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.Module = _Module
+
+        # attach function interface to function address
+        self.zeModuleCreate = _zeModuleCreate_t(self.__dditable.Module.pfnCreate)
+        self.zeModuleDestroy = _zeModuleDestroy_t(self.__dditable.Module.pfnDestroy)
+        self.zeModuleDynamicLink = _zeModuleDynamicLink_t(self.__dditable.Module.pfnDynamicLink)
+        self.zeModuleGetNativeBinary = _zeModuleGetNativeBinary_t(self.__dditable.Module.pfnGetNativeBinary)
+        self.zeModuleGetGlobalPointer = _zeModuleGetGlobalPointer_t(self.__dditable.Module.pfnGetGlobalPointer)
+        self.zeModuleGetKernelNames = _zeModuleGetKernelNames_t(self.__dditable.Module.pfnGetKernelNames)
+        self.zeModuleGetProperties = _zeModuleGetProperties_t(self.__dditable.Module.pfnGetProperties)
+        self.zeModuleGetFunctionPointer = _zeModuleGetFunctionPointer_t(self.__dditable.Module.pfnGetFunctionPointer)
+        self.zeModuleInspectLinkageExt = _zeModuleInspectLinkageExt_t(self.__dditable.Module.pfnInspectLinkageExt)
+
+        # call driver to get function pointers
+        _ModuleBuildLog = _ze_module_build_log_dditable_t()
+        r = ze_result_v(self.__dll.zeGetModuleBuildLogProcAddrTable(version, byref(_ModuleBuildLog)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.ModuleBuildLog = _ModuleBuildLog
+
+        # attach function interface to function address
+        self.zeModuleBuildLogDestroy = _zeModuleBuildLogDestroy_t(self.__dditable.ModuleBuildLog.pfnDestroy)
+        self.zeModuleBuildLogGetString = _zeModuleBuildLogGetString_t(self.__dditable.ModuleBuildLog.pfnGetString)
+
+        # call driver to get function pointers
+        _Kernel = _ze_kernel_dditable_t()
+        r = ze_result_v(self.__dll.zeGetKernelProcAddrTable(version, byref(_Kernel)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.Kernel = _Kernel
+
+        # attach function interface to function address
+        self.zeKernelCreate = _zeKernelCreate_t(self.__dditable.Kernel.pfnCreate)
+        self.zeKernelDestroy = _zeKernelDestroy_t(self.__dditable.Kernel.pfnDestroy)
+        self.zeKernelSetCacheConfig = _zeKernelSetCacheConfig_t(self.__dditable.Kernel.pfnSetCacheConfig)
+        self.zeKernelSetGroupSize = _zeKernelSetGroupSize_t(self.__dditable.Kernel.pfnSetGroupSize)
+        self.zeKernelSuggestGroupSize = _zeKernelSuggestGroupSize_t(self.__dditable.Kernel.pfnSuggestGroupSize)
+        self.zeKernelSuggestMaxCooperativeGroupCount = _zeKernelSuggestMaxCooperativeGroupCount_t(self.__dditable.Kernel.pfnSuggestMaxCooperativeGroupCount)
+        self.zeKernelSetArgumentValue = _zeKernelSetArgumentValue_t(self.__dditable.Kernel.pfnSetArgumentValue)
+        self.zeKernelSetIndirectAccess = _zeKernelSetIndirectAccess_t(self.__dditable.Kernel.pfnSetIndirectAccess)
+        self.zeKernelGetIndirectAccess = _zeKernelGetIndirectAccess_t(self.__dditable.Kernel.pfnGetIndirectAccess)
+        self.zeKernelGetSourceAttributes = _zeKernelGetSourceAttributes_t(self.__dditable.Kernel.pfnGetSourceAttributes)
+        self.zeKernelGetProperties = _zeKernelGetProperties_t(self.__dditable.Kernel.pfnGetProperties)
+        self.zeKernelGetName = _zeKernelGetName_t(self.__dditable.Kernel.pfnGetName)
+
+        # call driver to get function pointers
+        _KernelExp = _ze_kernel_exp_dditable_t()
+        r = ze_result_v(self.__dll.zeGetKernelExpProcAddrTable(version, byref(_KernelExp)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.KernelExp = _KernelExp
+
+        # attach function interface to function address
+        self.zeKernelSetGlobalOffsetExp = _zeKernelSetGlobalOffsetExp_t(self.__dditable.KernelExp.pfnSetGlobalOffsetExp)
+        self.zeKernelSchedulingHintExp = _zeKernelSchedulingHintExp_t(self.__dditable.KernelExp.pfnSchedulingHintExp)
+        self.zeKernelGetBinaryExp = _zeKernelGetBinaryExp_t(self.__dditable.KernelExp.pfnGetBinaryExp)
+
+        # call driver to get function pointers
+        _Sampler = _ze_sampler_dditable_t()
+        r = ze_result_v(self.__dll.zeGetSamplerProcAddrTable(version, byref(_Sampler)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.Sampler = _Sampler
+
+        # attach function interface to function address
+        self.zeSamplerCreate = _zeSamplerCreate_t(self.__dditable.Sampler.pfnCreate)
+        self.zeSamplerDestroy = _zeSamplerDestroy_t(self.__dditable.Sampler.pfnDestroy)
+
+        # call driver to get function pointers
+        _PhysicalMem = _ze_physical_mem_dditable_t()
+        r = ze_result_v(self.__dll.zeGetPhysicalMemProcAddrTable(version, byref(_PhysicalMem)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.PhysicalMem = _PhysicalMem
+
+        # attach function interface to function address
+        self.zePhysicalMemCreate = _zePhysicalMemCreate_t(self.__dditable.PhysicalMem.pfnCreate)
+        self.zePhysicalMemDestroy = _zePhysicalMemDestroy_t(self.__dditable.PhysicalMem.pfnDestroy)
+
+        # call driver to get function pointers
+        _VirtualMem = _ze_virtual_mem_dditable_t()
+        r = ze_result_v(self.__dll.zeGetVirtualMemProcAddrTable(version, byref(_VirtualMem)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.VirtualMem = _VirtualMem
+
+        # attach function interface to function address
+        self.zeVirtualMemReserve = _zeVirtualMemReserve_t(self.__dditable.VirtualMem.pfnReserve)
+        self.zeVirtualMemFree = _zeVirtualMemFree_t(self.__dditable.VirtualMem.pfnFree)
+        self.zeVirtualMemQueryPageSize = _zeVirtualMemQueryPageSize_t(self.__dditable.VirtualMem.pfnQueryPageSize)
+        self.zeVirtualMemMap = _zeVirtualMemMap_t(self.__dditable.VirtualMem.pfnMap)
+        self.zeVirtualMemUnmap = _zeVirtualMemUnmap_t(self.__dditable.VirtualMem.pfnUnmap)
+        self.zeVirtualMemSetAccessAttribute = _zeVirtualMemSetAccessAttribute_t(self.__dditable.VirtualMem.pfnSetAccessAttribute)
+        self.zeVirtualMemGetAccessAttribute = _zeVirtualMemGetAccessAttribute_t(self.__dditable.VirtualMem.pfnGetAccessAttribute)
+
+        # call driver to get function pointers
+        _FabricVertexExp = _ze_fabric_vertex_exp_dditable_t()
+        r = ze_result_v(self.__dll.zeGetFabricVertexExpProcAddrTable(version, byref(_FabricVertexExp)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.FabricVertexExp = _FabricVertexExp
+
+        # attach function interface to function address
+        self.zeFabricVertexGetExp = _zeFabricVertexGetExp_t(self.__dditable.FabricVertexExp.pfnGetExp)
+        self.zeFabricVertexGetSubVerticesExp = _zeFabricVertexGetSubVerticesExp_t(self.__dditable.FabricVertexExp.pfnGetSubVerticesExp)
+        self.zeFabricVertexGetPropertiesExp = _zeFabricVertexGetPropertiesExp_t(self.__dditable.FabricVertexExp.pfnGetPropertiesExp)
+        self.zeFabricVertexGetDeviceExp = _zeFabricVertexGetDeviceExp_t(self.__dditable.FabricVertexExp.pfnGetDeviceExp)
+
+        # call driver to get function pointers
+        _FabricEdgeExp = _ze_fabric_edge_exp_dditable_t()
+        r = ze_result_v(self.__dll.zeGetFabricEdgeExpProcAddrTable(version, byref(_FabricEdgeExp)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.FabricEdgeExp = _FabricEdgeExp
+
+        # attach function interface to function address
+        self.zeFabricEdgeGetExp = _zeFabricEdgeGetExp_t(self.__dditable.FabricEdgeExp.pfnGetExp)
+        self.zeFabricEdgeGetVerticesExp = _zeFabricEdgeGetVerticesExp_t(self.__dditable.FabricEdgeExp.pfnGetVerticesExp)
+        self.zeFabricEdgeGetPropertiesExp = _zeFabricEdgeGetPropertiesExp_t(self.__dditable.FabricEdgeExp.pfnGetPropertiesExp)
+
+        # success!

--- a/include/level_zero/ze_api.h
+++ b/include/level_zero/ze_api.h
@@ -1,0 +1,14843 @@
+/*
+ *
+ * Copyright (C) 2019-2021 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file ze_api.h
+ * @version v1.12-r1.12.15
+ *
+ */
+#ifndef _ZE_API_H
+#define _ZE_API_H
+#if defined(__cplusplus)
+#pragma once
+#endif
+
+// standard headers
+#include <stdint.h>
+#include <stddef.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+// Intel 'oneAPI' Level-Zero API common types
+#if !defined(__GNUC__)
+#pragma region common
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_MAKE_VERSION
+/// @brief Generates generic 'oneAPI' API versions
+#define ZE_MAKE_VERSION( _major, _minor )  (( _major << 16 )|( _minor & 0x0000ffff))
+#endif // ZE_MAKE_VERSION
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_MAJOR_VERSION
+/// @brief Extracts 'oneAPI' API major version
+#define ZE_MAJOR_VERSION( _ver )  ( _ver >> 16 )
+#endif // ZE_MAJOR_VERSION
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_MINOR_VERSION
+/// @brief Extracts 'oneAPI' API minor version
+#define ZE_MINOR_VERSION( _ver )  ( _ver & 0x0000ffff )
+#endif // ZE_MINOR_VERSION
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_APICALL
+#if defined(_WIN32)
+/// @brief Calling convention for all API functions
+#define ZE_APICALL  __cdecl
+#else
+#define ZE_APICALL  
+#endif // defined(_WIN32)
+#endif // ZE_APICALL
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_APIEXPORT
+#if defined(_WIN32)
+/// @brief Microsoft-specific dllexport storage-class attribute
+#define ZE_APIEXPORT  __declspec(dllexport)
+#endif // defined(_WIN32)
+#endif // ZE_APIEXPORT
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_APIEXPORT
+#if __GNUC__ >= 4
+/// @brief GCC-specific dllexport storage-class attribute
+#define ZE_APIEXPORT  __attribute__ ((visibility ("default")))
+#else
+#define ZE_APIEXPORT  
+#endif // __GNUC__ >= 4
+#endif // ZE_APIEXPORT
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_DLLEXPORT
+#if defined(_WIN32)
+/// @brief Microsoft-specific dllexport storage-class attribute
+#define ZE_DLLEXPORT  __declspec(dllexport)
+#endif // defined(_WIN32)
+#endif // ZE_DLLEXPORT
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_DLLEXPORT
+#if __GNUC__ >= 4
+/// @brief GCC-specific dllexport storage-class attribute
+#define ZE_DLLEXPORT  __attribute__ ((visibility ("default")))
+#else
+#define ZE_DLLEXPORT  
+#endif // __GNUC__ >= 4
+#endif // ZE_DLLEXPORT
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief compiler-independent type
+typedef uint8_t ze_bool_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle of a driver instance
+typedef struct _ze_driver_handle_t *ze_driver_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle of driver's device object
+typedef struct _ze_device_handle_t *ze_device_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle of driver's context object
+typedef struct _ze_context_handle_t *ze_context_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle of driver's command queue object
+typedef struct _ze_command_queue_handle_t *ze_command_queue_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle of driver's command list object
+typedef struct _ze_command_list_handle_t *ze_command_list_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle of driver's fence object
+typedef struct _ze_fence_handle_t *ze_fence_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle of driver's event pool object
+typedef struct _ze_event_pool_handle_t *ze_event_pool_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle of driver's event object
+typedef struct _ze_event_handle_t *ze_event_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle of driver's image object
+typedef struct _ze_image_handle_t *ze_image_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle of driver's module object
+typedef struct _ze_module_handle_t *ze_module_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle of module's build log object
+typedef struct _ze_module_build_log_handle_t *ze_module_build_log_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle of driver's kernel object
+typedef struct _ze_kernel_handle_t *ze_kernel_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle of driver's sampler object
+typedef struct _ze_sampler_handle_t *ze_sampler_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle of physical memory object
+typedef struct _ze_physical_mem_handle_t *ze_physical_mem_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle of driver's fabric vertex object
+typedef struct _ze_fabric_vertex_handle_t *ze_fabric_vertex_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle of driver's fabric edge object
+typedef struct _ze_fabric_edge_handle_t *ze_fabric_edge_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_MAX_IPC_HANDLE_SIZE
+/// @brief Maximum IPC handle size
+#define ZE_MAX_IPC_HANDLE_SIZE  64
+#endif // ZE_MAX_IPC_HANDLE_SIZE
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief IPC handle to a memory allocation
+typedef struct _ze_ipc_mem_handle_t
+{
+    char data[ZE_MAX_IPC_HANDLE_SIZE];                                      ///< [out] Opaque data representing an IPC handle
+
+} ze_ipc_mem_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief IPC handle to a event pool allocation
+typedef struct _ze_ipc_event_pool_handle_t
+{
+    char data[ZE_MAX_IPC_HANDLE_SIZE];                                      ///< [out] Opaque data representing an IPC handle
+
+} ze_ipc_event_pool_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_BIT
+/// @brief Generic macro for enumerator bit masks
+#define ZE_BIT( _i )  ( 1 << _i )
+#endif // ZE_BIT
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Defines Return/Error codes
+typedef enum _ze_result_t
+{
+    ZE_RESULT_SUCCESS = 0,                                                  ///< [Core] success
+    ZE_RESULT_NOT_READY = 1,                                                ///< [Core] synchronization primitive not signaled
+    ZE_RESULT_ERROR_DEVICE_LOST = 0x70000001,                               ///< [Core] device hung, reset, was removed, or driver update occurred
+    ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY = 0x70000002,                        ///< [Core] insufficient host memory to satisfy call
+    ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY = 0x70000003,                      ///< [Core] insufficient device memory to satisfy call
+    ZE_RESULT_ERROR_MODULE_BUILD_FAILURE = 0x70000004,                      ///< [Core] error occurred when building module, see build log for details
+    ZE_RESULT_ERROR_MODULE_LINK_FAILURE = 0x70000005,                       ///< [Core] error occurred when linking modules, see build log for details
+    ZE_RESULT_ERROR_DEVICE_REQUIRES_RESET = 0x70000006,                     ///< [Core] device requires a reset
+    ZE_RESULT_ERROR_DEVICE_IN_LOW_POWER_STATE = 0x70000007,                 ///< [Core] device currently in low power state
+    ZE_RESULT_EXP_ERROR_DEVICE_IS_NOT_VERTEX = 0x7ff00001,                  ///< [Core, Experimental] device is not represented by a fabric vertex
+    ZE_RESULT_EXP_ERROR_VERTEX_IS_NOT_DEVICE = 0x7ff00002,                  ///< [Core, Experimental] fabric vertex does not represent a device
+    ZE_RESULT_EXP_ERROR_REMOTE_DEVICE = 0x7ff00003,                         ///< [Core, Experimental] fabric vertex represents a remote device or
+                                                                            ///< subdevice
+    ZE_RESULT_EXP_ERROR_OPERANDS_INCOMPATIBLE = 0x7ff00004,                 ///< [Core, Experimental] operands of comparison are not compatible
+    ZE_RESULT_EXP_RTAS_BUILD_RETRY = 0x7ff00005,                            ///< [Core, Experimental] ray tracing acceleration structure build
+                                                                            ///< operation failed due to insufficient resources, retry with a larger
+                                                                            ///< acceleration structure buffer allocation
+    ZE_RESULT_EXP_RTAS_BUILD_DEFERRED = 0x7ff00006,                         ///< [Core, Experimental] ray tracing acceleration structure build
+                                                                            ///< operation deferred to parallel operation join
+    ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS = 0x70010000,                  ///< [Sysman] access denied due to permission level
+    ZE_RESULT_ERROR_NOT_AVAILABLE = 0x70010001,                             ///< [Sysman] resource already in use and simultaneous access not allowed
+                                                                            ///< or resource was removed
+    ZE_RESULT_ERROR_DEPENDENCY_UNAVAILABLE = 0x70020000,                    ///< [Common] external required dependency is unavailable or missing
+    ZE_RESULT_WARNING_DROPPED_DATA = 0x70020001,                            ///< [Tools] data may have been dropped
+    ZE_RESULT_ERROR_UNINITIALIZED = 0x78000001,                             ///< [Validation] driver is not initialized
+    ZE_RESULT_ERROR_UNSUPPORTED_VERSION = 0x78000002,                       ///< [Validation] generic error code for unsupported versions
+    ZE_RESULT_ERROR_UNSUPPORTED_FEATURE = 0x78000003,                       ///< [Validation] generic error code for unsupported features
+    ZE_RESULT_ERROR_INVALID_ARGUMENT = 0x78000004,                          ///< [Validation] generic error code for invalid arguments
+    ZE_RESULT_ERROR_INVALID_NULL_HANDLE = 0x78000005,                       ///< [Validation] handle argument is not valid
+    ZE_RESULT_ERROR_HANDLE_OBJECT_IN_USE = 0x78000006,                      ///< [Validation] object pointed to by handle still in-use by device
+    ZE_RESULT_ERROR_INVALID_NULL_POINTER = 0x78000007,                      ///< [Validation] pointer argument may not be nullptr
+    ZE_RESULT_ERROR_INVALID_SIZE = 0x78000008,                              ///< [Validation] size argument is invalid (e.g., must not be zero)
+    ZE_RESULT_ERROR_UNSUPPORTED_SIZE = 0x78000009,                          ///< [Validation] size argument is not supported by the device (e.g., too
+                                                                            ///< large)
+    ZE_RESULT_ERROR_UNSUPPORTED_ALIGNMENT = 0x7800000a,                     ///< [Validation] alignment argument is not supported by the device (e.g.,
+                                                                            ///< too small)
+    ZE_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT = 0x7800000b,            ///< [Validation] synchronization object in invalid state
+    ZE_RESULT_ERROR_INVALID_ENUMERATION = 0x7800000c,                       ///< [Validation] enumerator argument is not valid
+    ZE_RESULT_ERROR_UNSUPPORTED_ENUMERATION = 0x7800000d,                   ///< [Validation] enumerator argument is not supported by the device
+    ZE_RESULT_ERROR_UNSUPPORTED_IMAGE_FORMAT = 0x7800000e,                  ///< [Validation] image format is not supported by the device
+    ZE_RESULT_ERROR_INVALID_NATIVE_BINARY = 0x7800000f,                     ///< [Validation] native binary is not supported by the device
+    ZE_RESULT_ERROR_INVALID_GLOBAL_NAME = 0x78000010,                       ///< [Validation] global variable is not found in the module
+    ZE_RESULT_ERROR_INVALID_KERNEL_NAME = 0x78000011,                       ///< [Validation] kernel name is not found in the module
+    ZE_RESULT_ERROR_INVALID_FUNCTION_NAME = 0x78000012,                     ///< [Validation] function name is not found in the module
+    ZE_RESULT_ERROR_INVALID_GROUP_SIZE_DIMENSION = 0x78000013,              ///< [Validation] group size dimension is not valid for the kernel or
+                                                                            ///< device
+    ZE_RESULT_ERROR_INVALID_GLOBAL_WIDTH_DIMENSION = 0x78000014,            ///< [Validation] global width dimension is not valid for the kernel or
+                                                                            ///< device
+    ZE_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX = 0x78000015,             ///< [Validation] kernel argument index is not valid for kernel
+    ZE_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE = 0x78000016,              ///< [Validation] kernel argument size does not match kernel
+    ZE_RESULT_ERROR_INVALID_KERNEL_ATTRIBUTE_VALUE = 0x78000017,            ///< [Validation] value of kernel attribute is not valid for the kernel or
+                                                                            ///< device
+    ZE_RESULT_ERROR_INVALID_MODULE_UNLINKED = 0x78000018,                   ///< [Validation] module with imports needs to be linked before kernels can
+                                                                            ///< be created from it.
+    ZE_RESULT_ERROR_INVALID_COMMAND_LIST_TYPE = 0x78000019,                 ///< [Validation] command list type does not match command queue type
+    ZE_RESULT_ERROR_OVERLAPPING_REGIONS = 0x7800001a,                       ///< [Validation] copy operations do not support overlapping regions of
+                                                                            ///< memory
+    ZE_RESULT_WARNING_ACTION_REQUIRED = 0x7800001b,                         ///< [Sysman] an action is required to complete the desired operation
+    ZE_RESULT_ERROR_INVALID_KERNEL_HANDLE = 0x7800001c,                     ///< [Core, Validation] kernel handle is invalid for the operation
+    ZE_RESULT_ERROR_UNKNOWN = 0x7ffffffe,                                   ///< [Core] unknown or internal error
+    ZE_RESULT_FORCE_UINT32 = 0x7fffffff
+
+} ze_result_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Defines structure types
+typedef enum _ze_structure_type_t
+{
+    ZE_STRUCTURE_TYPE_DRIVER_PROPERTIES = 0x1,                              ///< ::ze_driver_properties_t
+    ZE_STRUCTURE_TYPE_DRIVER_IPC_PROPERTIES = 0x2,                          ///< ::ze_driver_ipc_properties_t
+    ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES = 0x3,                              ///< ::ze_device_properties_t
+    ZE_STRUCTURE_TYPE_DEVICE_COMPUTE_PROPERTIES = 0x4,                      ///< ::ze_device_compute_properties_t
+    ZE_STRUCTURE_TYPE_DEVICE_MODULE_PROPERTIES = 0x5,                       ///< ::ze_device_module_properties_t
+    ZE_STRUCTURE_TYPE_COMMAND_QUEUE_GROUP_PROPERTIES = 0x6,                 ///< ::ze_command_queue_group_properties_t
+    ZE_STRUCTURE_TYPE_DEVICE_MEMORY_PROPERTIES = 0x7,                       ///< ::ze_device_memory_properties_t
+    ZE_STRUCTURE_TYPE_DEVICE_MEMORY_ACCESS_PROPERTIES = 0x8,                ///< ::ze_device_memory_access_properties_t
+    ZE_STRUCTURE_TYPE_DEVICE_CACHE_PROPERTIES = 0x9,                        ///< ::ze_device_cache_properties_t
+    ZE_STRUCTURE_TYPE_DEVICE_IMAGE_PROPERTIES = 0xa,                        ///< ::ze_device_image_properties_t
+    ZE_STRUCTURE_TYPE_DEVICE_P2P_PROPERTIES = 0xb,                          ///< ::ze_device_p2p_properties_t
+    ZE_STRUCTURE_TYPE_DEVICE_EXTERNAL_MEMORY_PROPERTIES = 0xc,              ///< ::ze_device_external_memory_properties_t
+    ZE_STRUCTURE_TYPE_CONTEXT_DESC = 0xd,                                   ///< ::ze_context_desc_t
+    ZE_STRUCTURE_TYPE_COMMAND_QUEUE_DESC = 0xe,                             ///< ::ze_command_queue_desc_t
+    ZE_STRUCTURE_TYPE_COMMAND_LIST_DESC = 0xf,                              ///< ::ze_command_list_desc_t
+    ZE_STRUCTURE_TYPE_EVENT_POOL_DESC = 0x10,                               ///< ::ze_event_pool_desc_t
+    ZE_STRUCTURE_TYPE_EVENT_DESC = 0x11,                                    ///< ::ze_event_desc_t
+    ZE_STRUCTURE_TYPE_FENCE_DESC = 0x12,                                    ///< ::ze_fence_desc_t
+    ZE_STRUCTURE_TYPE_IMAGE_DESC = 0x13,                                    ///< ::ze_image_desc_t
+    ZE_STRUCTURE_TYPE_IMAGE_PROPERTIES = 0x14,                              ///< ::ze_image_properties_t
+    ZE_STRUCTURE_TYPE_DEVICE_MEM_ALLOC_DESC = 0x15,                         ///< ::ze_device_mem_alloc_desc_t
+    ZE_STRUCTURE_TYPE_HOST_MEM_ALLOC_DESC = 0x16,                           ///< ::ze_host_mem_alloc_desc_t
+    ZE_STRUCTURE_TYPE_MEMORY_ALLOCATION_PROPERTIES = 0x17,                  ///< ::ze_memory_allocation_properties_t
+    ZE_STRUCTURE_TYPE_EXTERNAL_MEMORY_EXPORT_DESC = 0x18,                   ///< ::ze_external_memory_export_desc_t
+    ZE_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMPORT_FD = 0x19,                     ///< ::ze_external_memory_import_fd_t
+    ZE_STRUCTURE_TYPE_EXTERNAL_MEMORY_EXPORT_FD = 0x1a,                     ///< ::ze_external_memory_export_fd_t
+    ZE_STRUCTURE_TYPE_MODULE_DESC = 0x1b,                                   ///< ::ze_module_desc_t
+    ZE_STRUCTURE_TYPE_MODULE_PROPERTIES = 0x1c,                             ///< ::ze_module_properties_t
+    ZE_STRUCTURE_TYPE_KERNEL_DESC = 0x1d,                                   ///< ::ze_kernel_desc_t
+    ZE_STRUCTURE_TYPE_KERNEL_PROPERTIES = 0x1e,                             ///< ::ze_kernel_properties_t
+    ZE_STRUCTURE_TYPE_SAMPLER_DESC = 0x1f,                                  ///< ::ze_sampler_desc_t
+    ZE_STRUCTURE_TYPE_PHYSICAL_MEM_DESC = 0x20,                             ///< ::ze_physical_mem_desc_t
+    ZE_STRUCTURE_TYPE_KERNEL_PREFERRED_GROUP_SIZE_PROPERTIES = 0x21,        ///< ::ze_kernel_preferred_group_size_properties_t
+    ZE_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMPORT_WIN32 = 0x22,                  ///< ::ze_external_memory_import_win32_handle_t
+    ZE_STRUCTURE_TYPE_EXTERNAL_MEMORY_EXPORT_WIN32 = 0x23,                  ///< ::ze_external_memory_export_win32_handle_t
+    ZE_STRUCTURE_TYPE_DEVICE_RAYTRACING_EXT_PROPERTIES = 0x00010001,        ///< ::ze_device_raytracing_ext_properties_t
+    ZE_STRUCTURE_TYPE_RAYTRACING_MEM_ALLOC_EXT_DESC = 0x10002,              ///< ::ze_raytracing_mem_alloc_ext_desc_t
+    ZE_STRUCTURE_TYPE_FLOAT_ATOMIC_EXT_PROPERTIES = 0x10003,                ///< ::ze_float_atomic_ext_properties_t
+    ZE_STRUCTURE_TYPE_CACHE_RESERVATION_EXT_DESC = 0x10004,                 ///< ::ze_cache_reservation_ext_desc_t
+    ZE_STRUCTURE_TYPE_EU_COUNT_EXT = 0x10005,                               ///< ::ze_eu_count_ext_t
+    ZE_STRUCTURE_TYPE_SRGB_EXT_DESC = 0x10006,                              ///< ::ze_srgb_ext_desc_t
+    ZE_STRUCTURE_TYPE_LINKAGE_INSPECTION_EXT_DESC = 0x10007,                ///< ::ze_linkage_inspection_ext_desc_t
+    ZE_STRUCTURE_TYPE_PCI_EXT_PROPERTIES = 0x10008,                         ///< ::ze_pci_ext_properties_t
+    ZE_STRUCTURE_TYPE_DRIVER_MEMORY_FREE_EXT_PROPERTIES = 0x10009,          ///< ::ze_driver_memory_free_ext_properties_t
+    ZE_STRUCTURE_TYPE_MEMORY_FREE_EXT_DESC = 0x1000a,                       ///< ::ze_memory_free_ext_desc_t
+    ZE_STRUCTURE_TYPE_MEMORY_COMPRESSION_HINTS_EXT_DESC = 0x1000b,          ///< ::ze_memory_compression_hints_ext_desc_t
+    ZE_STRUCTURE_TYPE_IMAGE_ALLOCATION_EXT_PROPERTIES = 0x1000c,            ///< ::ze_image_allocation_ext_properties_t
+    ZE_STRUCTURE_TYPE_DEVICE_LUID_EXT_PROPERTIES = 0x1000d,                 ///< ::ze_device_luid_ext_properties_t
+    ZE_STRUCTURE_TYPE_DEVICE_MEMORY_EXT_PROPERTIES = 0x1000e,               ///< ::ze_device_memory_ext_properties_t
+    ZE_STRUCTURE_TYPE_DEVICE_IP_VERSION_EXT = 0x1000f,                      ///< ::ze_device_ip_version_ext_t
+    ZE_STRUCTURE_TYPE_IMAGE_VIEW_PLANAR_EXT_DESC = 0x10010,                 ///< ::ze_image_view_planar_ext_desc_t
+    ZE_STRUCTURE_TYPE_EVENT_QUERY_KERNEL_TIMESTAMPS_EXT_PROPERTIES = 0x10011,   ///< ::ze_event_query_kernel_timestamps_ext_properties_t
+    ZE_STRUCTURE_TYPE_EVENT_QUERY_KERNEL_TIMESTAMPS_RESULTS_EXT_PROPERTIES = 0x10012,   ///< ::ze_event_query_kernel_timestamps_results_ext_properties_t
+    ZE_STRUCTURE_TYPE_KERNEL_MAX_GROUP_SIZE_EXT_PROPERTIES = 0x10013,       ///< ::ze_kernel_max_group_size_ext_properties_t
+    ZE_STRUCTURE_TYPE_RELAXED_ALLOCATION_LIMITS_EXP_DESC = 0x00020001,      ///< ::ze_relaxed_allocation_limits_exp_desc_t
+    ZE_STRUCTURE_TYPE_MODULE_PROGRAM_EXP_DESC = 0x00020002,                 ///< ::ze_module_program_exp_desc_t
+    ZE_STRUCTURE_TYPE_SCHEDULING_HINT_EXP_PROPERTIES = 0x00020003,          ///< ::ze_scheduling_hint_exp_properties_t
+    ZE_STRUCTURE_TYPE_SCHEDULING_HINT_EXP_DESC = 0x00020004,                ///< ::ze_scheduling_hint_exp_desc_t
+    ZE_STRUCTURE_TYPE_IMAGE_VIEW_PLANAR_EXP_DESC = 0x00020005,              ///< ::ze_image_view_planar_exp_desc_t
+    ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES_1_2 = 0x00020006,                   ///< ::ze_device_properties_t
+    ZE_STRUCTURE_TYPE_IMAGE_MEMORY_EXP_PROPERTIES = 0x00020007,             ///< ::ze_image_memory_properties_exp_t
+    ZE_STRUCTURE_TYPE_POWER_SAVING_HINT_EXP_DESC = 0x00020008,              ///< ::ze_context_power_saving_hint_exp_desc_t
+    ZE_STRUCTURE_TYPE_COPY_BANDWIDTH_EXP_PROPERTIES = 0x00020009,           ///< ::ze_copy_bandwidth_exp_properties_t
+    ZE_STRUCTURE_TYPE_DEVICE_P2P_BANDWIDTH_EXP_PROPERTIES = 0x0002000A,     ///< ::ze_device_p2p_bandwidth_exp_properties_t
+    ZE_STRUCTURE_TYPE_FABRIC_VERTEX_EXP_PROPERTIES = 0x0002000B,            ///< ::ze_fabric_vertex_exp_properties_t
+    ZE_STRUCTURE_TYPE_FABRIC_EDGE_EXP_PROPERTIES = 0x0002000C,              ///< ::ze_fabric_edge_exp_properties_t
+    ZE_STRUCTURE_TYPE_MEMORY_SUB_ALLOCATIONS_EXP_PROPERTIES = 0x0002000D,   ///< ::ze_memory_sub_allocations_exp_properties_t
+    ZE_STRUCTURE_TYPE_RTAS_BUILDER_EXP_DESC = 0x0002000E,                   ///< ::ze_rtas_builder_exp_desc_t
+    ZE_STRUCTURE_TYPE_RTAS_BUILDER_BUILD_OP_EXP_DESC = 0x0002000F,          ///< ::ze_rtas_builder_build_op_exp_desc_t
+    ZE_STRUCTURE_TYPE_RTAS_BUILDER_EXP_PROPERTIES = 0x00020010,             ///< ::ze_rtas_builder_exp_properties_t
+    ZE_STRUCTURE_TYPE_RTAS_PARALLEL_OPERATION_EXP_PROPERTIES = 0x00020011,  ///< ::ze_rtas_parallel_operation_exp_properties_t
+    ZE_STRUCTURE_TYPE_RTAS_DEVICE_EXP_PROPERTIES = 0x00020012,              ///< ::ze_rtas_device_exp_properties_t
+    ZE_STRUCTURE_TYPE_RTAS_GEOMETRY_AABBS_EXP_CB_PARAMS = 0x00020013,       ///< ::ze_rtas_geometry_aabbs_exp_cb_params_t
+    ZE_STRUCTURE_TYPE_COUNTER_BASED_EVENT_POOL_EXP_DESC = 0x00020014,       ///< ::ze_event_pool_counter_based_exp_desc_t
+    ZE_STRUCTURE_TYPE_MUTABLE_COMMAND_LIST_EXP_PROPERTIES = 0x00020015,     ///< ::ze_mutable_command_list_exp_properties_t
+    ZE_STRUCTURE_TYPE_MUTABLE_COMMAND_LIST_EXP_DESC = 0x00020016,           ///< ::ze_mutable_command_list_exp_desc_t
+    ZE_STRUCTURE_TYPE_MUTABLE_COMMAND_ID_EXP_DESC = 0x00020017,             ///< ::ze_mutable_command_id_exp_desc_t
+    ZE_STRUCTURE_TYPE_MUTABLE_COMMANDS_EXP_DESC = 0x00020018,               ///< ::ze_mutable_commands_exp_desc_t
+    ZE_STRUCTURE_TYPE_MUTABLE_KERNEL_ARGUMENT_EXP_DESC = 0x00020019,        ///< ::ze_mutable_kernel_argument_exp_desc_t
+    ZE_STRUCTURE_TYPE_MUTABLE_GROUP_COUNT_EXP_DESC = 0x0002001A,            ///< ::ze_mutable_group_count_exp_desc_t
+    ZE_STRUCTURE_TYPE_MUTABLE_GROUP_SIZE_EXP_DESC = 0x0002001B,             ///< ::ze_mutable_group_size_exp_desc_t
+    ZE_STRUCTURE_TYPE_MUTABLE_GLOBAL_OFFSET_EXP_DESC = 0x0002001C,          ///< ::ze_mutable_global_offset_exp_desc_t
+    ZE_STRUCTURE_TYPE_PITCHED_ALLOC_DEVICE_EXP_PROPERTIES = 0x0002001D,     ///< ::ze_device_pitched_alloc_exp_properties_t
+    ZE_STRUCTURE_TYPE_BINDLESS_IMAGE_EXP_DESC = 0x0002001E,                 ///< ::ze_image_bindless_exp_desc_t
+    ZE_STRUCTURE_TYPE_PITCHED_IMAGE_EXP_DESC = 0x0002001F,                  ///< ::ze_image_pitched_exp_desc_t
+    ZE_STRUCTURE_TYPE_MUTABLE_GRAPH_ARGUMENT_EXP_DESC = 0x00020020,         ///< ::ze_mutable_graph_argument_exp_desc_t
+    ZE_STRUCTURE_TYPE_INIT_DRIVER_TYPE_DESC = 0x00020021,                   ///< ::ze_init_driver_type_desc_t
+    ZE_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_EXT_DESC = 0x00020022,             ///< ::ze_external_semaphore_ext_desc_t
+    ZE_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_WIN32_EXT_DESC = 0x00020023,       ///< ::ze_external_semaphore_win32_ext_desc_t
+    ZE_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_FD_EXT_DESC = 0x00020024,          ///< ::ze_external_semaphore_fd_ext_desc_t
+    ZE_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS_EXT = 0x00020025,    ///< ::ze_external_semaphore_signal_params_ext_t
+    ZE_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_WAIT_PARAMS_EXT = 0x00020026,      ///< ::ze_external_semaphore_wait_params_ext_t
+    ZE_STRUCTURE_TYPE_DRIVER_DDI_HANDLES_EXT_PROPERTIES = 0x00020027,       ///< ::ze_driver_ddi_handles_ext_properties_t
+    ZE_STRUCTURE_TYPE_FORCE_UINT32 = 0x7fffffff
+
+} ze_structure_type_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief External memory type flags
+typedef uint32_t ze_external_memory_type_flags_t;
+typedef enum _ze_external_memory_type_flag_t
+{
+    ZE_EXTERNAL_MEMORY_TYPE_FLAG_OPAQUE_FD = ZE_BIT(0),                     ///< an opaque POSIX file descriptor handle
+    ZE_EXTERNAL_MEMORY_TYPE_FLAG_DMA_BUF = ZE_BIT(1),                       ///< a file descriptor handle for a Linux dma_buf
+    ZE_EXTERNAL_MEMORY_TYPE_FLAG_OPAQUE_WIN32 = ZE_BIT(2),                  ///< an NT handle
+    ZE_EXTERNAL_MEMORY_TYPE_FLAG_OPAQUE_WIN32_KMT = ZE_BIT(3),              ///< a global share (KMT) handle
+    ZE_EXTERNAL_MEMORY_TYPE_FLAG_D3D11_TEXTURE = ZE_BIT(4),                 ///< an NT handle referring to a Direct3D 10 or 11 texture resource
+    ZE_EXTERNAL_MEMORY_TYPE_FLAG_D3D11_TEXTURE_KMT = ZE_BIT(5),             ///< a global share (KMT) handle referring to a Direct3D 10 or 11 texture
+                                                                            ///< resource
+    ZE_EXTERNAL_MEMORY_TYPE_FLAG_D3D12_HEAP = ZE_BIT(6),                    ///< an NT handle referring to a Direct3D 12 heap resource
+    ZE_EXTERNAL_MEMORY_TYPE_FLAG_D3D12_RESOURCE = ZE_BIT(7),                ///< an NT handle referring to a Direct3D 12 committed resource
+    ZE_EXTERNAL_MEMORY_TYPE_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_external_memory_type_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Bandwidth unit
+typedef enum _ze_bandwidth_unit_t
+{
+    ZE_BANDWIDTH_UNIT_UNKNOWN = 0,                                          ///< The unit used for bandwidth is unknown
+    ZE_BANDWIDTH_UNIT_BYTES_PER_NANOSEC = 1,                                ///< Bandwidth is provided in bytes/nanosec
+    ZE_BANDWIDTH_UNIT_BYTES_PER_CLOCK = 2,                                  ///< Bandwidth is provided in bytes/clock
+    ZE_BANDWIDTH_UNIT_FORCE_UINT32 = 0x7fffffff
+
+} ze_bandwidth_unit_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Latency unit
+typedef enum _ze_latency_unit_t
+{
+    ZE_LATENCY_UNIT_UNKNOWN = 0,                                            ///< The unit used for latency is unknown
+    ZE_LATENCY_UNIT_NANOSEC = 1,                                            ///< Latency is provided in nanosecs
+    ZE_LATENCY_UNIT_CLOCK = 2,                                              ///< Latency is provided in clocks
+    ZE_LATENCY_UNIT_HOP = 3,                                                ///< Latency is provided in hops (normalized so that the lowest latency
+                                                                            ///< link has a latency of 1 hop)
+    ZE_LATENCY_UNIT_FORCE_UINT32 = 0x7fffffff
+
+} ze_latency_unit_t;
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_MAX_UUID_SIZE
+/// @brief Maximum universal unique id (UUID) size in bytes
+#define ZE_MAX_UUID_SIZE  16
+#endif // ZE_MAX_UUID_SIZE
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Universal unique id (UUID)
+typedef struct _ze_uuid_t
+{
+    uint8_t id[ZE_MAX_UUID_SIZE];                                           ///< [out] opaque data representing a UUID
+
+} ze_uuid_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Base for all callback function parameter types
+typedef struct _ze_base_cb_params_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+
+} ze_base_cb_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Base for all properties types
+typedef struct _ze_base_properties_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+
+} ze_base_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Base for all descriptor types
+typedef struct _ze_base_desc_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+
+} ze_base_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forces driver to only report devices (and sub-devices) as specified by
+///        values
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forces driver to report devices from lowest to highest PCI bus ID
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forces all shared allocations into device memory
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Defines the device hierarchy model exposed by Level Zero driver
+///        implementation
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_ipc_mem_handle_t
+typedef struct _ze_ipc_mem_handle_t ze_ipc_mem_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_ipc_event_pool_handle_t
+typedef struct _ze_ipc_event_pool_handle_t ze_ipc_event_pool_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_uuid_t
+typedef struct _ze_uuid_t ze_uuid_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_base_cb_params_t
+typedef struct _ze_base_cb_params_t ze_base_cb_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_base_properties_t
+typedef struct _ze_base_properties_t ze_base_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_base_desc_t
+typedef struct _ze_base_desc_t ze_base_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_init_driver_type_desc_t
+typedef struct _ze_init_driver_type_desc_t ze_init_driver_type_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_driver_uuid_t
+typedef struct _ze_driver_uuid_t ze_driver_uuid_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_driver_properties_t
+typedef struct _ze_driver_properties_t ze_driver_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_driver_ipc_properties_t
+typedef struct _ze_driver_ipc_properties_t ze_driver_ipc_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_driver_extension_properties_t
+typedef struct _ze_driver_extension_properties_t ze_driver_extension_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_device_uuid_t
+typedef struct _ze_device_uuid_t ze_device_uuid_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_device_properties_t
+typedef struct _ze_device_properties_t ze_device_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_device_thread_t
+typedef struct _ze_device_thread_t ze_device_thread_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_device_compute_properties_t
+typedef struct _ze_device_compute_properties_t ze_device_compute_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_native_kernel_uuid_t
+typedef struct _ze_native_kernel_uuid_t ze_native_kernel_uuid_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_device_module_properties_t
+typedef struct _ze_device_module_properties_t ze_device_module_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_command_queue_group_properties_t
+typedef struct _ze_command_queue_group_properties_t ze_command_queue_group_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_device_memory_properties_t
+typedef struct _ze_device_memory_properties_t ze_device_memory_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_device_memory_access_properties_t
+typedef struct _ze_device_memory_access_properties_t ze_device_memory_access_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_device_cache_properties_t
+typedef struct _ze_device_cache_properties_t ze_device_cache_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_device_image_properties_t
+typedef struct _ze_device_image_properties_t ze_device_image_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_device_external_memory_properties_t
+typedef struct _ze_device_external_memory_properties_t ze_device_external_memory_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_device_p2p_properties_t
+typedef struct _ze_device_p2p_properties_t ze_device_p2p_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_context_desc_t
+typedef struct _ze_context_desc_t ze_context_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_command_queue_desc_t
+typedef struct _ze_command_queue_desc_t ze_command_queue_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_command_list_desc_t
+typedef struct _ze_command_list_desc_t ze_command_list_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_copy_region_t
+typedef struct _ze_copy_region_t ze_copy_region_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_image_region_t
+typedef struct _ze_image_region_t ze_image_region_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_event_pool_desc_t
+typedef struct _ze_event_pool_desc_t ze_event_pool_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_event_desc_t
+typedef struct _ze_event_desc_t ze_event_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_kernel_timestamp_data_t
+typedef struct _ze_kernel_timestamp_data_t ze_kernel_timestamp_data_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_kernel_timestamp_result_t
+typedef struct _ze_kernel_timestamp_result_t ze_kernel_timestamp_result_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_fence_desc_t
+typedef struct _ze_fence_desc_t ze_fence_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_image_format_t
+typedef struct _ze_image_format_t ze_image_format_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_image_desc_t
+typedef struct _ze_image_desc_t ze_image_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_image_properties_t
+typedef struct _ze_image_properties_t ze_image_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_device_mem_alloc_desc_t
+typedef struct _ze_device_mem_alloc_desc_t ze_device_mem_alloc_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_host_mem_alloc_desc_t
+typedef struct _ze_host_mem_alloc_desc_t ze_host_mem_alloc_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_memory_allocation_properties_t
+typedef struct _ze_memory_allocation_properties_t ze_memory_allocation_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_external_memory_export_desc_t
+typedef struct _ze_external_memory_export_desc_t ze_external_memory_export_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_external_memory_import_fd_t
+typedef struct _ze_external_memory_import_fd_t ze_external_memory_import_fd_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_external_memory_export_fd_t
+typedef struct _ze_external_memory_export_fd_t ze_external_memory_export_fd_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_external_memory_import_win32_handle_t
+typedef struct _ze_external_memory_import_win32_handle_t ze_external_memory_import_win32_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_external_memory_export_win32_handle_t
+typedef struct _ze_external_memory_export_win32_handle_t ze_external_memory_export_win32_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_module_constants_t
+typedef struct _ze_module_constants_t ze_module_constants_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_module_desc_t
+typedef struct _ze_module_desc_t ze_module_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_module_properties_t
+typedef struct _ze_module_properties_t ze_module_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_kernel_desc_t
+typedef struct _ze_kernel_desc_t ze_kernel_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_kernel_uuid_t
+typedef struct _ze_kernel_uuid_t ze_kernel_uuid_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_kernel_properties_t
+typedef struct _ze_kernel_properties_t ze_kernel_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_kernel_preferred_group_size_properties_t
+typedef struct _ze_kernel_preferred_group_size_properties_t ze_kernel_preferred_group_size_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_group_count_t
+typedef struct _ze_group_count_t ze_group_count_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_module_program_exp_desc_t
+typedef struct _ze_module_program_exp_desc_t ze_module_program_exp_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_device_raytracing_ext_properties_t
+typedef struct _ze_device_raytracing_ext_properties_t ze_device_raytracing_ext_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_raytracing_mem_alloc_ext_desc_t
+typedef struct _ze_raytracing_mem_alloc_ext_desc_t ze_raytracing_mem_alloc_ext_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_sampler_desc_t
+typedef struct _ze_sampler_desc_t ze_sampler_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_physical_mem_desc_t
+typedef struct _ze_physical_mem_desc_t ze_physical_mem_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_float_atomic_ext_properties_t
+typedef struct _ze_float_atomic_ext_properties_t ze_float_atomic_ext_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_relaxed_allocation_limits_exp_desc_t
+typedef struct _ze_relaxed_allocation_limits_exp_desc_t ze_relaxed_allocation_limits_exp_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_driver_ddi_handles_ext_properties_t
+typedef struct _ze_driver_ddi_handles_ext_properties_t ze_driver_ddi_handles_ext_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_external_semaphore_ext_desc_t
+typedef struct _ze_external_semaphore_ext_desc_t ze_external_semaphore_ext_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_external_semaphore_win32_ext_desc_t
+typedef struct _ze_external_semaphore_win32_ext_desc_t ze_external_semaphore_win32_ext_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_external_semaphore_fd_ext_desc_t
+typedef struct _ze_external_semaphore_fd_ext_desc_t ze_external_semaphore_fd_ext_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_external_semaphore_signal_params_ext_t
+typedef struct _ze_external_semaphore_signal_params_ext_t ze_external_semaphore_signal_params_ext_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_external_semaphore_wait_params_ext_t
+typedef struct _ze_external_semaphore_wait_params_ext_t ze_external_semaphore_wait_params_ext_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_cache_reservation_ext_desc_t
+typedef struct _ze_cache_reservation_ext_desc_t ze_cache_reservation_ext_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_image_memory_properties_exp_t
+typedef struct _ze_image_memory_properties_exp_t ze_image_memory_properties_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_image_view_planar_ext_desc_t
+typedef struct _ze_image_view_planar_ext_desc_t ze_image_view_planar_ext_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_image_view_planar_exp_desc_t
+typedef struct _ze_image_view_planar_exp_desc_t ze_image_view_planar_exp_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_scheduling_hint_exp_properties_t
+typedef struct _ze_scheduling_hint_exp_properties_t ze_scheduling_hint_exp_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_scheduling_hint_exp_desc_t
+typedef struct _ze_scheduling_hint_exp_desc_t ze_scheduling_hint_exp_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_context_power_saving_hint_exp_desc_t
+typedef struct _ze_context_power_saving_hint_exp_desc_t ze_context_power_saving_hint_exp_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_eu_count_ext_t
+typedef struct _ze_eu_count_ext_t ze_eu_count_ext_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_pci_address_ext_t
+typedef struct _ze_pci_address_ext_t ze_pci_address_ext_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_pci_speed_ext_t
+typedef struct _ze_pci_speed_ext_t ze_pci_speed_ext_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_pci_ext_properties_t
+typedef struct _ze_pci_ext_properties_t ze_pci_ext_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_srgb_ext_desc_t
+typedef struct _ze_srgb_ext_desc_t ze_srgb_ext_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_image_allocation_ext_properties_t
+typedef struct _ze_image_allocation_ext_properties_t ze_image_allocation_ext_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_linkage_inspection_ext_desc_t
+typedef struct _ze_linkage_inspection_ext_desc_t ze_linkage_inspection_ext_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_memory_compression_hints_ext_desc_t
+typedef struct _ze_memory_compression_hints_ext_desc_t ze_memory_compression_hints_ext_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_driver_memory_free_ext_properties_t
+typedef struct _ze_driver_memory_free_ext_properties_t ze_driver_memory_free_ext_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_memory_free_ext_desc_t
+typedef struct _ze_memory_free_ext_desc_t ze_memory_free_ext_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_device_p2p_bandwidth_exp_properties_t
+typedef struct _ze_device_p2p_bandwidth_exp_properties_t ze_device_p2p_bandwidth_exp_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_copy_bandwidth_exp_properties_t
+typedef struct _ze_copy_bandwidth_exp_properties_t ze_copy_bandwidth_exp_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_device_luid_ext_t
+typedef struct _ze_device_luid_ext_t ze_device_luid_ext_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_device_luid_ext_properties_t
+typedef struct _ze_device_luid_ext_properties_t ze_device_luid_ext_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_fabric_vertex_pci_exp_address_t
+typedef struct _ze_fabric_vertex_pci_exp_address_t ze_fabric_vertex_pci_exp_address_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_fabric_vertex_exp_properties_t
+typedef struct _ze_fabric_vertex_exp_properties_t ze_fabric_vertex_exp_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_fabric_edge_exp_properties_t
+typedef struct _ze_fabric_edge_exp_properties_t ze_fabric_edge_exp_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_device_memory_ext_properties_t
+typedef struct _ze_device_memory_ext_properties_t ze_device_memory_ext_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_device_ip_version_ext_t
+typedef struct _ze_device_ip_version_ext_t ze_device_ip_version_ext_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_kernel_max_group_size_properties_ext_t
+typedef struct _ze_kernel_max_group_size_properties_ext_t ze_kernel_max_group_size_properties_ext_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_sub_allocation_t
+typedef struct _ze_sub_allocation_t ze_sub_allocation_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_memory_sub_allocations_exp_properties_t
+typedef struct _ze_memory_sub_allocations_exp_properties_t ze_memory_sub_allocations_exp_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_event_query_kernel_timestamps_ext_properties_t
+typedef struct _ze_event_query_kernel_timestamps_ext_properties_t ze_event_query_kernel_timestamps_ext_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_synchronized_timestamp_data_ext_t
+typedef struct _ze_synchronized_timestamp_data_ext_t ze_synchronized_timestamp_data_ext_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_synchronized_timestamp_result_ext_t
+typedef struct _ze_synchronized_timestamp_result_ext_t ze_synchronized_timestamp_result_ext_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_event_query_kernel_timestamps_results_ext_properties_t
+typedef struct _ze_event_query_kernel_timestamps_results_ext_properties_t ze_event_query_kernel_timestamps_results_ext_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_rtas_builder_exp_desc_t
+typedef struct _ze_rtas_builder_exp_desc_t ze_rtas_builder_exp_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_rtas_builder_exp_properties_t
+typedef struct _ze_rtas_builder_exp_properties_t ze_rtas_builder_exp_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_rtas_parallel_operation_exp_properties_t
+typedef struct _ze_rtas_parallel_operation_exp_properties_t ze_rtas_parallel_operation_exp_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_rtas_device_exp_properties_t
+typedef struct _ze_rtas_device_exp_properties_t ze_rtas_device_exp_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_rtas_float3_exp_t
+typedef struct _ze_rtas_float3_exp_t ze_rtas_float3_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_rtas_transform_float3x4_column_major_exp_t
+typedef struct _ze_rtas_transform_float3x4_column_major_exp_t ze_rtas_transform_float3x4_column_major_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_rtas_transform_float3x4_aligned_column_major_exp_t
+typedef struct _ze_rtas_transform_float3x4_aligned_column_major_exp_t ze_rtas_transform_float3x4_aligned_column_major_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_rtas_transform_float3x4_row_major_exp_t
+typedef struct _ze_rtas_transform_float3x4_row_major_exp_t ze_rtas_transform_float3x4_row_major_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_rtas_aabb_exp_t
+typedef struct _ze_rtas_aabb_exp_t ze_rtas_aabb_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_rtas_triangle_indices_uint32_exp_t
+typedef struct _ze_rtas_triangle_indices_uint32_exp_t ze_rtas_triangle_indices_uint32_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_rtas_quad_indices_uint32_exp_t
+typedef struct _ze_rtas_quad_indices_uint32_exp_t ze_rtas_quad_indices_uint32_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_rtas_builder_geometry_info_exp_t
+typedef struct _ze_rtas_builder_geometry_info_exp_t ze_rtas_builder_geometry_info_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_rtas_builder_triangles_geometry_info_exp_t
+typedef struct _ze_rtas_builder_triangles_geometry_info_exp_t ze_rtas_builder_triangles_geometry_info_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_rtas_builder_quads_geometry_info_exp_t
+typedef struct _ze_rtas_builder_quads_geometry_info_exp_t ze_rtas_builder_quads_geometry_info_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_rtas_geometry_aabbs_exp_cb_params_t
+typedef struct _ze_rtas_geometry_aabbs_exp_cb_params_t ze_rtas_geometry_aabbs_exp_cb_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_rtas_builder_procedural_geometry_info_exp_t
+typedef struct _ze_rtas_builder_procedural_geometry_info_exp_t ze_rtas_builder_procedural_geometry_info_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_rtas_builder_instance_geometry_info_exp_t
+typedef struct _ze_rtas_builder_instance_geometry_info_exp_t ze_rtas_builder_instance_geometry_info_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_rtas_builder_build_op_exp_desc_t
+typedef struct _ze_rtas_builder_build_op_exp_desc_t ze_rtas_builder_build_op_exp_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_event_pool_counter_based_exp_desc_t
+typedef struct _ze_event_pool_counter_based_exp_desc_t ze_event_pool_counter_based_exp_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_image_bindless_exp_desc_t
+typedef struct _ze_image_bindless_exp_desc_t ze_image_bindless_exp_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_image_pitched_exp_desc_t
+typedef struct _ze_image_pitched_exp_desc_t ze_image_pitched_exp_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_device_pitched_alloc_exp_properties_t
+typedef struct _ze_device_pitched_alloc_exp_properties_t ze_device_pitched_alloc_exp_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_mutable_command_id_exp_desc_t
+typedef struct _ze_mutable_command_id_exp_desc_t ze_mutable_command_id_exp_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_mutable_command_list_exp_properties_t
+typedef struct _ze_mutable_command_list_exp_properties_t ze_mutable_command_list_exp_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_mutable_command_list_exp_desc_t
+typedef struct _ze_mutable_command_list_exp_desc_t ze_mutable_command_list_exp_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_mutable_commands_exp_desc_t
+typedef struct _ze_mutable_commands_exp_desc_t ze_mutable_commands_exp_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_mutable_kernel_argument_exp_desc_t
+typedef struct _ze_mutable_kernel_argument_exp_desc_t ze_mutable_kernel_argument_exp_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_mutable_group_count_exp_desc_t
+typedef struct _ze_mutable_group_count_exp_desc_t ze_mutable_group_count_exp_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_mutable_group_size_exp_desc_t
+typedef struct _ze_mutable_group_size_exp_desc_t ze_mutable_group_size_exp_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_mutable_global_offset_exp_desc_t
+typedef struct _ze_mutable_global_offset_exp_desc_t ze_mutable_global_offset_exp_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare ze_mutable_graph_argument_exp_desc_t
+typedef struct _ze_mutable_graph_argument_exp_desc_t ze_mutable_graph_argument_exp_desc_t;
+
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero APIs
+#if !defined(__GNUC__)
+#pragma region driver
+#endif
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported initialization flags
+typedef uint32_t ze_init_flags_t;
+typedef enum _ze_init_flag_t
+{
+    ZE_INIT_FLAG_GPU_ONLY = ZE_BIT(0),                                      ///< only initialize GPU drivers
+    ZE_INIT_FLAG_VPU_ONLY = ZE_BIT(1),                                      ///< only initialize VPU drivers
+    ZE_INIT_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_init_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Initialize the 'oneAPI' driver(s)
+/// 
+/// @details
+///     - @deprecated since 1.10. Please use zeInitDrivers()
+///     - The application must call this function or zeInitDrivers before
+///       calling any other function.
+///     - If this function is not called then all other functions will return
+///       ::ZE_RESULT_ERROR_UNINITIALIZED.
+///     - Only one instance of each driver will be initialized per process.
+///     - The application may call this function multiple times with different
+///       flags or environment variables enabled.
+///     - The application must call this function after forking new processes.
+///       Each forked process must call this function.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function must be thread-safe for scenarios
+///       where multiple libraries may initialize the driver(s) simultaneously.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `0x3 < flags`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeInit(
+    ze_init_flags_t flags                                                   ///< [in] initialization flags.
+                                                                            ///< must be 0 (default) or a combination of ::ze_init_flag_t.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves driver instances
+/// 
+/// @details
+///     - @deprecated since 1.10. Please use zeInitDrivers()
+///     - Usage of zeInitDrivers and zeDriverGet is mutually exclusive and
+///       should not be used together. Usage of them together will result in
+///       undefined behavior.
+///     - A driver represents a collection of physical devices.
+///     - Multiple calls to this function will return identical driver handles,
+///       in the same order.
+///     - The application may pass nullptr for pDrivers when only querying the
+///       number of drivers.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @remarks
+///   _Analogues_
+///     - clGetPlatformIDs
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeDriverGet(
+    uint32_t* pCount,                                                       ///< [in,out] pointer to the number of driver instances.
+                                                                            ///< if count is zero, then the loader shall update the value with the
+                                                                            ///< total number of drivers available.
+                                                                            ///< if count is greater than the number of drivers available, then the
+                                                                            ///< loader shall update the value with the correct number of drivers available.
+    ze_driver_handle_t* phDrivers                                           ///< [in,out][optional][range(0, *pCount)] array of driver instance handles.
+                                                                            ///< if count is less than the number of drivers available, then the loader
+                                                                            ///< shall only retrieve that number of drivers.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported driver initialization type flags
+/// 
+/// @details
+///     - Bit Field which details the driver types to be initialized and
+///       returned to the user.
+///     - Value Definition:
+///     - 0, do not init or retrieve any drivers.
+///     - ZE_INIT_DRIVER_TYPE_FLAG_GPU,	GPU Drivers are Init and driver handles
+///       retrieved.
+///     - ZE_INIT_DRIVER_TYPE_FLAG_NPU,	NPU Drivers are Init and driver handles
+///       retrieved.
+///     - ZE_INIT_DRIVER_TYPE_FLAG_GPU | ZE_INIT_DRIVER_TYPE_FLAG_NPU, NPU & GPU
+///       Drivers are Init and driver handles retrieved.
+///     - UINT32_MAX	All Drivers of any type are Init and driver handles
+///       retrieved.
+typedef uint32_t ze_init_driver_type_flags_t;
+typedef enum _ze_init_driver_type_flag_t
+{
+    ZE_INIT_DRIVER_TYPE_FLAG_GPU = ZE_BIT(0),                               ///< initialize and retrieve GPU drivers
+    ZE_INIT_DRIVER_TYPE_FLAG_NPU = ZE_BIT(1),                               ///< initialize and retrieve NPU drivers
+    ZE_INIT_DRIVER_TYPE_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_init_driver_type_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Init Driver Type descriptor
+typedef struct _ze_init_driver_type_desc_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_init_driver_type_flags_t flags;                                      ///< [in] driver type init flags.
+                                                                            ///< must be a valid combination of ::ze_init_driver_type_flag_t or UINT32_MAX;
+                                                                            ///< driver types are init and retrieved based on these init flags in zeInitDrivers().
+
+} ze_init_driver_type_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Initialize the 'oneAPI' driver(s) based on the driver types requested
+///        and retrieve the driver handles.
+/// 
+/// @details
+///     - The application must call this function or zeInit before calling any
+///       other function. (zeInit is [Deprecated] and is replaced by
+///       zeInitDrivers)
+///     - Calls to zeInit[Deprecated] or InitDrivers will not alter the drivers
+///       retrieved thru either api.
+///     - Drivers init thru zeInit[Deprecated] or InitDrivers will not be
+///       reInitialized once init in an application. The Loader will determine
+///       if the already init driver needs to be delivered to the user thru the
+///       init type flags.
+///     - Already init Drivers will not be uninitialized if the call to
+///       InitDrivers does not include that driver's type. Those init drivers
+///       which don't match the init flags will not have their driver handles
+///       returned to the user in that InitDrivers call.
+///     - If this function or zeInit[Deprecated] is not called, then all other
+///       functions will return ::ZE_RESULT_ERROR_UNINITIALIZED.
+///     - Only one instance of each driver will be initialized per process.
+///     - A driver represents a collection of physical devices.
+///     - Multiple calls to this function will return identical driver handles,
+///       in the same order.
+///     - The drivers returned to the caller will be based on the init types
+///       which state the drivers to be included.
+///     - The application may pass nullptr for pDrivers when only querying the
+///       number of drivers.
+///     - The application may call this function multiple times with different
+///       flags or environment variables enabled.
+///     - The application must call this function after forking new processes.
+///       Each forked process must call this function.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function must be thread-safe for scenarios
+///       where multiple libraries may initialize the driver(s) simultaneously.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+///         + `nullptr == desc`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `0x0 == desc->flags`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeInitDrivers(
+    uint32_t* pCount,                                                       ///< [in,out] pointer to the number of driver instances.
+                                                                            ///< if count is zero, then the loader shall update the value with the
+                                                                            ///< total number of drivers available.
+                                                                            ///< if count is greater than the number of drivers available, then the
+                                                                            ///< loader shall update the value with the correct number of drivers available.
+    ze_driver_handle_t* phDrivers,                                          ///< [in,out][optional][range(0, *pCount)] array of driver instance handles.
+                                                                            ///< if count is less than the number of drivers available, then the loader
+                                                                            ///< shall only retrieve that number of drivers.
+    ze_init_driver_type_desc_t* desc                                        ///< [in] descriptor containing the driver type initialization details
+                                                                            ///< including ::ze_init_driver_type_flag_t combinations.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported API versions
+/// 
+/// @details
+///     - API versions contain major and minor attributes, use
+///       ::ZE_MAJOR_VERSION and ::ZE_MINOR_VERSION
+typedef enum _ze_api_version_t
+{
+    ZE_API_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),                           ///< version 1.0
+    ZE_API_VERSION_1_1 = ZE_MAKE_VERSION( 1, 1 ),                           ///< version 1.1
+    ZE_API_VERSION_1_2 = ZE_MAKE_VERSION( 1, 2 ),                           ///< version 1.2
+    ZE_API_VERSION_1_3 = ZE_MAKE_VERSION( 1, 3 ),                           ///< version 1.3
+    ZE_API_VERSION_1_4 = ZE_MAKE_VERSION( 1, 4 ),                           ///< version 1.4
+    ZE_API_VERSION_1_5 = ZE_MAKE_VERSION( 1, 5 ),                           ///< version 1.5
+    ZE_API_VERSION_1_6 = ZE_MAKE_VERSION( 1, 6 ),                           ///< version 1.6
+    ZE_API_VERSION_1_7 = ZE_MAKE_VERSION( 1, 7 ),                           ///< version 1.7
+    ZE_API_VERSION_1_8 = ZE_MAKE_VERSION( 1, 8 ),                           ///< version 1.8
+    ZE_API_VERSION_1_9 = ZE_MAKE_VERSION( 1, 9 ),                           ///< version 1.9
+    ZE_API_VERSION_1_10 = ZE_MAKE_VERSION( 1, 10 ),                         ///< version 1.10
+    ZE_API_VERSION_1_11 = ZE_MAKE_VERSION( 1, 11 ),                         ///< version 1.11
+    ZE_API_VERSION_1_12 = ZE_MAKE_VERSION( 1, 12 ),                         ///< version 1.12
+    ZE_API_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 12 ),                      ///< latest known version
+    ZE_API_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} ze_api_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_API_VERSION_CURRENT_M
+/// @brief Current API version as a macro
+#define ZE_API_VERSION_CURRENT_M  ZE_MAKE_VERSION( 1, 12 )
+#endif // ZE_API_VERSION_CURRENT_M
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Returns the API version supported by the specified driver
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDriver`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == version`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeDriverGetApiVersion(
+    ze_driver_handle_t hDriver,                                             ///< [in] handle of the driver instance
+    ze_api_version_t* version                                               ///< [out] api version
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_MAX_DRIVER_UUID_SIZE
+/// @brief Maximum driver universal unique id (UUID) size in bytes
+#define ZE_MAX_DRIVER_UUID_SIZE  16
+#endif // ZE_MAX_DRIVER_UUID_SIZE
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Driver universal unique id (UUID)
+typedef struct _ze_driver_uuid_t
+{
+    uint8_t id[ZE_MAX_DRIVER_UUID_SIZE];                                    ///< [out] opaque data representing a driver UUID
+
+} ze_driver_uuid_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Driver properties queried using ::zeDriverGetProperties
+typedef struct _ze_driver_properties_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_driver_uuid_t uuid;                                                  ///< [out] universal unique identifier.
+    uint32_t driverVersion;                                                 ///< [out] driver version
+                                                                            ///< The driver version is a non-zero, monotonically increasing value where
+                                                                            ///< higher values always indicate a more recent version.
+
+} ze_driver_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves properties of the driver.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clGetPlatformInfo**
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDriver`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pDriverProperties`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeDriverGetProperties(
+    ze_driver_handle_t hDriver,                                             ///< [in] handle of the driver instance
+    ze_driver_properties_t* pDriverProperties                               ///< [in,out] query result for driver properties
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported IPC property flags
+typedef uint32_t ze_ipc_property_flags_t;
+typedef enum _ze_ipc_property_flag_t
+{
+    ZE_IPC_PROPERTY_FLAG_MEMORY = ZE_BIT(0),                                ///< Supports passing memory allocations between processes. See
+                                                                            ///< ::zeMemGetIpcHandle.
+    ZE_IPC_PROPERTY_FLAG_EVENT_POOL = ZE_BIT(1),                            ///< Supports passing event pools between processes. See
+                                                                            ///< ::zeEventPoolGetIpcHandle.
+    ZE_IPC_PROPERTY_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_ipc_property_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief IPC properties queried using ::zeDriverGetIpcProperties
+typedef struct _ze_driver_ipc_properties_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_ipc_property_flags_t flags;                                          ///< [out] 0 (none) or a valid combination of ::ze_ipc_property_flag_t
+
+} ze_driver_ipc_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves IPC attributes of the driver
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDriver`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pIpcProperties`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeDriverGetIpcProperties(
+    ze_driver_handle_t hDriver,                                             ///< [in] handle of the driver instance
+    ze_driver_ipc_properties_t* pIpcProperties                              ///< [in,out] query result for IPC properties
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_MAX_EXTENSION_NAME
+/// @brief Maximum extension name string size
+#define ZE_MAX_EXTENSION_NAME  256
+#endif // ZE_MAX_EXTENSION_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Extension properties queried using ::zeDriverGetExtensionProperties
+typedef struct _ze_driver_extension_properties_t
+{
+    char name[ZE_MAX_EXTENSION_NAME];                                       ///< [out] extension name
+    uint32_t version;                                                       ///< [out] extension version using ::ZE_MAKE_VERSION
+
+} ze_driver_extension_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves extension properties
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **vkEnumerateInstanceExtensionProperties**
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDriver`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeDriverGetExtensionProperties(
+    ze_driver_handle_t hDriver,                                             ///< [in] handle of the driver instance
+    uint32_t* pCount,                                                       ///< [in,out] pointer to the number of extension properties.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of extension properties available.
+                                                                            ///< if count is greater than the number of extension properties available,
+                                                                            ///< then the driver shall update the value with the correct number of
+                                                                            ///< extension properties available.
+    ze_driver_extension_properties_t* pExtensionProperties                  ///< [in,out][optional][range(0, *pCount)] array of query results for
+                                                                            ///< extension properties.
+                                                                            ///< if count is less than the number of extension properties available,
+                                                                            ///< then driver shall only retrieve that number of extension properties.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves function pointer for vendor-specific or experimental
+///        extensions
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDriver`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == name`
+///         + `nullptr == ppFunctionAddress`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeDriverGetExtensionFunctionAddress(
+    ze_driver_handle_t hDriver,                                             ///< [in] handle of the driver instance
+    const char* name,                                                       ///< [in] extension function name
+    void** ppFunctionAddress                                                ///< [out] pointer to function pointer
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves a string describing the last error code returned by the
+///        driver in the current thread.
+/// 
+/// @details
+///     - String returned is thread local.
+///     - String is only updated on calls returning an error, i.e., not on calls
+///       returning ::ZE_RESULT_SUCCESS.
+///     - String may be empty if driver considers error code is already explicit
+///       enough to describe cause.
+///     - Memory pointed to by ppString is owned by the driver.
+///     - String returned is null-terminated.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDriver`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == ppString`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeDriverGetLastErrorDescription(
+    ze_driver_handle_t hDriver,                                             ///< [in] handle of the driver instance
+    const char** ppString                                                   ///< [in,out] pointer to a null-terminated array of characters describing
+                                                                            ///< cause of error.
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero APIs for Device
+#if !defined(__GNUC__)
+#pragma region device
+#endif
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves devices within a driver
+/// 
+/// @details
+///     - Multiple calls to this function will return identical device handles,
+///       in the same order.
+///     - The number and order of handles returned from this function is
+///       affected by the ::ZE_AFFINITY_MASK and ::ZE_ENABLE_PCI_ID_DEVICE_ORDER
+///       environment variables.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDriver`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeDeviceGet(
+    ze_driver_handle_t hDriver,                                             ///< [in] handle of the driver instance
+    uint32_t* pCount,                                                       ///< [in,out] pointer to the number of devices.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of devices available.
+                                                                            ///< if count is greater than the number of devices available, then the
+                                                                            ///< driver shall update the value with the correct number of devices available.
+    ze_device_handle_t* phDevices                                           ///< [in,out][optional][range(0, *pCount)] array of handle of devices.
+                                                                            ///< if count is less than the number of devices available, then driver
+                                                                            ///< shall only retrieve that number of devices.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves the root-device of a device handle
+/// 
+/// @details
+///     - When the device handle passed does not belong to any root-device,
+///       nullptr is returned.
+///     - Multiple calls to this function will return the same device handle.
+///     - The root-device handle returned by this function does not have access
+///       automatically to the resources
+///       created with the associated sub-device, unless those resources have
+///       been created with a context
+///       explicitly containing both handles.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == phRootDevice`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeDeviceGetRootDevice(
+    ze_device_handle_t hDevice,                                             ///< [in] handle of the device object
+    ze_device_handle_t* phRootDevice                                        ///< [in,out] parent root device.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves a sub-device from a device
+/// 
+/// @details
+///     - When the device handle passed does not contain any sub-device, a
+///       pCount of 0 is returned.
+///     - Multiple calls to this function will return identical device handles,
+///       in the same order.
+///     - The number of handles returned from this function is affected by the
+///       ::ZE_AFFINITY_MASK environment variable.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @remarks
+///   _Analogues_
+///     - clCreateSubDevices
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeDeviceGetSubDevices(
+    ze_device_handle_t hDevice,                                             ///< [in] handle of the device object
+    uint32_t* pCount,                                                       ///< [in,out] pointer to the number of sub-devices.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of sub-devices available.
+                                                                            ///< if count is greater than the number of sub-devices available, then the
+                                                                            ///< driver shall update the value with the correct number of sub-devices available.
+    ze_device_handle_t* phSubdevices                                        ///< [in,out][optional][range(0, *pCount)] array of handle of sub-devices.
+                                                                            ///< if count is less than the number of sub-devices available, then driver
+                                                                            ///< shall only retrieve that number of sub-devices.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported device types
+typedef enum _ze_device_type_t
+{
+    ZE_DEVICE_TYPE_GPU = 1,                                                 ///< Graphics Processing Unit
+    ZE_DEVICE_TYPE_CPU = 2,                                                 ///< Central Processing Unit
+    ZE_DEVICE_TYPE_FPGA = 3,                                                ///< Field Programmable Gate Array
+    ZE_DEVICE_TYPE_MCA = 4,                                                 ///< Memory Copy Accelerator
+    ZE_DEVICE_TYPE_VPU = 5,                                                 ///< Vision Processing Unit
+    ZE_DEVICE_TYPE_FORCE_UINT32 = 0x7fffffff
+
+} ze_device_type_t;
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_MAX_DEVICE_UUID_SIZE
+/// @brief Maximum device universal unique id (UUID) size in bytes
+#define ZE_MAX_DEVICE_UUID_SIZE  16
+#endif // ZE_MAX_DEVICE_UUID_SIZE
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Device universal unique id (UUID)
+typedef struct _ze_device_uuid_t
+{
+    uint8_t id[ZE_MAX_DEVICE_UUID_SIZE];                                    ///< [out] opaque data representing a device UUID
+
+} ze_device_uuid_t;
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_MAX_DEVICE_NAME
+/// @brief Maximum device name string size
+#define ZE_MAX_DEVICE_NAME  256
+#endif // ZE_MAX_DEVICE_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported device property flags
+typedef uint32_t ze_device_property_flags_t;
+typedef enum _ze_device_property_flag_t
+{
+    ZE_DEVICE_PROPERTY_FLAG_INTEGRATED = ZE_BIT(0),                         ///< Device is integrated with the Host.
+    ZE_DEVICE_PROPERTY_FLAG_SUBDEVICE = ZE_BIT(1),                          ///< Device handle used for query represents a sub-device.
+    ZE_DEVICE_PROPERTY_FLAG_ECC = ZE_BIT(2),                                ///< Device supports error correction memory access.
+    ZE_DEVICE_PROPERTY_FLAG_ONDEMANDPAGING = ZE_BIT(3),                     ///< Device supports on-demand page-faulting.
+    ZE_DEVICE_PROPERTY_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_device_property_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Device properties queried using ::zeDeviceGetProperties
+typedef struct _ze_device_properties_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_device_type_t type;                                                  ///< [out] generic device type
+    uint32_t vendorId;                                                      ///< [out] vendor id from PCI configuration
+    uint32_t deviceId;                                                      ///< [out] device id from PCI configuration.
+                                                                            ///< Note, the device id uses little-endian format.
+    ze_device_property_flags_t flags;                                       ///< [out] 0 (none) or a valid combination of ::ze_device_property_flag_t
+    uint32_t subdeviceId;                                                   ///< [out] sub-device id. Only valid if ::ZE_DEVICE_PROPERTY_FLAG_SUBDEVICE
+                                                                            ///< is set.
+    uint32_t coreClockRate;                                                 ///< [out] Clock rate for device core.
+    uint64_t maxMemAllocSize;                                               ///< [out] Maximum memory allocation size.
+    uint32_t maxHardwareContexts;                                           ///< [out] Maximum number of logical hardware contexts.
+    uint32_t maxCommandQueuePriority;                                       ///< [out] Maximum priority for command queues. Higher value is higher
+                                                                            ///< priority.
+    uint32_t numThreadsPerEU;                                               ///< [out] Maximum number of threads per EU.
+    uint32_t physicalEUSimdWidth;                                           ///< [out] The physical EU simd width.
+    uint32_t numEUsPerSubslice;                                             ///< [out] Maximum number of EUs per sub-slice.
+    uint32_t numSubslicesPerSlice;                                          ///< [out] Maximum number of sub-slices per slice.
+    uint32_t numSlices;                                                     ///< [out] Maximum number of slices.
+    uint64_t timerResolution;                                               ///< [out] Returns the resolution of device timer used for profiling,
+                                                                            ///< timestamps, etc. When stype==::ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES the
+                                                                            ///< units are in nanoseconds. When
+                                                                            ///< stype==::ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES_1_2 units are in
+                                                                            ///< cycles/sec
+    uint32_t timestampValidBits;                                            ///< [out] Returns the number of valid bits in the timestamp value.
+    uint32_t kernelTimestampValidBits;                                      ///< [out] Returns the number of valid bits in the kernel timestamp values
+    ze_device_uuid_t uuid;                                                  ///< [out] universal unique identifier. Note: Subdevices will have their
+                                                                            ///< own uuid.
+    char name[ZE_MAX_DEVICE_NAME];                                          ///< [out] Device name
+
+} ze_device_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Device thread identifier.
+typedef struct _ze_device_thread_t
+{
+    uint32_t slice;                                                         ///< [in,out] the slice number.
+                                                                            ///< Must be `UINT32_MAX` (all) or less than the `numSlices` member of ::ze_device_properties_t.
+    uint32_t subslice;                                                      ///< [in,out] the sub-slice number within its slice.
+                                                                            ///< Must be `UINT32_MAX` (all) or less than the `numSubslicesPerSlice`
+                                                                            ///< member of ::ze_device_properties_t.
+    uint32_t eu;                                                            ///< [in,out] the EU number within its sub-slice.
+                                                                            ///< Must be `UINT32_MAX` (all) or less than the `numEUsPerSubslice` member
+                                                                            ///< of ::ze_device_properties_t.
+    uint32_t thread;                                                        ///< [in,out] the thread number within its EU.
+                                                                            ///< Must be `UINT32_MAX` (all) or less than the `numThreadsPerEU` member
+                                                                            ///< of ::ze_device_properties_t.
+
+} ze_device_thread_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves properties of the device.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @remarks
+///   _Analogues_
+///     - clGetDeviceInfo
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pDeviceProperties`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeDeviceGetProperties(
+    ze_device_handle_t hDevice,                                             ///< [in] handle of the device
+    ze_device_properties_t* pDeviceProperties                               ///< [in,out] query result for device properties
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_SUBGROUPSIZE_COUNT
+/// @brief Maximum number of subgroup sizes supported.
+#define ZE_SUBGROUPSIZE_COUNT  8
+#endif // ZE_SUBGROUPSIZE_COUNT
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Device compute properties queried using ::zeDeviceGetComputeProperties
+typedef struct _ze_device_compute_properties_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    uint32_t maxTotalGroupSize;                                             ///< [out] Maximum items per compute group. (groupSizeX * groupSizeY *
+                                                                            ///< groupSizeZ) <= maxTotalGroupSize
+    uint32_t maxGroupSizeX;                                                 ///< [out] Maximum items for X dimension in group
+    uint32_t maxGroupSizeY;                                                 ///< [out] Maximum items for Y dimension in group
+    uint32_t maxGroupSizeZ;                                                 ///< [out] Maximum items for Z dimension in group
+    uint32_t maxGroupCountX;                                                ///< [out] Maximum groups that can be launched for x dimension
+    uint32_t maxGroupCountY;                                                ///< [out] Maximum groups that can be launched for y dimension
+    uint32_t maxGroupCountZ;                                                ///< [out] Maximum groups that can be launched for z dimension
+    uint32_t maxSharedLocalMemory;                                          ///< [out] Maximum shared local memory per group.
+    uint32_t numSubGroupSizes;                                              ///< [out] Number of subgroup sizes supported. This indicates number of
+                                                                            ///< entries in subGroupSizes.
+    uint32_t subGroupSizes[ZE_SUBGROUPSIZE_COUNT];                          ///< [out] Size group sizes supported.
+
+} ze_device_compute_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves compute properties of the device.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @remarks
+///   _Analogues_
+///     - clGetDeviceInfo
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pComputeProperties`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeDeviceGetComputeProperties(
+    ze_device_handle_t hDevice,                                             ///< [in] handle of the device
+    ze_device_compute_properties_t* pComputeProperties                      ///< [in,out] query result for compute properties
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_MAX_NATIVE_KERNEL_UUID_SIZE
+/// @brief Maximum native kernel universal unique id (UUID) size in bytes
+#define ZE_MAX_NATIVE_KERNEL_UUID_SIZE  16
+#endif // ZE_MAX_NATIVE_KERNEL_UUID_SIZE
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Native kernel universal unique id (UUID)
+typedef struct _ze_native_kernel_uuid_t
+{
+    uint8_t id[ZE_MAX_NATIVE_KERNEL_UUID_SIZE];                             ///< [out] opaque data representing a native kernel UUID
+
+} ze_native_kernel_uuid_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported device module flags
+typedef uint32_t ze_device_module_flags_t;
+typedef enum _ze_device_module_flag_t
+{
+    ZE_DEVICE_MODULE_FLAG_FP16 = ZE_BIT(0),                                 ///< Device supports 16-bit floating-point operations
+    ZE_DEVICE_MODULE_FLAG_FP64 = ZE_BIT(1),                                 ///< Device supports 64-bit floating-point operations
+    ZE_DEVICE_MODULE_FLAG_INT64_ATOMICS = ZE_BIT(2),                        ///< Device supports 64-bit atomic operations
+    ZE_DEVICE_MODULE_FLAG_DP4A = ZE_BIT(3),                                 ///< Device supports four component dot product and accumulate operations
+    ZE_DEVICE_MODULE_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_device_module_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported floating-Point capability flags
+typedef uint32_t ze_device_fp_flags_t;
+typedef enum _ze_device_fp_flag_t
+{
+    ZE_DEVICE_FP_FLAG_DENORM = ZE_BIT(0),                                   ///< Supports denorms
+    ZE_DEVICE_FP_FLAG_INF_NAN = ZE_BIT(1),                                  ///< Supports INF and quiet NaNs
+    ZE_DEVICE_FP_FLAG_ROUND_TO_NEAREST = ZE_BIT(2),                         ///< Supports rounding to nearest even rounding mode
+    ZE_DEVICE_FP_FLAG_ROUND_TO_ZERO = ZE_BIT(3),                            ///< Supports rounding to zero.
+    ZE_DEVICE_FP_FLAG_ROUND_TO_INF = ZE_BIT(4),                             ///< Supports rounding to both positive and negative INF.
+    ZE_DEVICE_FP_FLAG_FMA = ZE_BIT(5),                                      ///< Supports IEEE754-2008 fused multiply-add.
+    ZE_DEVICE_FP_FLAG_ROUNDED_DIVIDE_SQRT = ZE_BIT(6),                      ///< Supports rounding as defined by IEEE754 for divide and sqrt
+                                                                            ///< operations.
+    ZE_DEVICE_FP_FLAG_SOFT_FLOAT = ZE_BIT(7),                               ///< Uses software implementation for basic floating-point operations.
+    ZE_DEVICE_FP_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_device_fp_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Device module properties queried using ::zeDeviceGetModuleProperties
+typedef struct _ze_device_module_properties_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    uint32_t spirvVersionSupported;                                         ///< [out] Maximum supported SPIR-V version.
+                                                                            ///< Returns zero if SPIR-V is not supported.
+                                                                            ///< Contains major and minor attributes, use ::ZE_MAJOR_VERSION and ::ZE_MINOR_VERSION.
+    ze_device_module_flags_t flags;                                         ///< [out] 0 or a valid combination of ::ze_device_module_flag_t
+    ze_device_fp_flags_t fp16flags;                                         ///< [out] Capabilities for half-precision floating-point operations.
+                                                                            ///< returns 0 (if ::ZE_DEVICE_MODULE_FLAG_FP16 is not set) or a
+                                                                            ///< combination of ::ze_device_fp_flag_t.
+    ze_device_fp_flags_t fp32flags;                                         ///< [out] Capabilities for single-precision floating-point operations.
+                                                                            ///< returns a combination of ::ze_device_fp_flag_t.
+    ze_device_fp_flags_t fp64flags;                                         ///< [out] Capabilities for double-precision floating-point operations.
+                                                                            ///< returns 0 (if ::ZE_DEVICE_MODULE_FLAG_FP64 is not set) or a
+                                                                            ///< combination of ::ze_device_fp_flag_t.
+    uint32_t maxArgumentsSize;                                              ///< [out] Maximum kernel argument size that is supported.
+    uint32_t printfBufferSize;                                              ///< [out] Maximum size of internal buffer that holds output of printf
+                                                                            ///< calls from kernel.
+    ze_native_kernel_uuid_t nativeKernelSupported;                          ///< [out] Compatibility UUID of supported native kernel.
+                                                                            ///< UUID may or may not be the same across driver release, devices, or
+                                                                            ///< operating systems.
+                                                                            ///< Application is responsible for ensuring UUID matches before creating
+                                                                            ///< module using
+                                                                            ///< previously created native kernel.
+
+} ze_device_module_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves module properties of the device
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pModuleProperties`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeDeviceGetModuleProperties(
+    ze_device_handle_t hDevice,                                             ///< [in] handle of the device
+    ze_device_module_properties_t* pModuleProperties                        ///< [in,out] query result for module properties
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported command queue group property flags
+typedef uint32_t ze_command_queue_group_property_flags_t;
+typedef enum _ze_command_queue_group_property_flag_t
+{
+    ZE_COMMAND_QUEUE_GROUP_PROPERTY_FLAG_COMPUTE = ZE_BIT(0),               ///< Command queue group supports enqueing compute commands.
+    ZE_COMMAND_QUEUE_GROUP_PROPERTY_FLAG_COPY = ZE_BIT(1),                  ///< Command queue group supports enqueing copy commands.
+    ZE_COMMAND_QUEUE_GROUP_PROPERTY_FLAG_COOPERATIVE_KERNELS = ZE_BIT(2),   ///< Command queue group supports cooperative kernels.
+                                                                            ///< See ::zeCommandListAppendLaunchCooperativeKernel for more details.
+    ZE_COMMAND_QUEUE_GROUP_PROPERTY_FLAG_METRICS = ZE_BIT(3),               ///< Command queue groups supports metric queries.
+    ZE_COMMAND_QUEUE_GROUP_PROPERTY_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_command_queue_group_property_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Command queue group properties queried using
+///        ::zeDeviceGetCommandQueueGroupProperties
+typedef struct _ze_command_queue_group_properties_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_command_queue_group_property_flags_t flags;                          ///< [out] 0 (none) or a valid combination of
+                                                                            ///< ::ze_command_queue_group_property_flag_t
+    size_t maxMemoryFillPatternSize;                                        ///< [out] maximum `pattern_size` supported by command queue group.
+                                                                            ///< See ::zeCommandListAppendMemoryFill for more details.
+    uint32_t numQueues;                                                     ///< [out] the number of physical engines within the group.
+
+} ze_command_queue_group_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves command queue group properties of the device.
+/// 
+/// @details
+///     - Properties are reported for each physical command queue type supported
+///       by the device.
+///     - Multiple calls to this function will return properties in the same
+///       order.
+///     - The order in which the properties are returned defines the command
+///       queue group's ordinal.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **vkGetPhysicalDeviceQueueFamilyProperties**
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeDeviceGetCommandQueueGroupProperties(
+    ze_device_handle_t hDevice,                                             ///< [in] handle of the device
+    uint32_t* pCount,                                                       ///< [in,out] pointer to the number of command queue group properties.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of command queue group properties available.
+                                                                            ///< if count is greater than the number of command queue group properties
+                                                                            ///< available, then the driver shall update the value with the correct
+                                                                            ///< number of command queue group properties available.
+    ze_command_queue_group_properties_t* pCommandQueueGroupProperties       ///< [in,out][optional][range(0, *pCount)] array of query results for
+                                                                            ///< command queue group properties.
+                                                                            ///< if count is less than the number of command queue group properties
+                                                                            ///< available, then driver shall only retrieve that number of command
+                                                                            ///< queue group properties.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported device memory property flags
+typedef uint32_t ze_device_memory_property_flags_t;
+typedef enum _ze_device_memory_property_flag_t
+{
+    ZE_DEVICE_MEMORY_PROPERTY_FLAG_TBD = ZE_BIT(0),                         ///< reserved for future use
+    ZE_DEVICE_MEMORY_PROPERTY_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_device_memory_property_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Device local memory properties queried using
+///        ::zeDeviceGetMemoryProperties
+typedef struct _ze_device_memory_properties_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_device_memory_property_flags_t flags;                                ///< [out] 0 (none) or a valid combination of
+                                                                            ///< ::ze_device_memory_property_flag_t
+    uint32_t maxClockRate;                                                  ///< [out] Maximum clock rate for device memory.
+    uint32_t maxBusWidth;                                                   ///< [out] Maximum bus width between device and memory.
+    uint64_t totalSize;                                                     ///< [out] Total memory size in bytes that is available to the device.
+    char name[ZE_MAX_DEVICE_NAME];                                          ///< [out] Memory name
+
+} ze_device_memory_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves local memory properties of the device.
+/// 
+/// @details
+///     - Properties are reported for each physical memory type supported by the
+///       device.
+///     - Multiple calls to this function will return properties in the same
+///       order.
+///     - The order in which the properties are returned defines the device's
+///       local memory ordinal.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @remarks
+///   _Analogues_
+///     - clGetDeviceInfo
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeDeviceGetMemoryProperties(
+    ze_device_handle_t hDevice,                                             ///< [in] handle of the device
+    uint32_t* pCount,                                                       ///< [in,out] pointer to the number of memory properties.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of memory properties available.
+                                                                            ///< if count is greater than the number of memory properties available,
+                                                                            ///< then the driver shall update the value with the correct number of
+                                                                            ///< memory properties available.
+    ze_device_memory_properties_t* pMemProperties                           ///< [in,out][optional][range(0, *pCount)] array of query results for
+                                                                            ///< memory properties.
+                                                                            ///< if count is less than the number of memory properties available, then
+                                                                            ///< driver shall only retrieve that number of memory properties.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Memory access capability flags
+/// 
+/// @details
+///     - Supported access capabilities for different types of memory
+///       allocations
+typedef uint32_t ze_memory_access_cap_flags_t;
+typedef enum _ze_memory_access_cap_flag_t
+{
+    ZE_MEMORY_ACCESS_CAP_FLAG_RW = ZE_BIT(0),                               ///< Supports load/store access
+    ZE_MEMORY_ACCESS_CAP_FLAG_ATOMIC = ZE_BIT(1),                           ///< Supports atomic access
+    ZE_MEMORY_ACCESS_CAP_FLAG_CONCURRENT = ZE_BIT(2),                       ///< Supports concurrent access
+    ZE_MEMORY_ACCESS_CAP_FLAG_CONCURRENT_ATOMIC = ZE_BIT(3),                ///< Supports concurrent atomic access
+    ZE_MEMORY_ACCESS_CAP_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_memory_access_cap_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Device memory access properties queried using
+///        ::zeDeviceGetMemoryAccessProperties
+typedef struct _ze_device_memory_access_properties_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_memory_access_cap_flags_t hostAllocCapabilities;                     ///< [out] host memory capabilities.
+                                                                            ///< returns 0 (unsupported) or a combination of ::ze_memory_access_cap_flag_t.
+    ze_memory_access_cap_flags_t deviceAllocCapabilities;                   ///< [out] device memory capabilities.
+                                                                            ///< returns 0 (unsupported) or a combination of ::ze_memory_access_cap_flag_t.
+    ze_memory_access_cap_flags_t sharedSingleDeviceAllocCapabilities;       ///< [out] shared, single-device memory capabilities.
+                                                                            ///< returns 0 (unsupported) or a combination of ::ze_memory_access_cap_flag_t.
+    ze_memory_access_cap_flags_t sharedCrossDeviceAllocCapabilities;        ///< [out] shared, cross-device memory capabilities.
+                                                                            ///< returns 0 (unsupported) or a combination of ::ze_memory_access_cap_flag_t.
+    ze_memory_access_cap_flags_t sharedSystemAllocCapabilities;             ///< [out] shared, system memory capabilities.
+                                                                            ///< returns 0 (unsupported) or a combination of ::ze_memory_access_cap_flag_t.
+
+} ze_device_memory_access_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves memory access properties of the device.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @remarks
+///   _Analogues_
+///     - clGetDeviceInfo
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pMemAccessProperties`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeDeviceGetMemoryAccessProperties(
+    ze_device_handle_t hDevice,                                             ///< [in] handle of the device
+    ze_device_memory_access_properties_t* pMemAccessProperties              ///< [in,out] query result for memory access properties
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported cache control property flags
+typedef uint32_t ze_device_cache_property_flags_t;
+typedef enum _ze_device_cache_property_flag_t
+{
+    ZE_DEVICE_CACHE_PROPERTY_FLAG_USER_CONTROL = ZE_BIT(0),                 ///< Device support User Cache Control (i.e. SLM section vs Generic Cache)
+    ZE_DEVICE_CACHE_PROPERTY_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_device_cache_property_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Device cache properties queried using ::zeDeviceGetCacheProperties
+typedef struct _ze_device_cache_properties_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_device_cache_property_flags_t flags;                                 ///< [out] 0 (none) or a valid combination of
+                                                                            ///< ::ze_device_cache_property_flag_t
+    size_t cacheSize;                                                       ///< [out] Per-cache size, in bytes
+
+} ze_device_cache_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves cache properties of the device
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @remarks
+///   _Analogues_
+///     - clGetDeviceInfo
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeDeviceGetCacheProperties(
+    ze_device_handle_t hDevice,                                             ///< [in] handle of the device
+    uint32_t* pCount,                                                       ///< [in,out] pointer to the number of cache properties.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of cache properties available.
+                                                                            ///< if count is greater than the number of cache properties available,
+                                                                            ///< then the driver shall update the value with the correct number of
+                                                                            ///< cache properties available.
+    ze_device_cache_properties_t* pCacheProperties                          ///< [in,out][optional][range(0, *pCount)] array of query results for cache properties.
+                                                                            ///< if count is less than the number of cache properties available, then
+                                                                            ///< driver shall only retrieve that number of cache properties.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Device image properties queried using ::zeDeviceGetImageProperties
+typedef struct _ze_device_image_properties_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    uint32_t maxImageDims1D;                                                ///< [out] Maximum image dimensions for 1D resources. if 0, then 1D images
+                                                                            ///< are unsupported.
+    uint32_t maxImageDims2D;                                                ///< [out] Maximum image dimensions for 2D resources. if 0, then 2D images
+                                                                            ///< are unsupported.
+    uint32_t maxImageDims3D;                                                ///< [out] Maximum image dimensions for 3D resources. if 0, then 3D images
+                                                                            ///< are unsupported.
+    uint64_t maxImageBufferSize;                                            ///< [out] Maximum image buffer size in bytes. if 0, then buffer images are
+                                                                            ///< unsupported.
+    uint32_t maxImageArraySlices;                                           ///< [out] Maximum image array slices. if 0, then image arrays are
+                                                                            ///< unsupported.
+    uint32_t maxSamplers;                                                   ///< [out] Max samplers that can be used in kernel. if 0, then sampling is
+                                                                            ///< unsupported.
+    uint32_t maxReadImageArgs;                                              ///< [out] Returns the maximum number of simultaneous image objects that
+                                                                            ///< can be read from by a kernel. if 0, then reading images is
+                                                                            ///< unsupported.
+    uint32_t maxWriteImageArgs;                                             ///< [out] Returns the maximum number of simultaneous image objects that
+                                                                            ///< can be written to by a kernel. if 0, then writing images is
+                                                                            ///< unsupported.
+
+} ze_device_image_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves image properties of the device
+/// 
+/// @details
+///     - See ::zeImageGetProperties for format-specific capabilities.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pImageProperties`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeDeviceGetImageProperties(
+    ze_device_handle_t hDevice,                                             ///< [in] handle of the device
+    ze_device_image_properties_t* pImageProperties                          ///< [in,out] query result for image properties
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Device external memory import and export properties
+typedef struct _ze_device_external_memory_properties_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_external_memory_type_flags_t memoryAllocationImportTypes;            ///< [out] Supported external memory import types for memory allocations.
+    ze_external_memory_type_flags_t memoryAllocationExportTypes;            ///< [out] Supported external memory export types for memory allocations.
+    ze_external_memory_type_flags_t imageImportTypes;                       ///< [out] Supported external memory import types for images.
+    ze_external_memory_type_flags_t imageExportTypes;                       ///< [out] Supported external memory export types for images.
+
+} ze_device_external_memory_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves external memory import and export of the device
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pExternalMemoryProperties`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeDeviceGetExternalMemoryProperties(
+    ze_device_handle_t hDevice,                                             ///< [in] handle of the device
+    ze_device_external_memory_properties_t* pExternalMemoryProperties       ///< [in,out] query result for external memory properties
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported device peer-to-peer property flags
+typedef uint32_t ze_device_p2p_property_flags_t;
+typedef enum _ze_device_p2p_property_flag_t
+{
+    ZE_DEVICE_P2P_PROPERTY_FLAG_ACCESS = ZE_BIT(0),                         ///< Device supports access between peer devices.
+    ZE_DEVICE_P2P_PROPERTY_FLAG_ATOMICS = ZE_BIT(1),                        ///< Device supports atomics between peer devices.
+    ZE_DEVICE_P2P_PROPERTY_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_device_p2p_property_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Device peer-to-peer properties queried using
+///        ::zeDeviceGetP2PProperties
+typedef struct _ze_device_p2p_properties_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_device_p2p_property_flags_t flags;                                   ///< [out] 0 (none) or a valid combination of
+                                                                            ///< ::ze_device_p2p_property_flag_t
+
+} ze_device_p2p_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves peer-to-peer properties between one device and a peer
+///        devices
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///         + `nullptr == hPeerDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pP2PProperties`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeDeviceGetP2PProperties(
+    ze_device_handle_t hDevice,                                             ///< [in] handle of the device performing the access
+    ze_device_handle_t hPeerDevice,                                         ///< [in] handle of the peer device with the allocation
+    ze_device_p2p_properties_t* pP2PProperties                              ///< [in,out] Peer-to-Peer properties between source and peer device
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Queries if one device can directly access peer device allocations
+/// 
+/// @details
+///     - Any device can access any other device within a node through a
+///       scale-up fabric.
+///     - The following are conditions for CanAccessPeer query.
+///         + If both device and peer device are the same then return true.
+///         + If both sub-device and peer sub-device are the same then return
+///           true.
+///         + If both are sub-devices and share the same parent device then
+///           return true.
+///         + If both device and remote device are connected by a direct or
+///           indirect scale-up fabric or over PCIe (same root complex or shared
+///           PCIe switch) then true.
+///         + If both sub-device and remote parent device (and vice-versa) are
+///           connected by a direct or indirect scale-up fabric or over PCIe
+///           (same root complex or shared PCIe switch) then true.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///         + `nullptr == hPeerDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == value`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeDeviceCanAccessPeer(
+    ze_device_handle_t hDevice,                                             ///< [in] handle of the device performing the access
+    ze_device_handle_t hPeerDevice,                                         ///< [in] handle of the peer device with the allocation
+    ze_bool_t* value                                                        ///< [out] returned access capability
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Returns current status of the device.
+/// 
+/// @details
+///     - Once a device is reset, this call will update the OS handle attached
+///       to the device handle.
+///     - The application may call this function from simultaneous threads with
+///       the same device handle.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_SUCCESS
+///         + Device is available for use.
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///         + Device is lost; must be reset for use.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeDeviceGetStatus(
+    ze_device_handle_t hDevice                                              ///< [in] handle of the device
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Returns synchronized Host and device global timestamps.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads with
+///       the same device handle.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == hostTimestamp`
+///         + `nullptr == deviceTimestamp`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + The feature is not supported by the underlying platform.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeDeviceGetGlobalTimestamps(
+    ze_device_handle_t hDevice,                                             ///< [in] handle of the device
+    uint64_t* hostTimestamp,                                                ///< [out] value of the Host's global timestamp that correlates with the
+                                                                            ///< Device's global timestamp value.
+    uint64_t* deviceTimestamp                                               ///< [out] value of the Device's global timestamp that correlates with the
+                                                                            ///< Host's global timestamp value.
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero APIs for Context
+#if !defined(__GNUC__)
+#pragma region context
+#endif
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported context creation flags
+typedef uint32_t ze_context_flags_t;
+typedef enum _ze_context_flag_t
+{
+    ZE_CONTEXT_FLAG_TBD = ZE_BIT(0),                                        ///< reserved for future use
+    ZE_CONTEXT_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_context_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Context descriptor
+typedef struct _ze_context_desc_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_context_flags_t flags;                                               ///< [in] creation flags.
+                                                                            ///< must be 0 (default) or a valid combination of ::ze_context_flag_t;
+                                                                            ///< default behavior may use implicit driver-based heuristics.
+
+} ze_context_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Creates a context for the driver.
+/// 
+/// @details
+///     - The application must only use the context for the driver which was
+///       provided during creation.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDriver`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == desc`
+///         + `nullptr == phContext`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `0x1 < desc->flags`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeContextCreate(
+    ze_driver_handle_t hDriver,                                             ///< [in] handle of the driver object
+    const ze_context_desc_t* desc,                                          ///< [in] pointer to context descriptor
+    ze_context_handle_t* phContext                                          ///< [out] pointer to handle of context object created
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Creates a context for the driver.
+/// 
+/// @details
+///     - The application must only use the context for the driver which was
+///       provided during creation.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDriver`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == desc`
+///         + `nullptr == phContext`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `0x1 < desc->flags`
+///     - ::ZE_RESULT_ERROR_INVALID_SIZE
+///         + `(nullptr == phDevices) && (0 < numDevices)`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeContextCreateEx(
+    ze_driver_handle_t hDriver,                                             ///< [in] handle of the driver object
+    const ze_context_desc_t* desc,                                          ///< [in] pointer to context descriptor
+    uint32_t numDevices,                                                    ///< [in][optional] number of device handles; must be 0 if `nullptr ==
+                                                                            ///< phDevices`
+    ze_device_handle_t* phDevices,                                          ///< [in][optional][range(0, numDevices)] array of device handles which
+                                                                            ///< context has visibility.
+                                                                            ///< if nullptr, then all devices and any sub-devices supported by the
+                                                                            ///< driver instance are
+                                                                            ///< visible to the context.
+                                                                            ///< otherwise, the context only has visibility to the devices and any
+                                                                            ///< sub-devices of the
+                                                                            ///< devices in this array.
+    ze_context_handle_t* phContext                                          ///< [out] pointer to handle of context object created
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Destroys a context.
+/// 
+/// @details
+///     - The application must ensure the device is not currently referencing
+///       the context before it is deleted.
+///     - The implementation of this function may immediately free all Host and
+///       Device allocations associated with this context.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same context handle.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+///     - ::ZE_RESULT_ERROR_HANDLE_OBJECT_IN_USE
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeContextDestroy(
+    ze_context_handle_t hContext                                            ///< [in][release] handle of context object to destroy
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Returns current status of the context.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads with
+///       the same context handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+///     - ::ZE_RESULT_SUCCESS
+///         + Context is available for use.
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///         + Context is invalid; due to device lost or reset.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeContextGetStatus(
+    ze_context_handle_t hContext                                            ///< [in] handle of context object
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero APIs for Command Queue
+#if !defined(__GNUC__)
+#pragma region cmdqueue
+#endif
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported command queue flags
+typedef uint32_t ze_command_queue_flags_t;
+typedef enum _ze_command_queue_flag_t
+{
+    ZE_COMMAND_QUEUE_FLAG_EXPLICIT_ONLY = ZE_BIT(0),                        ///< command queue should be optimized for submission to a single device engine.
+                                                                            ///< driver **must** disable any implicit optimizations for distributing
+                                                                            ///< work across multiple engines.
+                                                                            ///< this flag should be used when applications want full control over
+                                                                            ///< multi-engine submission and scheduling.
+    ZE_COMMAND_QUEUE_FLAG_IN_ORDER = ZE_BIT(1),                             ///< To be used only when creating immediate command lists. Commands
+                                                                            ///< appended to the immediate command
+                                                                            ///< list are executed in-order, with driver implementation enforcing
+                                                                            ///< dependencies between them.
+                                                                            ///< Application is not required to have the signal event of a given
+                                                                            ///< command being the wait event of
+                                                                            ///< the next to define an in-order list, and application is allowed to
+                                                                            ///< pass signal and wait events
+                                                                            ///< to each appended command to implement more complex dependency graphs.
+    ZE_COMMAND_QUEUE_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_command_queue_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported command queue modes
+typedef enum _ze_command_queue_mode_t
+{
+    ZE_COMMAND_QUEUE_MODE_DEFAULT = 0,                                      ///< implicit default behavior; uses driver-based heuristics
+    ZE_COMMAND_QUEUE_MODE_SYNCHRONOUS = 1,                                  ///< Device execution always completes immediately on execute;
+                                                                            ///< Host thread is blocked using wait on implicit synchronization object
+    ZE_COMMAND_QUEUE_MODE_ASYNCHRONOUS = 2,                                 ///< Device execution is scheduled and will complete in future;
+                                                                            ///< explicit synchronization object must be used to determine completeness
+    ZE_COMMAND_QUEUE_MODE_FORCE_UINT32 = 0x7fffffff
+
+} ze_command_queue_mode_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported command queue priorities
+typedef enum _ze_command_queue_priority_t
+{
+    ZE_COMMAND_QUEUE_PRIORITY_NORMAL = 0,                                   ///< [default] normal priority
+    ZE_COMMAND_QUEUE_PRIORITY_PRIORITY_LOW = 1,                             ///< lower priority than normal
+    ZE_COMMAND_QUEUE_PRIORITY_PRIORITY_HIGH = 2,                            ///< higher priority than normal
+    ZE_COMMAND_QUEUE_PRIORITY_FORCE_UINT32 = 0x7fffffff
+
+} ze_command_queue_priority_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Command Queue descriptor
+typedef struct _ze_command_queue_desc_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    uint32_t ordinal;                                                       ///< [in] command queue group ordinal
+    uint32_t index;                                                         ///< [in] command queue index within the group;
+                                                                            ///< must be zero if ::ZE_COMMAND_QUEUE_FLAG_EXPLICIT_ONLY is not set
+    ze_command_queue_flags_t flags;                                         ///< [in] usage flags.
+                                                                            ///< must be 0 (default) or a valid combination of ::ze_command_queue_flag_t;
+                                                                            ///< default behavior may use implicit driver-based heuristics to balance
+                                                                            ///< latency and throughput.
+    ze_command_queue_mode_t mode;                                           ///< [in] operation mode
+    ze_command_queue_priority_t priority;                                   ///< [in] priority
+
+} ze_command_queue_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Creates a command queue on the context.
+/// 
+/// @details
+///     - A command queue represents a logical input stream to the device, tied
+///       to a physical input stream.
+///     - The application must only use the command queue for the device, or its
+///       sub-devices, which was provided during creation.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clCreateCommandQueue**
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == desc`
+///         + `nullptr == phCommandQueue`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `0x3 < desc->flags`
+///         + `::ZE_COMMAND_QUEUE_MODE_ASYNCHRONOUS < desc->mode`
+///         + `::ZE_COMMAND_QUEUE_PRIORITY_PRIORITY_HIGH < desc->priority`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandQueueCreate(
+    ze_context_handle_t hContext,                                           ///< [in] handle of the context object
+    ze_device_handle_t hDevice,                                             ///< [in] handle of the device object
+    const ze_command_queue_desc_t* desc,                                    ///< [in] pointer to command queue descriptor
+    ze_command_queue_handle_t* phCommandQueue                               ///< [out] pointer to handle of command queue object created
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Destroys a command queue.
+/// 
+/// @details
+///     - The application must destroy all fence handles created from the
+///       command queue before destroying the command queue itself
+///     - The application must ensure the device is not currently referencing
+///       the command queue before it is deleted
+///     - The implementation of this function may immediately free all Host and
+///       Device allocations associated with this command queue
+///     - The application must **not** call this function from simultaneous
+///       threads with the same command queue handle.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clReleaseCommandQueue**
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandQueue`
+///     - ::ZE_RESULT_ERROR_HANDLE_OBJECT_IN_USE
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandQueueDestroy(
+    ze_command_queue_handle_t hCommandQueue                                 ///< [in][release] handle of command queue object to destroy
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Executes a command list in a command queue.
+/// 
+/// @details
+///     - The command lists are submitted to the device in the order they are
+///       received, whether from multiple calls (on the same or different
+///       threads) or a single call with multiple command lists.
+///     - The application must ensure the command lists are accessible by the
+///       device on which the command queue was created.
+///     - The application must ensure the device is not currently referencing
+///       the command list since the implementation is allowed to modify the
+///       contents of the command list for submission.
+///     - The application must only execute command lists created with an
+///       identical command queue group ordinal to the command queue.
+///     - The application must use a fence created using the same command queue.
+///     - The application must ensure the command queue, command list and fence
+///       were created on the same context.
+///     - The application must ensure the command lists being executed are not
+///       immediate command lists.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @remarks
+///   _Analogues_
+///     - vkQueueSubmit
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandQueue`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == phCommandLists`
+///     - ::ZE_RESULT_ERROR_INVALID_SIZE
+///         + `0 == numCommandLists`
+///     - ::ZE_RESULT_ERROR_INVALID_COMMAND_LIST_TYPE
+///     - ::ZE_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandQueueExecuteCommandLists(
+    ze_command_queue_handle_t hCommandQueue,                                ///< [in] handle of the command queue
+    uint32_t numCommandLists,                                               ///< [in] number of command lists to execute
+    ze_command_list_handle_t* phCommandLists,                               ///< [in][range(0, numCommandLists)] list of handles of the command lists
+                                                                            ///< to execute
+    ze_fence_handle_t hFence                                                ///< [in][optional] handle of the fence to signal on completion
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Synchronizes a command queue by waiting on the host.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandQueue`
+///     - ::ZE_RESULT_NOT_READY
+///         + timeout expired
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandQueueSynchronize(
+    ze_command_queue_handle_t hCommandQueue,                                ///< [in] handle of the command queue
+    uint64_t timeout                                                        ///< [in] if non-zero, then indicates the maximum time (in nanoseconds) to
+                                                                            ///< yield before returning ::ZE_RESULT_SUCCESS or ::ZE_RESULT_NOT_READY;
+                                                                            ///< if zero, then immediately returns the status of the command queue;
+                                                                            ///< if `UINT64_MAX`, then function will not return until complete or
+                                                                            ///< device is lost.
+                                                                            ///< Due to external dependencies, timeout may be rounded to the closest
+                                                                            ///< value allowed by the accuracy of those dependencies.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Gets the command queue group ordinal.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandQueue`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pOrdinal`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandQueueGetOrdinal(
+    ze_command_queue_handle_t hCommandQueue,                                ///< [in] handle of the command queue
+    uint32_t* pOrdinal                                                      ///< [out] command queue group ordinal
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Gets the command queue index within the group.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandQueue`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pIndex`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandQueueGetIndex(
+    ze_command_queue_handle_t hCommandQueue,                                ///< [in] handle of the command queue
+    uint32_t* pIndex                                                        ///< [out] command queue index within the group
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero APIs for Command List
+#if !defined(__GNUC__)
+#pragma region cmdlist
+#endif
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported command list creation flags
+typedef uint32_t ze_command_list_flags_t;
+typedef enum _ze_command_list_flag_t
+{
+    ZE_COMMAND_LIST_FLAG_RELAXED_ORDERING = ZE_BIT(0),                      ///< driver may reorder commands (e.g., kernels, copies) between barriers
+                                                                            ///< and synchronization primitives.
+                                                                            ///< using this flag may increase Host overhead of ::zeCommandListClose.
+                                                                            ///< therefore, this flag should **not** be set for low-latency usage-models.
+    ZE_COMMAND_LIST_FLAG_MAXIMIZE_THROUGHPUT = ZE_BIT(1),                   ///< driver may perform additional optimizations that increase execution
+                                                                            ///< throughput. 
+                                                                            ///< using this flag may increase Host overhead of ::zeCommandListClose and ::zeCommandQueueExecuteCommandLists.
+                                                                            ///< therefore, this flag should **not** be set for low-latency usage-models.
+    ZE_COMMAND_LIST_FLAG_EXPLICIT_ONLY = ZE_BIT(2),                         ///< command list should be optimized for submission to a single command
+                                                                            ///< queue and device engine.
+                                                                            ///< driver **must** disable any implicit optimizations for distributing
+                                                                            ///< work across multiple engines.
+                                                                            ///< this flag should be used when applications want full control over
+                                                                            ///< multi-engine submission and scheduling.
+    ZE_COMMAND_LIST_FLAG_IN_ORDER = ZE_BIT(3),                              ///< commands appended to this command list are executed in-order, with
+                                                                            ///< driver implementation
+                                                                            ///< enforcing dependencies between them. Application is not required to
+                                                                            ///< have the signal event
+                                                                            ///< of a given command being the wait event of the next to define an
+                                                                            ///< in-order list, and
+                                                                            ///< application is allowed to pass signal and wait events to each appended
+                                                                            ///< command to implement
+                                                                            ///< more complex dependency graphs. Cannot be combined with ::ZE_COMMAND_LIST_FLAG_RELAXED_ORDERING.
+    ZE_COMMAND_LIST_FLAG_EXP_CLONEABLE = ZE_BIT(4),                         ///< this command list may be cloned using ::zeCommandListCreateCloneExp
+                                                                            ///< after ::zeCommandListClose.
+    ZE_COMMAND_LIST_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_command_list_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Command List descriptor
+typedef struct _ze_command_list_desc_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    uint32_t commandQueueGroupOrdinal;                                      ///< [in] command queue group ordinal to which this command list will be
+                                                                            ///< submitted
+    ze_command_list_flags_t flags;                                          ///< [in] usage flags.
+                                                                            ///< must be 0 (default) or a valid combination of ::ze_command_list_flag_t;
+                                                                            ///< default behavior may use implicit driver-based heuristics to balance
+                                                                            ///< latency and throughput.
+
+} ze_command_list_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Creates a command list on the context.
+/// 
+/// @details
+///     - A command list represents a sequence of commands for execution on a
+///       command queue.
+///     - The command list is created in the 'open' state.
+///     - The application must only use the command list for the device, or its
+///       sub-devices, which was provided during creation.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == desc`
+///         + `nullptr == phCommandList`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `0x1f < desc->flags`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandListCreate(
+    ze_context_handle_t hContext,                                           ///< [in] handle of the context object
+    ze_device_handle_t hDevice,                                             ///< [in] handle of the device object
+    const ze_command_list_desc_t* desc,                                     ///< [in] pointer to command list descriptor
+    ze_command_list_handle_t* phCommandList                                 ///< [out] pointer to handle of command list object created
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Creates an immediate command list on the context.
+/// 
+/// @details
+///     - An immediate command list is used for low-latency submission of
+///       commands.
+///     - An immediate command list creates an implicit command queue.
+///     - Immediate command lists must not be passed to
+///       ::zeCommandQueueExecuteCommandLists.
+///     - Commands appended into an immediate command list may execute
+///       synchronously, by blocking until the command is complete.
+///     - The command list is created in the 'open' state and never needs to be
+///       closed.
+///     - The application must only use the command list for the device, or its
+///       sub-devices, which was provided during creation.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == altdesc`
+///         + `nullptr == phCommandList`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `0x3 < altdesc->flags`
+///         + `::ZE_COMMAND_QUEUE_MODE_ASYNCHRONOUS < altdesc->mode`
+///         + `::ZE_COMMAND_QUEUE_PRIORITY_PRIORITY_HIGH < altdesc->priority`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandListCreateImmediate(
+    ze_context_handle_t hContext,                                           ///< [in] handle of the context object
+    ze_device_handle_t hDevice,                                             ///< [in] handle of the device object
+    const ze_command_queue_desc_t* altdesc,                                 ///< [in] pointer to command queue descriptor
+    ze_command_list_handle_t* phCommandList                                 ///< [out] pointer to handle of command list object created
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Destroys a command list.
+/// 
+/// @details
+///     - The application must ensure the device is not currently referencing
+///       the command list before it is deleted.
+///     - The implementation of this function may immediately free all Host and
+///       Device allocations associated with this command list.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same command list handle.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandList`
+///     - ::ZE_RESULT_ERROR_HANDLE_OBJECT_IN_USE
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandListDestroy(
+    ze_command_list_handle_t hCommandList                                   ///< [in][release] handle of command list object to destroy
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Closes a command list; ready to be executed by a command queue.
+/// 
+/// @details
+///     - The application must **not** call this function from simultaneous
+///       threads with the same command list handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandList`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandListClose(
+    ze_command_list_handle_t hCommandList                                   ///< [in] handle of command list object to close
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Reset a command list to initial (empty) state; ready for appending
+///        commands.
+/// 
+/// @details
+///     - The application must ensure the device is not currently referencing
+///       the command list before it is reset
+///     - The application must **not** call this function from simultaneous
+///       threads with the same command list handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandList`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandListReset(
+    ze_command_list_handle_t hCommandList                                   ///< [in] handle of command list object to reset
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Appends a memory write of the device's global timestamp value into a
+///        command list.
+/// 
+/// @details
+///     - The application must ensure the events are accessible by the device on
+///       which the command list was created.
+///     - The timestamp frequency can be queried from the `timerResolution`
+///       member of ::ze_device_properties_t.
+///     - The number of valid bits in the timestamp value can be queried from
+///       the `timestampValidBits` member of ::ze_device_properties_t.
+///     - The application must ensure the memory pointed to by dstptr is
+///       accessible by the device on which the command list was created.
+///     - The application must ensure the command list and events were created,
+///       and the memory was allocated, on the same context.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same command list handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandList`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == dstptr`
+///     - ::ZE_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT
+///     - ::ZE_RESULT_ERROR_INVALID_SIZE
+///         + `(nullptr == phWaitEvents) && (0 < numWaitEvents)`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandListAppendWriteGlobalTimestamp(
+    ze_command_list_handle_t hCommandList,                                  ///< [in] handle of the command list
+    uint64_t* dstptr,                                                       ///< [in,out] pointer to memory where timestamp value will be written; must
+                                                                            ///< be 8byte-aligned.
+    ze_event_handle_t hSignalEvent,                                         ///< [in][optional] handle of the event to signal on completion
+    uint32_t numWaitEvents,                                                 ///< [in][optional] number of events to wait on before executing query;
+                                                                            ///< must be 0 if `nullptr == phWaitEvents`
+    ze_event_handle_t* phWaitEvents                                         ///< [in][optional][range(0, numWaitEvents)] handle of the events to wait
+                                                                            ///< on before executing query
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Synchronizes an immediate command list by waiting on the host for the
+///        completion of all commands previously submitted to it.
+/// 
+/// @details
+///     - The application must call this function only with command lists
+///       created with ::zeCommandListCreateImmediate.
+///     - Waiting on one immediate command list shall not block the concurrent
+///       execution of commands appended to other
+///       immediate command lists created with either a different ordinal or
+///       different index.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandList`
+///     - ::ZE_RESULT_NOT_READY
+///         + timeout expired
+///     - ::ZE_RESULT_ERROR_INVALID_ARGUMENT
+///         + handle does not correspond to an immediate command list
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandListHostSynchronize(
+    ze_command_list_handle_t hCommandList,                                  ///< [in] handle of the immediate command list
+    uint64_t timeout                                                        ///< [in] if non-zero, then indicates the maximum time (in nanoseconds) to
+                                                                            ///< yield before returning ::ZE_RESULT_SUCCESS or ::ZE_RESULT_NOT_READY;
+                                                                            ///< if zero, then immediately returns the status of the immediate command list;
+                                                                            ///< if `UINT64_MAX`, then function will not return until complete or
+                                                                            ///< device is lost.
+                                                                            ///< Due to external dependencies, timeout may be rounded to the closest
+                                                                            ///< value allowed by the accuracy of those dependencies.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Gets the handle of the device on which the command list was created.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandList`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == phDevice`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandListGetDeviceHandle(
+    ze_command_list_handle_t hCommandList,                                  ///< [in] handle of the command list
+    ze_device_handle_t* phDevice                                            ///< [out] handle of the device on which the command list was created
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Gets the handle of the context on which the command list was created.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandList`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == phContext`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandListGetContextHandle(
+    ze_command_list_handle_t hCommandList,                                  ///< [in] handle of the command list
+    ze_context_handle_t* phContext                                          ///< [out] handle of the context on which the command list was created
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Gets the command queue group ordinal to which the command list is
+///        submitted.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandList`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pOrdinal`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandListGetOrdinal(
+    ze_command_list_handle_t hCommandList,                                  ///< [in] handle of the command list
+    uint32_t* pOrdinal                                                      ///< [out] command queue group ordinal to which command list is submitted
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Gets the command queue index within the group to which the immediate
+///        command list is submitted.
+/// 
+/// @details
+///     - The application must call this function only with command lists
+///       created with ::zeCommandListCreateImmediate.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandListImmediate`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pIndex`
+///     - ::ZE_RESULT_ERROR_INVALID_ARGUMENT
+///         + handle does not correspond to an immediate command list
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandListImmediateGetIndex(
+    ze_command_list_handle_t hCommandListImmediate,                         ///< [in] handle of the immediate command list
+    uint32_t* pIndex                                                        ///< [out] command queue index within the group to which the immediate
+                                                                            ///< command list is submitted
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Query whether a command list is an immediate command list.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandList`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pIsImmediate`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandListIsImmediate(
+    ze_command_list_handle_t hCommandList,                                  ///< [in] handle of the command list
+    ze_bool_t* pIsImmediate                                                 ///< [out] Boolean indicating whether the command list is an immediate
+                                                                            ///< command list (true) or not (false)
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero APIs for Barrier
+#if !defined(__GNUC__)
+#pragma region barrier
+#endif
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Appends an execution and global memory barrier into a command list.
+/// 
+/// @details
+///     - The application must ensure the events are accessible by the device on
+///       which the command list was created.
+///     - If numWaitEvents is zero, then all previous commands, enqueued on same
+///       command queue, must complete prior to the execution of the barrier.
+///       This is not the case when numWaitEvents is non-zero.
+///     - If numWaitEvents is non-zero, then only all phWaitEvents must be
+///       signaled prior to the execution of the barrier.
+///     - This command blocks all following commands from beginning until the
+///       execution of the barrier completes.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same command list handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **vkCmdPipelineBarrier**
+///     - clEnqueueBarrierWithWaitList
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandList`
+///     - ::ZE_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT
+///     - ::ZE_RESULT_ERROR_INVALID_SIZE
+///         + `(nullptr == phWaitEvents) && (0 < numWaitEvents)`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandListAppendBarrier(
+    ze_command_list_handle_t hCommandList,                                  ///< [in] handle of the command list
+    ze_event_handle_t hSignalEvent,                                         ///< [in][optional] handle of the event to signal on completion
+    uint32_t numWaitEvents,                                                 ///< [in][optional] number of events to wait on before executing barrier;
+                                                                            ///< must be 0 if `nullptr == phWaitEvents`
+    ze_event_handle_t* phWaitEvents                                         ///< [in][optional][range(0, numWaitEvents)] handle of the events to wait
+                                                                            ///< on before executing barrier
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Appends a global memory ranges barrier into a command list.
+/// 
+/// @details
+///     - The application must ensure the events are accessible by the device on
+///       which the command list was created.
+///     - If numWaitEvents is zero, then all previous commands are completed
+///       prior to the execution of the barrier.
+///     - If numWaitEvents is non-zero, then then all phWaitEvents must be
+///       signaled prior to the execution of the barrier.
+///     - This command blocks all following commands from beginning until the
+///       execution of the barrier completes.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same command list handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandList`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pRangeSizes`
+///         + `nullptr == pRanges`
+///     - ::ZE_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT
+///     - ::ZE_RESULT_ERROR_INVALID_SIZE
+///         + `(nullptr == phWaitEvents) && (0 < numWaitEvents)`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandListAppendMemoryRangesBarrier(
+    ze_command_list_handle_t hCommandList,                                  ///< [in] handle of the command list
+    uint32_t numRanges,                                                     ///< [in] number of memory ranges
+    const size_t* pRangeSizes,                                              ///< [in][range(0, numRanges)] array of sizes of memory range
+    const void** pRanges,                                                   ///< [in][range(0, numRanges)] array of memory ranges
+    ze_event_handle_t hSignalEvent,                                         ///< [in][optional] handle of the event to signal on completion
+    uint32_t numWaitEvents,                                                 ///< [in][optional] number of events to wait on before executing barrier;
+                                                                            ///< must be 0 if `nullptr == phWaitEvents`
+    ze_event_handle_t* phWaitEvents                                         ///< [in][optional][range(0, numWaitEvents)] handle of the events to wait
+                                                                            ///< on before executing barrier
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Ensures in-bound writes to the device are globally observable.
+/// 
+/// @details
+///     - This is a special-case system level barrier that can be used to ensure
+///       global observability of writes; 
+///       typically needed after a producer (e.g., NIC) performs direct writes
+///       to the device's memory (e.g., Direct RDMA writes).
+///       This is typically required when the memory corresponding to the writes
+///       is subsequently accessed from a remote device.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+///         + `nullptr == hDevice`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeContextSystemBarrier(
+    ze_context_handle_t hContext,                                           ///< [in] handle of context object
+    ze_device_handle_t hDevice                                              ///< [in] handle of the device
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero APIs for Copies
+#if !defined(__GNUC__)
+#pragma region copy
+#endif
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Copies host, device, or shared memory.
+/// 
+/// @details
+///     - The application must ensure the memory pointed to by dstptr and srcptr
+///       is accessible by the device on which the command list was created.
+///     - The implementation must not access the memory pointed to by dstptr and
+///       srcptr as they are free to be modified by either the Host or device up
+///       until execution.
+///     - The application must ensure the events are accessible by the device on
+///       which the command list was created.
+///     - The application must ensure the command list and events were created,
+///       and the memory was allocated, on the same context.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same command list handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clEnqueueCopyBuffer**
+///     - **clEnqueueReadBuffer**
+///     - **clEnqueueWriteBuffer**
+///     - **clEnqueueSVMMemcpy**
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandList`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == dstptr`
+///         + `nullptr == srcptr`
+///     - ::ZE_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT
+///     - ::ZE_RESULT_ERROR_INVALID_SIZE
+///         + `(nullptr == phWaitEvents) && (0 < numWaitEvents)`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandListAppendMemoryCopy(
+    ze_command_list_handle_t hCommandList,                                  ///< [in] handle of command list
+    void* dstptr,                                                           ///< [in] pointer to destination memory to copy to
+    const void* srcptr,                                                     ///< [in] pointer to source memory to copy from
+    size_t size,                                                            ///< [in] size in bytes to copy
+    ze_event_handle_t hSignalEvent,                                         ///< [in][optional] handle of the event to signal on completion
+    uint32_t numWaitEvents,                                                 ///< [in][optional] number of events to wait on before launching; must be 0
+                                                                            ///< if `nullptr == phWaitEvents`
+    ze_event_handle_t* phWaitEvents                                         ///< [in][optional][range(0, numWaitEvents)] handle of the events to wait
+                                                                            ///< on before launching
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Initializes host, device, or shared memory.
+/// 
+/// @details
+///     - The application must ensure the memory pointed to by dstptr is
+///       accessible by the device on which the command list was created.
+///     - The implementation must not access the memory pointed to by dstptr as
+///       it is free to be modified by either the Host or device up until
+///       execution.
+///     - The value to initialize memory to is described by the pattern and the
+///       pattern size.
+///     - The pattern size must be a power-of-two and less than or equal to the
+///       `maxMemoryFillPatternSize` member of
+///       ::ze_command_queue_group_properties_t.
+///     - The application must ensure the events are accessible by the device on
+///       which the command list was created.
+///     - The application must ensure the command list and events were created,
+///       and the memory was allocated, on the same context.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same command list handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clEnqueueFillBuffer**
+///     - **clEnqueueSVMMemFill**
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandList`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == ptr`
+///         + `nullptr == pattern`
+///     - ::ZE_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT
+///     - ::ZE_RESULT_ERROR_INVALID_SIZE
+///         + `(nullptr == phWaitEvents) && (0 < numWaitEvents)`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandListAppendMemoryFill(
+    ze_command_list_handle_t hCommandList,                                  ///< [in] handle of command list
+    void* ptr,                                                              ///< [in] pointer to memory to initialize
+    const void* pattern,                                                    ///< [in] pointer to value to initialize memory to
+    size_t pattern_size,                                                    ///< [in] size in bytes of the value to initialize memory to
+    size_t size,                                                            ///< [in] size in bytes to initialize
+    ze_event_handle_t hSignalEvent,                                         ///< [in][optional] handle of the event to signal on completion
+    uint32_t numWaitEvents,                                                 ///< [in][optional] number of events to wait on before launching; must be 0
+                                                                            ///< if `nullptr == phWaitEvents`
+    ze_event_handle_t* phWaitEvents                                         ///< [in][optional][range(0, numWaitEvents)] handle of the events to wait
+                                                                            ///< on before launching
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Copy region descriptor
+typedef struct _ze_copy_region_t
+{
+    uint32_t originX;                                                       ///< [in] The origin x offset for region in bytes
+    uint32_t originY;                                                       ///< [in] The origin y offset for region in rows
+    uint32_t originZ;                                                       ///< [in] The origin z offset for region in slices
+    uint32_t width;                                                         ///< [in] The region width relative to origin in bytes
+    uint32_t height;                                                        ///< [in] The region height relative to origin in rows
+    uint32_t depth;                                                         ///< [in] The region depth relative to origin in slices. Set this to 0 for
+                                                                            ///< 2D copy.
+
+} ze_copy_region_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Copies a region from a 2D or 3D array of host, device, or shared
+///        memory.
+/// 
+/// @details
+///     - The application must ensure the memory pointed to by dstptr and srcptr
+///       is accessible by the device on which the command list was created.
+///     - The implementation must not access the memory pointed to by dstptr and
+///       srcptr as they are free to be modified by either the Host or device up
+///       until execution.
+///     - The region width, height, and depth for both src and dst must be same.
+///       The origins can be different.
+///     - The src and dst regions cannot be overlapping.
+///     - The application must ensure the events are accessible by the device on
+///       which the command list was created.
+///     - The application must ensure the command list and events were created,
+///       and the memory was allocated, on the same context.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same command list handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandList`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == dstptr`
+///         + `nullptr == dstRegion`
+///         + `nullptr == srcptr`
+///         + `nullptr == srcRegion`
+///     - ::ZE_RESULT_ERROR_OVERLAPPING_REGIONS
+///     - ::ZE_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT
+///     - ::ZE_RESULT_ERROR_INVALID_SIZE
+///         + `(nullptr == phWaitEvents) && (0 < numWaitEvents)`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandListAppendMemoryCopyRegion(
+    ze_command_list_handle_t hCommandList,                                  ///< [in] handle of command list
+    void* dstptr,                                                           ///< [in] pointer to destination memory to copy to
+    const ze_copy_region_t* dstRegion,                                      ///< [in] pointer to destination region to copy to
+    uint32_t dstPitch,                                                      ///< [in] destination pitch in bytes
+    uint32_t dstSlicePitch,                                                 ///< [in] destination slice pitch in bytes. This is required for 3D region
+                                                                            ///< copies where the `depth` member of ::ze_copy_region_t is not 0,
+                                                                            ///< otherwise it's ignored.
+    const void* srcptr,                                                     ///< [in] pointer to source memory to copy from
+    const ze_copy_region_t* srcRegion,                                      ///< [in] pointer to source region to copy from
+    uint32_t srcPitch,                                                      ///< [in] source pitch in bytes
+    uint32_t srcSlicePitch,                                                 ///< [in] source slice pitch in bytes. This is required for 3D region
+                                                                            ///< copies where the `depth` member of ::ze_copy_region_t is not 0,
+                                                                            ///< otherwise it's ignored.
+    ze_event_handle_t hSignalEvent,                                         ///< [in][optional] handle of the event to signal on completion
+    uint32_t numWaitEvents,                                                 ///< [in][optional] number of events to wait on before launching; must be 0
+                                                                            ///< if `nullptr == phWaitEvents`
+    ze_event_handle_t* phWaitEvents                                         ///< [in][optional][range(0, numWaitEvents)] handle of the events to wait
+                                                                            ///< on before launching
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Copies host, device, or shared memory from another context.
+/// 
+/// @details
+///     - The current active and source context must be from the same driver.
+///     - The application must ensure the memory pointed to by dstptr and srcptr
+///       is accessible by the device on which the command list was created.
+///     - The implementation must not access the memory pointed to by dstptr and
+///       srcptr as they are free to be modified by either the Host or device up
+///       until execution.
+///     - The application must ensure the events are accessible by the device on
+///       which the command list was created.
+///     - The application must ensure the command list and events were created,
+///       and the memory was allocated, on the same context.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same command list handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandList`
+///         + `nullptr == hContextSrc`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == dstptr`
+///         + `nullptr == srcptr`
+///     - ::ZE_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT
+///     - ::ZE_RESULT_ERROR_INVALID_SIZE
+///         + `(nullptr == phWaitEvents) && (0 < numWaitEvents)`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandListAppendMemoryCopyFromContext(
+    ze_command_list_handle_t hCommandList,                                  ///< [in] handle of command list
+    void* dstptr,                                                           ///< [in] pointer to destination memory to copy to
+    ze_context_handle_t hContextSrc,                                        ///< [in] handle of source context object
+    const void* srcptr,                                                     ///< [in] pointer to source memory to copy from
+    size_t size,                                                            ///< [in] size in bytes to copy
+    ze_event_handle_t hSignalEvent,                                         ///< [in][optional] handle of the event to signal on completion
+    uint32_t numWaitEvents,                                                 ///< [in][optional] number of events to wait on before launching; must be 0
+                                                                            ///< if `nullptr == phWaitEvents`
+    ze_event_handle_t* phWaitEvents                                         ///< [in][optional][range(0, numWaitEvents)] handle of the events to wait
+                                                                            ///< on before launching
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Copies an image.
+/// 
+/// @details
+///     - The application must ensure the image and events are accessible by the
+///       device on which the command list was created.
+///     - The application must ensure the image format descriptors for both
+///       source and destination images are the same.
+///     - The application must ensure the command list, images and events were
+///       created on the same context.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same command list handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clEnqueueCopyImage**
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandList`
+///         + `nullptr == hDstImage`
+///         + `nullptr == hSrcImage`
+///     - ::ZE_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT
+///     - ::ZE_RESULT_ERROR_INVALID_SIZE
+///         + `(nullptr == phWaitEvents) && (0 < numWaitEvents)`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandListAppendImageCopy(
+    ze_command_list_handle_t hCommandList,                                  ///< [in] handle of command list
+    ze_image_handle_t hDstImage,                                            ///< [in] handle of destination image to copy to
+    ze_image_handle_t hSrcImage,                                            ///< [in] handle of source image to copy from
+    ze_event_handle_t hSignalEvent,                                         ///< [in][optional] handle of the event to signal on completion
+    uint32_t numWaitEvents,                                                 ///< [in][optional] number of events to wait on before launching; must be 0
+                                                                            ///< if `nullptr == phWaitEvents`
+    ze_event_handle_t* phWaitEvents                                         ///< [in][optional][range(0, numWaitEvents)] handle of the events to wait
+                                                                            ///< on before launching
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Region descriptor
+typedef struct _ze_image_region_t
+{
+    uint32_t originX;                                                       ///< [in] The origin x offset for region in pixels
+    uint32_t originY;                                                       ///< [in] The origin y offset for region in pixels
+    uint32_t originZ;                                                       ///< [in] The origin z offset for region in pixels
+    uint32_t width;                                                         ///< [in] The region width relative to origin in pixels
+    uint32_t height;                                                        ///< [in] The region height relative to origin in pixels
+    uint32_t depth;                                                         ///< [in] The region depth relative to origin. For 1D or 2D images, set
+                                                                            ///< this to 1.
+
+} ze_image_region_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Copies a region of an image to another image.
+/// 
+/// @details
+///     - The application must ensure the image and events are accessible by the
+///       device on which the command list was created.
+///     - The region width and height for both src and dst must be same. The
+///       origins can be different.
+///     - The src and dst regions cannot be overlapping.
+///     - The application must ensure the image format descriptors for both
+///       source and destination images are the same.
+///     - The application must ensure the command list, images and events were
+///       created, and the memory was allocated, on the same context.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same command list handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandList`
+///         + `nullptr == hDstImage`
+///         + `nullptr == hSrcImage`
+///     - ::ZE_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT
+///     - ::ZE_RESULT_ERROR_OVERLAPPING_REGIONS
+///     - ::ZE_RESULT_ERROR_INVALID_SIZE
+///         + `(nullptr == phWaitEvents) && (0 < numWaitEvents)`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandListAppendImageCopyRegion(
+    ze_command_list_handle_t hCommandList,                                  ///< [in] handle of command list
+    ze_image_handle_t hDstImage,                                            ///< [in] handle of destination image to copy to
+    ze_image_handle_t hSrcImage,                                            ///< [in] handle of source image to copy from
+    const ze_image_region_t* pDstRegion,                                    ///< [in][optional] destination region descriptor
+    const ze_image_region_t* pSrcRegion,                                    ///< [in][optional] source region descriptor
+    ze_event_handle_t hSignalEvent,                                         ///< [in][optional] handle of the event to signal on completion
+    uint32_t numWaitEvents,                                                 ///< [in][optional] number of events to wait on before launching; must be 0
+                                                                            ///< if `nullptr == phWaitEvents`
+    ze_event_handle_t* phWaitEvents                                         ///< [in][optional][range(0, numWaitEvents)] handle of the events to wait
+                                                                            ///< on before launching
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Copies from an image to device or shared memory.
+/// 
+/// @details
+///     - The application must ensure the memory pointed to by dstptr is
+///       accessible by the device on which the command list was created.
+///     - The implementation must not access the memory pointed to by dstptr as
+///       it is free to be modified by either the Host or device up until
+///       execution.
+///     - The application must ensure the image and events are accessible by the
+///       device on which the command list was created.
+///     - The application must ensure the image format descriptor for the source
+///       image is a single-planar format.
+///     - The application must ensure the command list, image and events were
+///       created, and the memory was allocated, on the same context.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same command list handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @remarks
+///   _Analogues_
+///     - clEnqueueReadImage
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandList`
+///         + `nullptr == hSrcImage`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == dstptr`
+///     - ::ZE_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT
+///     - ::ZE_RESULT_ERROR_INVALID_SIZE
+///         + `(nullptr == phWaitEvents) && (0 < numWaitEvents)`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandListAppendImageCopyToMemory(
+    ze_command_list_handle_t hCommandList,                                  ///< [in] handle of command list
+    void* dstptr,                                                           ///< [in] pointer to destination memory to copy to
+    ze_image_handle_t hSrcImage,                                            ///< [in] handle of source image to copy from
+    const ze_image_region_t* pSrcRegion,                                    ///< [in][optional] source region descriptor
+    ze_event_handle_t hSignalEvent,                                         ///< [in][optional] handle of the event to signal on completion
+    uint32_t numWaitEvents,                                                 ///< [in][optional] number of events to wait on before launching; must be 0
+                                                                            ///< if `nullptr == phWaitEvents`
+    ze_event_handle_t* phWaitEvents                                         ///< [in][optional][range(0, numWaitEvents)] handle of the events to wait
+                                                                            ///< on before launching
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Copies to an image from device or shared memory.
+/// 
+/// @details
+///     - The application must ensure the memory pointed to by srcptr is
+///       accessible by the device on which the command list was created.
+///     - The implementation must not access the memory pointed to by srcptr as
+///       it is free to be modified by either the Host or device up until
+///       execution.
+///     - The application must ensure the image and events are accessible by the
+///       device on which the command list was created.
+///     - The application must ensure the image format descriptor for the
+///       destination image is a single-planar format.
+///     - The application must ensure the command list, image and events were
+///       created, and the memory was allocated, on the same context.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same command list handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @remarks
+///   _Analogues_
+///     - clEnqueueWriteImage
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandList`
+///         + `nullptr == hDstImage`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == srcptr`
+///     - ::ZE_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT
+///     - ::ZE_RESULT_ERROR_INVALID_SIZE
+///         + `(nullptr == phWaitEvents) && (0 < numWaitEvents)`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandListAppendImageCopyFromMemory(
+    ze_command_list_handle_t hCommandList,                                  ///< [in] handle of command list
+    ze_image_handle_t hDstImage,                                            ///< [in] handle of destination image to copy to
+    const void* srcptr,                                                     ///< [in] pointer to source memory to copy from
+    const ze_image_region_t* pDstRegion,                                    ///< [in][optional] destination region descriptor
+    ze_event_handle_t hSignalEvent,                                         ///< [in][optional] handle of the event to signal on completion
+    uint32_t numWaitEvents,                                                 ///< [in][optional] number of events to wait on before launching; must be 0
+                                                                            ///< if `nullptr == phWaitEvents`
+    ze_event_handle_t* phWaitEvents                                         ///< [in][optional][range(0, numWaitEvents)] handle of the events to wait
+                                                                            ///< on before launching
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Asynchronously prefetches shared memory to the device associated with
+///        the specified command list
+/// 
+/// @details
+///     - This is a hint to improve performance only and is not required for
+///       correctness.
+///     - Only prefetching to the device associated with the specified command
+///       list is supported.
+///       Prefetching to the host or to a peer device is not supported.
+///     - Prefetching may not be supported for all allocation types for all devices.
+///       If memory prefetching is not supported for the specified memory range
+///       the prefetch hint may be ignored.
+///     - Prefetching may only be supported at a device-specific granularity,
+///       such as at a page boundary.
+///       In this case, the memory range may be expanded such that the start and
+///       end of the range satisfy granularity requirements.
+///     - The application must ensure the memory pointed to by ptr is accessible
+///       by the device on which the command list was created.
+///     - The application must ensure the command list was created, and the
+///       memory was allocated, on the same context.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same command list handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @remarks
+///   _Analogues_
+///     - clEnqueueSVMMigrateMem
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandList`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == ptr`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandListAppendMemoryPrefetch(
+    ze_command_list_handle_t hCommandList,                                  ///< [in] handle of command list
+    const void* ptr,                                                        ///< [in] pointer to start of the memory range to prefetch
+    size_t size                                                             ///< [in] size in bytes of the memory range to prefetch
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported memory advice hints
+typedef enum _ze_memory_advice_t
+{
+    ZE_MEMORY_ADVICE_SET_READ_MOSTLY = 0,                                   ///< hint that memory will be read from frequently and written to rarely
+    ZE_MEMORY_ADVICE_CLEAR_READ_MOSTLY = 1,                                 ///< removes the effect of ::ZE_MEMORY_ADVICE_SET_READ_MOSTLY
+    ZE_MEMORY_ADVICE_SET_PREFERRED_LOCATION = 2,                            ///< hint that the preferred memory location is the specified device
+    ZE_MEMORY_ADVICE_CLEAR_PREFERRED_LOCATION = 3,                          ///< removes the effect of ::ZE_MEMORY_ADVICE_SET_PREFERRED_LOCATION
+    ZE_MEMORY_ADVICE_SET_NON_ATOMIC_MOSTLY = 4,                             ///< hints that memory will mostly be accessed non-atomically
+    ZE_MEMORY_ADVICE_CLEAR_NON_ATOMIC_MOSTLY = 5,                           ///< removes the effect of ::ZE_MEMORY_ADVICE_SET_NON_ATOMIC_MOSTLY
+    ZE_MEMORY_ADVICE_BIAS_CACHED = 6,                                       ///< hints that memory should be cached
+    ZE_MEMORY_ADVICE_BIAS_UNCACHED = 7,                                     ///< hints that memory should be not be cached
+    ZE_MEMORY_ADVICE_SET_SYSTEM_MEMORY_PREFERRED_LOCATION = 8,              ///< hint that the preferred memory location is host memory
+    ZE_MEMORY_ADVICE_CLEAR_SYSTEM_MEMORY_PREFERRED_LOCATION = 9,            ///< removes the effect of
+                                                                            ///< ::ZE_MEMORY_ADVICE_SET_SYSTEM_MEMORY_PREFERRED_LOCATION
+    ZE_MEMORY_ADVICE_FORCE_UINT32 = 0x7fffffff
+
+} ze_memory_advice_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Provides advice about the use of a shared memory range
+/// 
+/// @details
+///     - Memory advice is a performance hint only and is not required for
+///       functional correctness.
+///     - Memory advice can be used to override driver heuristics to explicitly
+///       control shared memory behavior.
+///     - Not all memory advice hints may be supported for all allocation types
+///       for all devices.
+///       If a memory advice hint is not supported by the device it will be ignored.
+///     - Memory advice may only be supported at a device-specific granularity,
+///       such as at a page boundary.
+///       In this case, the memory range may be expanded such that the start and
+///       end of the range satisfy granularity requirements.
+///     - The application must ensure the memory pointed to by ptr is accessible
+///       by the device on which the command list was created.
+///     - The application must ensure the command list was created, and memory
+///       was allocated, on the same context.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same command list handle, and the memory was
+///       allocated.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandList`
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == ptr`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::ZE_MEMORY_ADVICE_CLEAR_SYSTEM_MEMORY_PREFERRED_LOCATION < advice`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandListAppendMemAdvise(
+    ze_command_list_handle_t hCommandList,                                  ///< [in] handle of command list
+    ze_device_handle_t hDevice,                                             ///< [in] device associated with the memory advice
+    const void* ptr,                                                        ///< [in] Pointer to the start of the memory range
+    size_t size,                                                            ///< [in] Size in bytes of the memory range
+    ze_memory_advice_t advice                                               ///< [in] Memory advice for the memory range
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero APIs for Event
+#if !defined(__GNUC__)
+#pragma region event
+#endif
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported event pool creation flags
+typedef uint32_t ze_event_pool_flags_t;
+typedef enum _ze_event_pool_flag_t
+{
+    ZE_EVENT_POOL_FLAG_HOST_VISIBLE = ZE_BIT(0),                            ///< signals and waits are also visible to host
+    ZE_EVENT_POOL_FLAG_IPC = ZE_BIT(1),                                     ///< signals and waits may be shared across processes
+    ZE_EVENT_POOL_FLAG_KERNEL_TIMESTAMP = ZE_BIT(2),                        ///< Indicates all events in pool will contain kernel timestamps
+    ZE_EVENT_POOL_FLAG_KERNEL_MAPPED_TIMESTAMP = ZE_BIT(3),                 ///< Indicates all events in pool will contain kernel timestamps
+                                                                            ///< synchronized to host time domain; cannot be combined with
+                                                                            ///< ::ZE_EVENT_POOL_FLAG_KERNEL_TIMESTAMP
+    ZE_EVENT_POOL_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_event_pool_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Event pool descriptor
+typedef struct _ze_event_pool_desc_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_event_pool_flags_t flags;                                            ///< [in] creation flags.
+                                                                            ///< must be 0 (default) or a valid combination of ::ze_event_pool_flag_t;
+                                                                            ///< default behavior is signals and waits are visible to the entire device
+                                                                            ///< and peer devices.
+    uint32_t count;                                                         ///< [in] number of events within the pool; must be greater than 0
+
+} ze_event_pool_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Creates a pool of events on the context.
+/// 
+/// @details
+///     - The application must only use events within the pool for the
+///       device(s), or their sub-devices, which were provided during creation.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == desc`
+///         + `nullptr == phEventPool`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `0xf < desc->flags`
+///     - ::ZE_RESULT_ERROR_INVALID_SIZE
+///         + `0 == desc->count`
+///         + `(nullptr == phDevices) && (0 < numDevices)`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeEventPoolCreate(
+    ze_context_handle_t hContext,                                           ///< [in] handle of the context object
+    const ze_event_pool_desc_t* desc,                                       ///< [in] pointer to event pool descriptor
+    uint32_t numDevices,                                                    ///< [in][optional] number of device handles; must be 0 if `nullptr ==
+                                                                            ///< phDevices`
+    ze_device_handle_t* phDevices,                                          ///< [in][optional][range(0, numDevices)] array of device handles which
+                                                                            ///< have visibility to the event pool.
+                                                                            ///< if nullptr, then event pool is visible to all devices supported by the
+                                                                            ///< driver instance.
+    ze_event_pool_handle_t* phEventPool                                     ///< [out] pointer handle of event pool object created
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Deletes an event pool object.
+/// 
+/// @details
+///     - The application must destroy all event handles created from the pool
+///       before destroying the pool itself.
+///     - The application must ensure the device is not currently referencing
+///       the any event within the pool before it is deleted.
+///     - The implementation of this function may immediately free all Host and
+///       Device allocations associated with this event pool.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same event pool handle.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hEventPool`
+///     - ::ZE_RESULT_ERROR_HANDLE_OBJECT_IN_USE
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeEventPoolDestroy(
+    ze_event_pool_handle_t hEventPool                                       ///< [in][release] handle of event pool object to destroy
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported event scope flags
+typedef uint32_t ze_event_scope_flags_t;
+typedef enum _ze_event_scope_flag_t
+{
+    ZE_EVENT_SCOPE_FLAG_SUBDEVICE = ZE_BIT(0),                              ///< cache hierarchies are flushed or invalidated sufficient for local
+                                                                            ///< sub-device access
+    ZE_EVENT_SCOPE_FLAG_DEVICE = ZE_BIT(1),                                 ///< cache hierarchies are flushed or invalidated sufficient for global
+                                                                            ///< device access and peer device access
+    ZE_EVENT_SCOPE_FLAG_HOST = ZE_BIT(2),                                   ///< cache hierarchies are flushed or invalidated sufficient for device and
+                                                                            ///< host access
+    ZE_EVENT_SCOPE_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_event_scope_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Event descriptor
+typedef struct _ze_event_desc_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    uint32_t index;                                                         ///< [in] index of the event within the pool; must be less than the count
+                                                                            ///< specified during pool creation
+    ze_event_scope_flags_t signal;                                          ///< [in] defines the scope of relevant cache hierarchies to flush on a
+                                                                            ///< signal action before the event is triggered.
+                                                                            ///< must be 0 (default) or a valid combination of ::ze_event_scope_flag_t;
+                                                                            ///< default behavior is synchronization within the command list only, no
+                                                                            ///< additional cache hierarchies are flushed.
+    ze_event_scope_flags_t wait;                                            ///< [in] defines the scope of relevant cache hierarchies to invalidate on
+                                                                            ///< a wait action after the event is complete.
+                                                                            ///< must be 0 (default) or a valid combination of ::ze_event_scope_flag_t;
+                                                                            ///< default behavior is synchronization within the command list only, no
+                                                                            ///< additional cache hierarchies are invalidated.
+
+} ze_event_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Creates an event from the pool.
+/// 
+/// @details
+///     - An event is used to communicate fine-grain host-to-device,
+///       device-to-host or device-to-device dependencies have completed.
+///     - The application must ensure the location in the pool is not being used
+///       by another event.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same event pool handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clCreateUserEvent**
+///     - vkCreateEvent
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hEventPool`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == desc`
+///         + `nullptr == phEvent`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `0x7 < desc->signal`
+///         + `0x7 < desc->wait`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeEventCreate(
+    ze_event_pool_handle_t hEventPool,                                      ///< [in] handle of the event pool
+    const ze_event_desc_t* desc,                                            ///< [in] pointer to event descriptor
+    ze_event_handle_t* phEvent                                              ///< [out] pointer to handle of event object created
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Deletes an event object.
+/// 
+/// @details
+///     - The application must ensure the device is not currently referencing
+///       the event before it is deleted.
+///     - The implementation of this function may immediately free all Host and
+///       Device allocations associated with this event.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same event handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clReleaseEvent**
+///     - vkDestroyEvent
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hEvent`
+///     - ::ZE_RESULT_ERROR_HANDLE_OBJECT_IN_USE
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeEventDestroy(
+    ze_event_handle_t hEvent                                                ///< [in][release] handle of event object to destroy
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Gets an IPC event pool handle for the specified event handle that can
+///        be shared with another process.
+/// 
+/// @details
+///     - Event pool must have been created with ::ZE_EVENT_POOL_FLAG_IPC.
+///     - The application may call this function from simultaneous threads.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hEventPool`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == phIpc`
+///     - ::ZE_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeEventPoolGetIpcHandle(
+    ze_event_pool_handle_t hEventPool,                                      ///< [in] handle of event pool object
+    ze_ipc_event_pool_handle_t* phIpc                                       ///< [out] Returned IPC event handle
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Returns an IPC event pool handle to the driver
+/// 
+/// @details
+///     - This call must be used for IPC handles previously obtained with
+///       ::zeEventPoolGetIpcHandle.
+///     - Upon call, driver may release any underlying resources associated with
+///       the IPC handle.
+///       For instance, it may close the file descriptor contained in the IPC
+///       handle, if such type of handle is being used by the driver.
+///     - This call does not destroy the original event pool for which the IPC
+///       handle was created.
+///     - This function may **not** be called from simultaneous threads with the
+///       same IPC handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeEventPoolPutIpcHandle(
+    ze_context_handle_t hContext,                                           ///< [in] handle of the context object associated with the IPC event pool
+                                                                            ///< handle
+    ze_ipc_event_pool_handle_t hIpc                                         ///< [in] IPC event pool handle
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Opens an IPC event pool handle to retrieve an event pool handle from
+///        another process.
+/// 
+/// @details
+///     - Multiple calls to this function with the same IPC handle will return
+///       unique event pool handles.
+///     - The event handle in this process should not be freed with
+///       ::zeEventPoolDestroy, but rather with ::zeEventPoolCloseIpcHandle.
+///     - If the original event pool has been created for a device containing a
+///       number of sub-devices, then the event pool
+///       returned by this call may be used on a device containing the same
+///       number of sub-devices, or on any of
+///       those sub-devices.
+///     - However, if the original event pool has been created for a sub-device,
+///       then the event pool returned by this call
+///       cannot be used on a device containing any number of sub-devices, and
+///       must be used only in a sub-device. This ensures
+///       functional correctness for any implementation or optimizations the
+///       underlying Level Zero driver may do on
+///       event pools and events.
+///     - The application may call this function from simultaneous threads.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == phEventPool`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeEventPoolOpenIpcHandle(
+    ze_context_handle_t hContext,                                           ///< [in] handle of the context object to associate with the IPC event pool
+                                                                            ///< handle
+    ze_ipc_event_pool_handle_t hIpc,                                        ///< [in] IPC event pool handle
+    ze_event_pool_handle_t* phEventPool                                     ///< [out] pointer handle of event pool object created
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Closes an IPC event handle in the current process.
+/// 
+/// @details
+///     - Closes an IPC event handle by destroying events that were opened in
+///       this process using ::zeEventPoolOpenIpcHandle.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same event pool handle.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hEventPool`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeEventPoolCloseIpcHandle(
+    ze_event_pool_handle_t hEventPool                                       ///< [in][release] handle of event pool object
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Appends a signal of the event from the device into a command list.
+/// 
+/// @details
+///     - The application must ensure the events are accessible by the device on
+///       which the command list was created.
+///     - The duration of an event created from an event pool that was created
+///       using ::ZE_EVENT_POOL_FLAG_KERNEL_TIMESTAMP or
+///       ::ZE_EVENT_POOL_FLAG_KERNEL_MAPPED_TIMESTAMP flags is undefined.
+///       However, for consistency and orthogonality the event will report
+///       correctly as signaled when used by other event API functionality.
+///     - The application must ensure the command list and events were created
+///       on the same context.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same command list handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clSetUserEventStatus**
+///     - vkCmdSetEvent
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandList`
+///         + `nullptr == hEvent`
+///     - ::ZE_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandListAppendSignalEvent(
+    ze_command_list_handle_t hCommandList,                                  ///< [in] handle of the command list
+    ze_event_handle_t hEvent                                                ///< [in] handle of the event
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Appends wait on event(s) on the device into a command list.
+/// 
+/// @details
+///     - The application must ensure the events are accessible by the device on
+///       which the command list was created.
+///     - The application must ensure the command list and events were created
+///       on the same context.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same command list handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandList`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == phEvents`
+///     - ::ZE_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandListAppendWaitOnEvents(
+    ze_command_list_handle_t hCommandList,                                  ///< [in] handle of the command list
+    uint32_t numEvents,                                                     ///< [in] number of events to wait on before continuing
+    ze_event_handle_t* phEvents                                             ///< [in][range(0, numEvents)] handles of the events to wait on before
+                                                                            ///< continuing
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Signals a event from host.
+/// 
+/// @details
+///     - The duration of an event created from an event pool that was created
+///       using ::ZE_EVENT_POOL_FLAG_KERNEL_TIMESTAMP or
+///       ::ZE_EVENT_POOL_FLAG_KERNEL_MAPPED_TIMESTAMP flags is undefined.
+///       However, for consistency and orthogonality the event will report
+///       correctly as signaled when used by other event API functionality.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @remarks
+///   _Analogues_
+///     - clSetUserEventStatus
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hEvent`
+///     - ::ZE_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeEventHostSignal(
+    ze_event_handle_t hEvent                                                ///< [in] handle of the event
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief The current host thread waits on an event to be signaled.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @remarks
+///   _Analogues_
+///     - clWaitForEvents
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hEvent`
+///     - ::ZE_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT
+///     - ::ZE_RESULT_NOT_READY
+///         + timeout expired
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeEventHostSynchronize(
+    ze_event_handle_t hEvent,                                               ///< [in] handle of the event
+    uint64_t timeout                                                        ///< [in] if non-zero, then indicates the maximum time (in nanoseconds) to
+                                                                            ///< yield before returning ::ZE_RESULT_SUCCESS or ::ZE_RESULT_NOT_READY;
+                                                                            ///< if zero, then operates exactly like ::zeEventQueryStatus;
+                                                                            ///< if `UINT64_MAX`, then function will not return until complete or
+                                                                            ///< device is lost.
+                                                                            ///< Due to external dependencies, timeout may be rounded to the closest
+                                                                            ///< value allowed by the accuracy of those dependencies.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Queries an event object's status on the host.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clGetEventInfo**
+///     - vkGetEventStatus
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hEvent`
+///     - ::ZE_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT
+///     - ::ZE_RESULT_NOT_READY
+///         + not signaled
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeEventQueryStatus(
+    ze_event_handle_t hEvent                                                ///< [in] handle of the event
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Appends a reset of an event back to not signaled state into a command
+///        list.
+/// 
+/// @details
+///     - The application must ensure the events are accessible by the device on
+///       which the command list was created.
+///     - The application must ensure the command list and events were created
+///       on the same context.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same command list handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @remarks
+///   _Analogues_
+///     - vkResetEvent
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandList`
+///         + `nullptr == hEvent`
+///     - ::ZE_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandListAppendEventReset(
+    ze_command_list_handle_t hCommandList,                                  ///< [in] handle of the command list
+    ze_event_handle_t hEvent                                                ///< [in] handle of the event
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief The current host thread resets an event back to not signaled state.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @remarks
+///   _Analogues_
+///     - vkResetEvent
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hEvent`
+///     - ::ZE_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeEventHostReset(
+    ze_event_handle_t hEvent                                                ///< [in] handle of the event
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Kernel timestamp clock data
+/// 
+/// @details
+///     - The timestamp frequency can be queried from the `timerResolution`
+///       member of ::ze_device_properties_t.
+///     - The number of valid bits in the timestamp value can be queried from
+///       the `kernelTimestampValidBits` member of ::ze_device_properties_t.
+typedef struct _ze_kernel_timestamp_data_t
+{
+    uint64_t kernelStart;                                                   ///< [out] device clock at start of kernel execution
+    uint64_t kernelEnd;                                                     ///< [out] device clock at end of kernel execution
+
+} ze_kernel_timestamp_data_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Kernel timestamp result
+typedef struct _ze_kernel_timestamp_result_t
+{
+    ze_kernel_timestamp_data_t global;                                      ///< [out] wall-clock data
+    ze_kernel_timestamp_data_t context;                                     ///< [out] context-active data; only includes clocks while device context
+                                                                            ///< was actively executing.
+
+} ze_kernel_timestamp_result_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Queries an event's timestamp value on the host.
+/// 
+/// @details
+///     - The application must ensure the event was created from an event pool
+///       that was created using ::ZE_EVENT_POOL_FLAG_KERNEL_TIMESTAMP or
+///       ::ZE_EVENT_POOL_FLAG_KERNEL_MAPPED_TIMESTAMP flag.
+///     - The destination memory will be unmodified if the event has not been
+///       signaled.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hEvent`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == dstptr`
+///     - ::ZE_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT
+///     - ::ZE_RESULT_NOT_READY
+///         + not signaled
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeEventQueryKernelTimestamp(
+    ze_event_handle_t hEvent,                                               ///< [in] handle of the event
+    ze_kernel_timestamp_result_t* dstptr                                    ///< [in,out] pointer to memory for where timestamp result will be written.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Appends a query of an events' timestamp value(s) into a command list.
+/// 
+/// @details
+///     - The application must ensure the events are accessible by the device on
+///       which the command list was created.
+///     - The application must ensure the events were created from an event pool
+///       that was created using ::ZE_EVENT_POOL_FLAG_KERNEL_TIMESTAMP flag.
+///     - The application must ensure the memory pointed to by both dstptr and
+///       pOffsets is accessible by the device on which the command list was
+///       created.
+///     - The value(s) written to the destination buffer are undefined if any
+///       timestamp event has not been signaled.
+///     - If pOffsets is nullptr, then multiple results will be appended
+///       sequentially into memory in the same order as phEvents.
+///     - The application must ensure the command list and events were created,
+///       and the memory was allocated, on the same context.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same command list handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandList`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == phEvents`
+///         + `nullptr == dstptr`
+///     - ::ZE_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT
+///     - ::ZE_RESULT_ERROR_INVALID_SIZE
+///         + `(nullptr == phWaitEvents) && (0 < numWaitEvents)`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandListAppendQueryKernelTimestamps(
+    ze_command_list_handle_t hCommandList,                                  ///< [in] handle of the command list
+    uint32_t numEvents,                                                     ///< [in] the number of timestamp events to query
+    ze_event_handle_t* phEvents,                                            ///< [in][range(0, numEvents)] handles of timestamp events to query
+    void* dstptr,                                                           ///< [in,out] pointer to memory where ::ze_kernel_timestamp_result_t will
+                                                                            ///< be written; must be size-aligned.
+    const size_t* pOffsets,                                                 ///< [in][optional][range(0, numEvents)] offset, in bytes, to write
+                                                                            ///< results; address must be 4byte-aligned and offsets must be
+                                                                            ///< size-aligned.
+    ze_event_handle_t hSignalEvent,                                         ///< [in][optional] handle of the event to signal on completion
+    uint32_t numWaitEvents,                                                 ///< [in][optional] number of events to wait on before executing query;
+                                                                            ///< must be 0 if `nullptr == phWaitEvents`
+    ze_event_handle_t* phWaitEvents                                         ///< [in][optional][range(0, numWaitEvents)] handle of the events to wait
+                                                                            ///< on before executing query
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Gets the handle of the event pool for the event.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hEvent`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == phEventPool`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeEventGetEventPool(
+    ze_event_handle_t hEvent,                                               ///< [in] handle of the event
+    ze_event_pool_handle_t* phEventPool                                     ///< [out] handle of the event pool for the event
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Gets the signal event scope.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hEvent`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pSignalScope`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeEventGetSignalScope(
+    ze_event_handle_t hEvent,                                               ///< [in] handle of the event
+    ze_event_scope_flags_t* pSignalScope                                    ///< [out] signal event scope. This is the scope of relevant cache
+                                                                            ///< hierarchies that are flushed on a signal action before the event is
+                                                                            ///< triggered. May be 0 or a valid combination of ::ze_event_scope_flag_t.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Gets the wait event scope.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hEvent`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pWaitScope`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeEventGetWaitScope(
+    ze_event_handle_t hEvent,                                               ///< [in] handle of the event
+    ze_event_scope_flags_t* pWaitScope                                      ///< [out] wait event scope. This is the scope of relevant cache
+                                                                            ///< hierarchies invalidated on a wait action after the event is complete.
+                                                                            ///< May be 0 or a valid combination of ::ze_event_scope_flag_t.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Gets the handle of the context on which the event pool was created.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hEventPool`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == phContext`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeEventPoolGetContextHandle(
+    ze_event_pool_handle_t hEventPool,                                      ///< [in] handle of the event pool
+    ze_context_handle_t* phContext                                          ///< [out] handle of the context on which the event pool was created
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Gets the creation flags used to create the event pool.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hEventPool`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pFlags`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeEventPoolGetFlags(
+    ze_event_pool_handle_t hEventPool,                                      ///< [in] handle of the event pool
+    ze_event_pool_flags_t* pFlags                                           ///< [out] creation flags used to create the event pool; may be 0 or a
+                                                                            ///< valid combination of ::ze_event_pool_flag_t
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero APIs for Fence
+#if !defined(__GNUC__)
+#pragma region fence
+#endif
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported fence creation flags
+typedef uint32_t ze_fence_flags_t;
+typedef enum _ze_fence_flag_t
+{
+    ZE_FENCE_FLAG_SIGNALED = ZE_BIT(0),                                     ///< fence is created in the signaled state, otherwise not signaled.
+    ZE_FENCE_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_fence_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Fence descriptor
+typedef struct _ze_fence_desc_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_fence_flags_t flags;                                                 ///< [in] creation flags.
+                                                                            ///< must be 0 (default) or a valid combination of ::ze_fence_flag_t.
+
+} ze_fence_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Creates a fence for the command queue.
+/// 
+/// @details
+///     - A fence is a heavyweight synchronization primitive used to communicate
+///       to the host that command list execution has completed.
+///     - The application must only use the fence for the command queue which
+///       was provided during creation.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **vkCreateFence**
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandQueue`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == desc`
+///         + `nullptr == phFence`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `0x1 < desc->flags`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeFenceCreate(
+    ze_command_queue_handle_t hCommandQueue,                                ///< [in] handle of command queue
+    const ze_fence_desc_t* desc,                                            ///< [in] pointer to fence descriptor
+    ze_fence_handle_t* phFence                                              ///< [out] pointer to handle of fence object created
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Deletes a fence object.
+/// 
+/// @details
+///     - The application must ensure the device is not currently referencing
+///       the fence before it is deleted.
+///     - The implementation of this function may immediately free all Host and
+///       Device allocations associated with this fence.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same fence handle.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **vkDestroyFence**
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hFence`
+///     - ::ZE_RESULT_ERROR_HANDLE_OBJECT_IN_USE
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeFenceDestroy(
+    ze_fence_handle_t hFence                                                ///< [in][release] handle of fence object to destroy
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief The current host thread waits on a fence to be signaled.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **vkWaitForFences**
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hFence`
+///     - ::ZE_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT
+///     - ::ZE_RESULT_NOT_READY
+///         + timeout expired
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeFenceHostSynchronize(
+    ze_fence_handle_t hFence,                                               ///< [in] handle of the fence
+    uint64_t timeout                                                        ///< [in] if non-zero, then indicates the maximum time (in nanoseconds) to
+                                                                            ///< yield before returning ::ZE_RESULT_SUCCESS or ::ZE_RESULT_NOT_READY;
+                                                                            ///< if zero, then operates exactly like ::zeFenceQueryStatus;
+                                                                            ///< if `UINT64_MAX`, then function will not return until complete or
+                                                                            ///< device is lost.
+                                                                            ///< Due to external dependencies, timeout may be rounded to the closest
+                                                                            ///< value allowed by the accuracy of those dependencies.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Queries a fence object's status.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **vkGetFenceStatus**
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hFence`
+///     - ::ZE_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT
+///     - ::ZE_RESULT_NOT_READY
+///         + not signaled
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeFenceQueryStatus(
+    ze_fence_handle_t hFence                                                ///< [in] handle of the fence
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Reset a fence back to the not signaled state.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **vkResetFences**
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hFence`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeFenceReset(
+    ze_fence_handle_t hFence                                                ///< [in] handle of the fence
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero APIs for Images
+#if !defined(__GNUC__)
+#pragma region image
+#endif
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported image creation flags
+typedef uint32_t ze_image_flags_t;
+typedef enum _ze_image_flag_t
+{
+    ZE_IMAGE_FLAG_KERNEL_WRITE = ZE_BIT(0),                                 ///< kernels will write contents
+    ZE_IMAGE_FLAG_BIAS_UNCACHED = ZE_BIT(1),                                ///< device should not cache contents
+    ZE_IMAGE_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_image_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported image types
+typedef enum _ze_image_type_t
+{
+    ZE_IMAGE_TYPE_1D = 0,                                                   ///< 1D
+    ZE_IMAGE_TYPE_1DARRAY = 1,                                              ///< 1D array
+    ZE_IMAGE_TYPE_2D = 2,                                                   ///< 2D
+    ZE_IMAGE_TYPE_2DARRAY = 3,                                              ///< 2D array
+    ZE_IMAGE_TYPE_3D = 4,                                                   ///< 3D
+    ZE_IMAGE_TYPE_BUFFER = 5,                                               ///< Buffer
+    ZE_IMAGE_TYPE_FORCE_UINT32 = 0x7fffffff
+
+} ze_image_type_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported image format layouts
+typedef enum _ze_image_format_layout_t
+{
+    ZE_IMAGE_FORMAT_LAYOUT_8 = 0,                                           ///< 8-bit single component layout
+    ZE_IMAGE_FORMAT_LAYOUT_16 = 1,                                          ///< 16-bit single component layout
+    ZE_IMAGE_FORMAT_LAYOUT_32 = 2,                                          ///< 32-bit single component layout
+    ZE_IMAGE_FORMAT_LAYOUT_8_8 = 3,                                         ///< 2-component 8-bit layout
+    ZE_IMAGE_FORMAT_LAYOUT_8_8_8_8 = 4,                                     ///< 4-component 8-bit layout
+    ZE_IMAGE_FORMAT_LAYOUT_16_16 = 5,                                       ///< 2-component 16-bit layout
+    ZE_IMAGE_FORMAT_LAYOUT_16_16_16_16 = 6,                                 ///< 4-component 16-bit layout
+    ZE_IMAGE_FORMAT_LAYOUT_32_32 = 7,                                       ///< 2-component 32-bit layout
+    ZE_IMAGE_FORMAT_LAYOUT_32_32_32_32 = 8,                                 ///< 4-component 32-bit layout
+    ZE_IMAGE_FORMAT_LAYOUT_10_10_10_2 = 9,                                  ///< 4-component 10_10_10_2 layout
+    ZE_IMAGE_FORMAT_LAYOUT_11_11_10 = 10,                                   ///< 3-component 11_11_10 layout
+    ZE_IMAGE_FORMAT_LAYOUT_5_6_5 = 11,                                      ///< 3-component 5_6_5 layout
+    ZE_IMAGE_FORMAT_LAYOUT_5_5_5_1 = 12,                                    ///< 4-component 5_5_5_1 layout
+    ZE_IMAGE_FORMAT_LAYOUT_4_4_4_4 = 13,                                    ///< 4-component 4_4_4_4 layout
+    ZE_IMAGE_FORMAT_LAYOUT_Y8 = 14,                                         ///< Media Format: Y8. Format type and swizzle is ignored for this.
+    ZE_IMAGE_FORMAT_LAYOUT_NV12 = 15,                                       ///< Media Format: NV12. Format type and swizzle is ignored for this.
+    ZE_IMAGE_FORMAT_LAYOUT_YUYV = 16,                                       ///< Media Format: YUYV. Format type and swizzle is ignored for this.
+    ZE_IMAGE_FORMAT_LAYOUT_VYUY = 17,                                       ///< Media Format: VYUY. Format type and swizzle is ignored for this.
+    ZE_IMAGE_FORMAT_LAYOUT_YVYU = 18,                                       ///< Media Format: YVYU. Format type and swizzle is ignored for this.
+    ZE_IMAGE_FORMAT_LAYOUT_UYVY = 19,                                       ///< Media Format: UYVY. Format type and swizzle is ignored for this.
+    ZE_IMAGE_FORMAT_LAYOUT_AYUV = 20,                                       ///< Media Format: AYUV. Format type and swizzle is ignored for this.
+    ZE_IMAGE_FORMAT_LAYOUT_P010 = 21,                                       ///< Media Format: P010. Format type and swizzle is ignored for this.
+    ZE_IMAGE_FORMAT_LAYOUT_Y410 = 22,                                       ///< Media Format: Y410. Format type and swizzle is ignored for this.
+    ZE_IMAGE_FORMAT_LAYOUT_P012 = 23,                                       ///< Media Format: P012. Format type and swizzle is ignored for this.
+    ZE_IMAGE_FORMAT_LAYOUT_Y16 = 24,                                        ///< Media Format: Y16. Format type and swizzle is ignored for this.
+    ZE_IMAGE_FORMAT_LAYOUT_P016 = 25,                                       ///< Media Format: P016. Format type and swizzle is ignored for this.
+    ZE_IMAGE_FORMAT_LAYOUT_Y216 = 26,                                       ///< Media Format: Y216. Format type and swizzle is ignored for this.
+    ZE_IMAGE_FORMAT_LAYOUT_P216 = 27,                                       ///< Media Format: P216. Format type and swizzle is ignored for this.
+    ZE_IMAGE_FORMAT_LAYOUT_P8 = 28,                                         ///< Media Format: P8. Format type and swizzle is ignored for this.
+    ZE_IMAGE_FORMAT_LAYOUT_YUY2 = 29,                                       ///< Media Format: YUY2. Format type and swizzle is ignored for this.
+    ZE_IMAGE_FORMAT_LAYOUT_A8P8 = 30,                                       ///< Media Format: A8P8. Format type and swizzle is ignored for this.
+    ZE_IMAGE_FORMAT_LAYOUT_IA44 = 31,                                       ///< Media Format: IA44. Format type and swizzle is ignored for this.
+    ZE_IMAGE_FORMAT_LAYOUT_AI44 = 32,                                       ///< Media Format: AI44. Format type and swizzle is ignored for this.
+    ZE_IMAGE_FORMAT_LAYOUT_Y416 = 33,                                       ///< Media Format: Y416. Format type and swizzle is ignored for this.
+    ZE_IMAGE_FORMAT_LAYOUT_Y210 = 34,                                       ///< Media Format: Y210. Format type and swizzle is ignored for this.
+    ZE_IMAGE_FORMAT_LAYOUT_I420 = 35,                                       ///< Media Format: I420. Format type and swizzle is ignored for this.
+    ZE_IMAGE_FORMAT_LAYOUT_YV12 = 36,                                       ///< Media Format: YV12. Format type and swizzle is ignored for this.
+    ZE_IMAGE_FORMAT_LAYOUT_400P = 37,                                       ///< Media Format: 400P. Format type and swizzle is ignored for this.
+    ZE_IMAGE_FORMAT_LAYOUT_422H = 38,                                       ///< Media Format: 422H. Format type and swizzle is ignored for this.
+    ZE_IMAGE_FORMAT_LAYOUT_422V = 39,                                       ///< Media Format: 422V. Format type and swizzle is ignored for this.
+    ZE_IMAGE_FORMAT_LAYOUT_444P = 40,                                       ///< Media Format: 444P. Format type and swizzle is ignored for this.
+    ZE_IMAGE_FORMAT_LAYOUT_RGBP = 41,                                       ///< Media Format: RGBP. Format type and swizzle is ignored for this.
+    ZE_IMAGE_FORMAT_LAYOUT_BRGP = 42,                                       ///< Media Format: BRGP. Format type and swizzle is ignored for this.
+    ZE_IMAGE_FORMAT_LAYOUT_8_8_8 = 43,                                      ///< 3-component 8-bit layout
+    ZE_IMAGE_FORMAT_LAYOUT_16_16_16 = 44,                                   ///< 3-component 16-bit layout
+    ZE_IMAGE_FORMAT_LAYOUT_32_32_32 = 45,                                   ///< 3-component 32-bit layout
+    ZE_IMAGE_FORMAT_LAYOUT_FORCE_UINT32 = 0x7fffffff
+
+} ze_image_format_layout_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported image format types
+typedef enum _ze_image_format_type_t
+{
+    ZE_IMAGE_FORMAT_TYPE_UINT = 0,                                          ///< Unsigned integer
+    ZE_IMAGE_FORMAT_TYPE_SINT = 1,                                          ///< Signed integer
+    ZE_IMAGE_FORMAT_TYPE_UNORM = 2,                                         ///< Unsigned normalized integer
+    ZE_IMAGE_FORMAT_TYPE_SNORM = 3,                                         ///< Signed normalized integer
+    ZE_IMAGE_FORMAT_TYPE_FLOAT = 4,                                         ///< Float
+    ZE_IMAGE_FORMAT_TYPE_FORCE_UINT32 = 0x7fffffff
+
+} ze_image_format_type_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported image format component swizzle into channel
+typedef enum _ze_image_format_swizzle_t
+{
+    ZE_IMAGE_FORMAT_SWIZZLE_R = 0,                                          ///< Red component
+    ZE_IMAGE_FORMAT_SWIZZLE_G = 1,                                          ///< Green component
+    ZE_IMAGE_FORMAT_SWIZZLE_B = 2,                                          ///< Blue component
+    ZE_IMAGE_FORMAT_SWIZZLE_A = 3,                                          ///< Alpha component
+    ZE_IMAGE_FORMAT_SWIZZLE_0 = 4,                                          ///< Zero
+    ZE_IMAGE_FORMAT_SWIZZLE_1 = 5,                                          ///< One
+    ZE_IMAGE_FORMAT_SWIZZLE_X = 6,                                          ///< Don't care
+    ZE_IMAGE_FORMAT_SWIZZLE_FORCE_UINT32 = 0x7fffffff
+
+} ze_image_format_swizzle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Image format 
+typedef struct _ze_image_format_t
+{
+    ze_image_format_layout_t layout;                                        ///< [in] image format component layout (e.g. N-component layouts and media
+                                                                            ///< formats)
+    ze_image_format_type_t type;                                            ///< [in] image format type
+    ze_image_format_swizzle_t x;                                            ///< [in] image component swizzle into channel x
+    ze_image_format_swizzle_t y;                                            ///< [in] image component swizzle into channel y
+    ze_image_format_swizzle_t z;                                            ///< [in] image component swizzle into channel z
+    ze_image_format_swizzle_t w;                                            ///< [in] image component swizzle into channel w
+
+} ze_image_format_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Image descriptor
+typedef struct _ze_image_desc_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_image_flags_t flags;                                                 ///< [in] creation flags.
+                                                                            ///< must be 0 (default) or a valid combination of ::ze_image_flag_t;
+                                                                            ///< default is read-only, cached access.
+    ze_image_type_t type;                                                   ///< [in] image type. Media format layouts are unsupported for
+                                                                            ///< ::ZE_IMAGE_TYPE_BUFFER
+    ze_image_format_t format;                                               ///< [in] image format
+    uint64_t width;                                                         ///< [in] width dimension.
+                                                                            ///< ::ZE_IMAGE_TYPE_BUFFER: size in bytes; see the `maxImageBufferSize`
+                                                                            ///< member of ::ze_device_image_properties_t for limits.
+                                                                            ///< ::ZE_IMAGE_TYPE_1D, ::ZE_IMAGE_TYPE_1DARRAY: width in pixels; see the
+                                                                            ///< `maxImageDims1D` member of ::ze_device_image_properties_t for limits.
+                                                                            ///< ::ZE_IMAGE_TYPE_2D, ::ZE_IMAGE_TYPE_2DARRAY: width in pixels; see the
+                                                                            ///< `maxImageDims2D` member of ::ze_device_image_properties_t for limits.
+                                                                            ///< ::ZE_IMAGE_TYPE_3D: width in pixels; see the `maxImageDims3D` member
+                                                                            ///< of ::ze_device_image_properties_t for limits.
+    uint32_t height;                                                        ///< [in] height dimension.
+                                                                            ///< ::ZE_IMAGE_TYPE_2D, ::ZE_IMAGE_TYPE_2DARRAY: height in pixels; see the
+                                                                            ///< `maxImageDims2D` member of ::ze_device_image_properties_t for limits.
+                                                                            ///< ::ZE_IMAGE_TYPE_3D: height in pixels; see the `maxImageDims3D` member
+                                                                            ///< of ::ze_device_image_properties_t for limits.
+                                                                            ///< other: ignored.
+    uint32_t depth;                                                         ///< [in] depth dimension.
+                                                                            ///< ::ZE_IMAGE_TYPE_3D: depth in pixels; see the `maxImageDims3D` member
+                                                                            ///< of ::ze_device_image_properties_t for limits.
+                                                                            ///< other: ignored.
+    uint32_t arraylevels;                                                   ///< [in] array levels.
+                                                                            ///< ::ZE_IMAGE_TYPE_1DARRAY, ::ZE_IMAGE_TYPE_2DARRAY: see the
+                                                                            ///< `maxImageArraySlices` member of ::ze_device_image_properties_t for limits.
+                                                                            ///< other: ignored.
+    uint32_t miplevels;                                                     ///< [in] mipmap levels (must be 0)
+
+} ze_image_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported sampler filtering flags
+typedef uint32_t ze_image_sampler_filter_flags_t;
+typedef enum _ze_image_sampler_filter_flag_t
+{
+    ZE_IMAGE_SAMPLER_FILTER_FLAG_POINT = ZE_BIT(0),                         ///< device supports point filtering
+    ZE_IMAGE_SAMPLER_FILTER_FLAG_LINEAR = ZE_BIT(1),                        ///< device supports linear filtering
+    ZE_IMAGE_SAMPLER_FILTER_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_image_sampler_filter_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Image properties
+typedef struct _ze_image_properties_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_image_sampler_filter_flags_t samplerFilterFlags;                     ///< [out] supported sampler filtering.
+                                                                            ///< returns 0 (unsupported) or a combination of ::ze_image_sampler_filter_flag_t.
+
+} ze_image_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves supported properties of an image.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == desc`
+///         + `nullptr == pImageProperties`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `0x3 < desc->flags`
+///         + `::ZE_IMAGE_TYPE_BUFFER < desc->type`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeImageGetProperties(
+    ze_device_handle_t hDevice,                                             ///< [in] handle of the device
+    const ze_image_desc_t* desc,                                            ///< [in] pointer to image descriptor
+    ze_image_properties_t* pImageProperties                                 ///< [out] pointer to image properties
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Creates an image on the context.
+/// 
+/// @details
+///     - The application must only use the image for the device, or its
+///       sub-devices, which was provided during creation.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @remarks
+///   _Analogues_
+///     - clCreateImage
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == desc`
+///         + `nullptr == phImage`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `0x3 < desc->flags`
+///         + `::ZE_IMAGE_TYPE_BUFFER < desc->type`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_IMAGE_FORMAT
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeImageCreate(
+    ze_context_handle_t hContext,                                           ///< [in] handle of the context object
+    ze_device_handle_t hDevice,                                             ///< [in] handle of the device
+    const ze_image_desc_t* desc,                                            ///< [in] pointer to image descriptor
+    ze_image_handle_t* phImage                                              ///< [out] pointer to handle of image object created
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Deletes an image object.
+/// 
+/// @details
+///     - The application must ensure the device is not currently referencing
+///       the image before it is deleted.
+///     - The implementation of this function may immediately free all Host and
+///       Device allocations associated with this image.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same image handle.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hImage`
+///     - ::ZE_RESULT_ERROR_HANDLE_OBJECT_IN_USE
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeImageDestroy(
+    ze_image_handle_t hImage                                                ///< [in][release] handle of image object to destroy
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero APIs for Memory
+#if !defined(__GNUC__)
+#pragma region memory
+#endif
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported memory allocation flags
+typedef uint32_t ze_device_mem_alloc_flags_t;
+typedef enum _ze_device_mem_alloc_flag_t
+{
+    ZE_DEVICE_MEM_ALLOC_FLAG_BIAS_CACHED = ZE_BIT(0),                       ///< device should cache allocation
+    ZE_DEVICE_MEM_ALLOC_FLAG_BIAS_UNCACHED = ZE_BIT(1),                     ///< device should not cache allocation (UC)
+    ZE_DEVICE_MEM_ALLOC_FLAG_BIAS_INITIAL_PLACEMENT = ZE_BIT(2),            ///< optimize shared allocation for first access on the device
+    ZE_DEVICE_MEM_ALLOC_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_device_mem_alloc_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Device memory allocation descriptor
+typedef struct _ze_device_mem_alloc_desc_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_device_mem_alloc_flags_t flags;                                      ///< [in] flags specifying additional allocation controls.
+                                                                            ///< must be 0 (default) or a valid combination of ::ze_device_mem_alloc_flag_t;
+                                                                            ///< default behavior may use implicit driver-based heuristics.
+    uint32_t ordinal;                                                       ///< [in] ordinal of the device's local memory to allocate from.
+                                                                            ///< must be less than the count returned from ::zeDeviceGetMemoryProperties.
+
+} ze_device_mem_alloc_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported host memory allocation flags
+typedef uint32_t ze_host_mem_alloc_flags_t;
+typedef enum _ze_host_mem_alloc_flag_t
+{
+    ZE_HOST_MEM_ALLOC_FLAG_BIAS_CACHED = ZE_BIT(0),                         ///< host should cache allocation
+    ZE_HOST_MEM_ALLOC_FLAG_BIAS_UNCACHED = ZE_BIT(1),                       ///< host should not cache allocation (UC)
+    ZE_HOST_MEM_ALLOC_FLAG_BIAS_WRITE_COMBINED = ZE_BIT(2),                 ///< host memory should be allocated write-combined (WC)
+    ZE_HOST_MEM_ALLOC_FLAG_BIAS_INITIAL_PLACEMENT = ZE_BIT(3),              ///< optimize shared allocation for first access on the host
+    ZE_HOST_MEM_ALLOC_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_host_mem_alloc_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Host memory allocation descriptor
+typedef struct _ze_host_mem_alloc_desc_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_host_mem_alloc_flags_t flags;                                        ///< [in] flags specifying additional allocation controls.
+                                                                            ///< must be 0 (default) or a valid combination of ::ze_host_mem_alloc_flag_t;
+                                                                            ///< default behavior may use implicit driver-based heuristics.
+
+} ze_host_mem_alloc_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Allocates shared memory on the context.
+/// 
+/// @details
+///     - Shared allocations share ownership between the host and one or more
+///       devices.
+///     - Shared allocations may optionally be associated with a device by
+///       passing a handle to the device.
+///     - Devices supporting only single-device shared access capabilities may
+///       access shared memory associated with the device.
+///       For these devices, ownership of the allocation is shared between the
+///       host and the associated device only.
+///     - Passing nullptr as the device handle does not associate the shared
+///       allocation with any device.
+///       For allocations with no associated device, ownership of the allocation
+///       is shared between the host and all devices supporting cross-device
+///       shared access capabilities.
+///     - The application must only use the memory allocation for the context
+///       and device, or its sub-devices, which was provided during allocation.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == device_desc`
+///         + `nullptr == host_desc`
+///         + `nullptr == pptr`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `0x7 < device_desc->flags`
+///         + `0xf < host_desc->flags`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_SIZE
+///         + `0 == size`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_ALIGNMENT
+///         + Must be zero or a power-of-two
+///         + `0 != (alignment & (alignment - 1))`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeMemAllocShared(
+    ze_context_handle_t hContext,                                           ///< [in] handle of the context object
+    const ze_device_mem_alloc_desc_t* device_desc,                          ///< [in] pointer to device memory allocation descriptor
+    const ze_host_mem_alloc_desc_t* host_desc,                              ///< [in] pointer to host memory allocation descriptor
+    size_t size,                                                            ///< [in] size in bytes to allocate; must be less than or equal to the
+                                                                            ///< `maxMemAllocSize` member of ::ze_device_properties_t
+    size_t alignment,                                                       ///< [in] minimum alignment in bytes for the allocation; must be a power of
+                                                                            ///< two
+    ze_device_handle_t hDevice,                                             ///< [in][optional] device handle to associate with
+    void** pptr                                                             ///< [out] pointer to shared allocation
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Allocates device memory on the context.
+/// 
+/// @details
+///     - Device allocations are owned by a specific device.
+///     - In general, a device allocation may only be accessed by the device
+///       that owns it.
+///     - The application must only use the memory allocation for the context
+///       and device, or its sub-devices, which was provided during allocation.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == device_desc`
+///         + `nullptr == pptr`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `0x7 < device_desc->flags`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_SIZE
+///         + `0 == size`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_ALIGNMENT
+///         + Must be zero or a power-of-two
+///         + `0 != (alignment & (alignment - 1))`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeMemAllocDevice(
+    ze_context_handle_t hContext,                                           ///< [in] handle of the context object
+    const ze_device_mem_alloc_desc_t* device_desc,                          ///< [in] pointer to device memory allocation descriptor
+    size_t size,                                                            ///< [in] size in bytes to allocate; must be less than or equal to the
+                                                                            ///< `maxMemAllocSize` member of ::ze_device_properties_t
+    size_t alignment,                                                       ///< [in] minimum alignment in bytes for the allocation; must be a power of
+                                                                            ///< two
+    ze_device_handle_t hDevice,                                             ///< [in] handle of the device
+    void** pptr                                                             ///< [out] pointer to device allocation
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Allocates host memory on the context.
+/// 
+/// @details
+///     - Host allocations are owned by the host process.
+///     - Host allocations are accessible by the host and all devices within the
+///       driver's context.
+///     - Host allocations are frequently used as staging areas to transfer data
+///       to or from devices.
+///     - The application must only use the memory allocation for the context
+///       which was provided during allocation.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == host_desc`
+///         + `nullptr == pptr`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `0xf < host_desc->flags`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_SIZE
+///         + `0 == size`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_ALIGNMENT
+///         + Must be zero or a power-of-two
+///         + `0 != (alignment & (alignment - 1))`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeMemAllocHost(
+    ze_context_handle_t hContext,                                           ///< [in] handle of the context object
+    const ze_host_mem_alloc_desc_t* host_desc,                              ///< [in] pointer to host memory allocation descriptor
+    size_t size,                                                            ///< [in] size in bytes to allocate; must be less than or equal to the
+                                                                            ///< `maxMemAllocSize` member of ::ze_device_properties_t
+    size_t alignment,                                                       ///< [in] minimum alignment in bytes for the allocation; must be a power of
+                                                                            ///< two
+    void** pptr                                                             ///< [out] pointer to host allocation
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Frees allocated host memory, device memory, or shared memory on the
+///        context.
+/// 
+/// @details
+///     - The application must ensure the device is not currently referencing
+///       the memory before it is freed
+///     - The implementation of this function may immediately free all Host and
+///       Device allocations associated with this memory
+///     - The application must **not** call this function from simultaneous
+///       threads with the same pointer.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == ptr`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeMemFree(
+    ze_context_handle_t hContext,                                           ///< [in] handle of the context object
+    void* ptr                                                               ///< [in][release] pointer to memory to free
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Memory allocation type
+typedef enum _ze_memory_type_t
+{
+    ZE_MEMORY_TYPE_UNKNOWN = 0,                                             ///< the memory pointed to is of unknown type
+    ZE_MEMORY_TYPE_HOST = 1,                                                ///< the memory pointed to is a host allocation
+    ZE_MEMORY_TYPE_DEVICE = 2,                                              ///< the memory pointed to is a device allocation
+    ZE_MEMORY_TYPE_SHARED = 3,                                              ///< the memory pointed to is a shared ownership allocation
+    ZE_MEMORY_TYPE_FORCE_UINT32 = 0x7fffffff
+
+} ze_memory_type_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Memory allocation properties queried using ::zeMemGetAllocProperties
+typedef struct _ze_memory_allocation_properties_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_memory_type_t type;                                                  ///< [out] type of allocated memory
+    uint64_t id;                                                            ///< [out] identifier for this allocation
+    uint64_t pageSize;                                                      ///< [out] page size used for allocation
+
+} ze_memory_allocation_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves attributes of a memory allocation
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The application may query attributes of a memory allocation unrelated
+///       to the context.
+///       When this occurs, the returned allocation type will be
+///       ::ZE_MEMORY_TYPE_UNKNOWN, and the returned identifier and associated
+///       device is unspecified.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == ptr`
+///         + `nullptr == pMemAllocProperties`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeMemGetAllocProperties(
+    ze_context_handle_t hContext,                                           ///< [in] handle of the context object
+    const void* ptr,                                                        ///< [in] memory pointer to query
+    ze_memory_allocation_properties_t* pMemAllocProperties,                 ///< [in,out] query result for memory allocation properties
+    ze_device_handle_t* phDevice                                            ///< [out][optional] device associated with this allocation
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves the base address and/or size of an allocation
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == ptr`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeMemGetAddressRange(
+    ze_context_handle_t hContext,                                           ///< [in] handle of the context object
+    const void* ptr,                                                        ///< [in] memory pointer to query
+    void** pBase,                                                           ///< [in,out][optional] base address of the allocation
+    size_t* pSize                                                           ///< [in,out][optional] size of the allocation
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Creates an IPC memory handle for the specified allocation
+/// 
+/// @details
+///     - Takes a pointer to a device memory allocation and creates an IPC
+///       memory handle for exporting it for use in another process.
+///     - The pointer must be base pointer of a device or host memory
+///       allocation; i.e. the value returned from ::zeMemAllocDevice or from
+///       ::zeMemAllocHost, respectively.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == ptr`
+///         + `nullptr == pIpcHandle`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeMemGetIpcHandle(
+    ze_context_handle_t hContext,                                           ///< [in] handle of the context object
+    const void* ptr,                                                        ///< [in] pointer to the device memory allocation
+    ze_ipc_mem_handle_t* pIpcHandle                                         ///< [out] Returned IPC memory handle
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Creates an IPC memory handle out of a file descriptor
+/// 
+/// @details
+///     - Handle passed must be a valid file descriptor obtained with
+///       ::ze_external_memory_export_fd_t via ::zeMemGetAllocProperties.
+///     - Returned IPC handle may contain metadata in addition to the file
+///       descriptor.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pIpcHandle`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeMemGetIpcHandleFromFileDescriptorExp(
+    ze_context_handle_t hContext,                                           ///< [in] handle of the context object
+    uint64_t handle,                                                        ///< [in] file descriptor
+    ze_ipc_mem_handle_t* pIpcHandle                                         ///< [out] Returned IPC memory handle
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Gets the file descriptor contained in an IPC memory handle
+/// 
+/// @details
+///     - IPC memory handle must be a valid handle obtained with
+///       ::zeMemGetIpcHandle.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pHandle`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeMemGetFileDescriptorFromIpcHandleExp(
+    ze_context_handle_t hContext,                                           ///< [in] handle of the context object
+    ze_ipc_mem_handle_t ipcHandle,                                          ///< [in] IPC memory handle
+    uint64_t* pHandle                                                       ///< [out] Returned file descriptor
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Returns an IPC memory handle to the driver
+/// 
+/// @details
+///     - This call may be used for IPC handles previously obtained with either
+///       ::zeMemGetIpcHandle or with ::ze_external_memory_export_fd_t via ::zeMemGetAllocProperties.
+///     - Upon call, driver may release any underlying resources associated with
+///       the IPC handle.
+///       For instance, it may close the file descriptor contained in the IPC
+///       handle, if such type of handle is being used by the driver.
+///     - This call does not free the original allocation for which the IPC
+///       handle was created.
+///     - This function may **not** be called from simultaneous threads with the
+///       same IPC handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeMemPutIpcHandle(
+    ze_context_handle_t hContext,                                           ///< [in] handle of the context object
+    ze_ipc_mem_handle_t handle                                              ///< [in] IPC memory handle
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported IPC memory flags
+typedef uint32_t ze_ipc_memory_flags_t;
+typedef enum _ze_ipc_memory_flag_t
+{
+    ZE_IPC_MEMORY_FLAG_BIAS_CACHED = ZE_BIT(0),                             ///< device should cache allocation
+    ZE_IPC_MEMORY_FLAG_BIAS_UNCACHED = ZE_BIT(1),                           ///< device should not cache allocation (UC)
+    ZE_IPC_MEMORY_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_ipc_memory_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Opens an IPC memory handle to retrieve a device pointer on the
+///        context.
+/// 
+/// @details
+///     - Takes an IPC memory handle from a remote process and associates it
+///       with a device pointer usable in this process.
+///     - The device pointer in this process should not be freed with
+///       ::zeMemFree, but rather with ::zeMemCloseIpcHandle.
+///     - Multiple calls to this function with the same IPC handle will return
+///       unique pointers.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `0x3 < flags`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pptr`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeMemOpenIpcHandle(
+    ze_context_handle_t hContext,                                           ///< [in] handle of the context object
+    ze_device_handle_t hDevice,                                             ///< [in] handle of the device to associate with the IPC memory handle
+    ze_ipc_mem_handle_t handle,                                             ///< [in] IPC memory handle
+    ze_ipc_memory_flags_t flags,                                            ///< [in] flags controlling the operation.
+                                                                            ///< must be 0 (default) or a valid combination of ::ze_ipc_memory_flag_t.
+    void** pptr                                                             ///< [out] pointer to device allocation in this process
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Closes an IPC memory handle
+/// 
+/// @details
+///     - Closes an IPC memory handle by unmapping memory that was opened in
+///       this process using ::zeMemOpenIpcHandle.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same pointer.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == ptr`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeMemCloseIpcHandle(
+    ze_context_handle_t hContext,                                           ///< [in] handle of the context object
+    const void* ptr                                                         ///< [in][release] pointer to device allocation in this process
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Additional allocation descriptor for exporting external memory
+/// 
+/// @details
+///     - This structure may be passed to ::zeMemAllocDevice and
+///       ::zeMemAllocHost, via the `pNext` member of
+///       ::ze_device_mem_alloc_desc_t or ::ze_host_mem_alloc_desc_t,
+///       respectively, to indicate an exportable memory allocation.
+///     - This structure may be passed to ::zeImageCreate, via the `pNext`
+///       member of ::ze_image_desc_t, to indicate an exportable image.
+typedef struct _ze_external_memory_export_desc_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_external_memory_type_flags_t flags;                                  ///< [in] flags specifying memory export types for this allocation.
+                                                                            ///< must be 0 (default) or a valid combination of ::ze_external_memory_type_flags_t
+
+} ze_external_memory_export_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Additional allocation descriptor for importing external memory as a
+///        file descriptor
+/// 
+/// @details
+///     - This structure may be passed to ::zeMemAllocDevice or
+///       ::zeMemAllocHost, via the `pNext` member of
+///       ::ze_device_mem_alloc_desc_t or of ::ze_host_mem_alloc_desc_t,
+///       respectively, to import memory from a file descriptor.
+///     - This structure may be passed to ::zeImageCreate, via the `pNext`
+///       member of ::ze_image_desc_t, to import memory from a file descriptor.
+typedef struct _ze_external_memory_import_fd_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_external_memory_type_flags_t flags;                                  ///< [in] flags specifying the memory import type for the file descriptor.
+                                                                            ///< must be 0 (default) or a valid combination of ::ze_external_memory_type_flags_t
+    int fd;                                                                 ///< [in] the file descriptor handle to import
+
+} ze_external_memory_import_fd_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exports an allocation as a file descriptor
+/// 
+/// @details
+///     - This structure may be passed to ::zeMemGetAllocProperties, via the
+///       `pNext` member of ::ze_memory_allocation_properties_t, to export a
+///       memory allocation as a file descriptor.
+///     - This structure may be passed to ::zeImageGetAllocPropertiesExt, via
+///       the `pNext` member of ::ze_image_allocation_ext_properties_t, to
+///       export an image as a file descriptor.
+///     - The requested memory export type must have been specified when the
+///       allocation was made.
+typedef struct _ze_external_memory_export_fd_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_external_memory_type_flags_t flags;                                  ///< [in] flags specifying the memory export type for the file descriptor.
+                                                                            ///< must be 0 (default) or a valid combination of ::ze_external_memory_type_flags_t
+    int fd;                                                                 ///< [out] the exported file descriptor handle representing the allocation.
+
+} ze_external_memory_export_fd_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Additional allocation descriptor for importing external memory as a
+///        Win32 handle
+/// 
+/// @details
+///     - When `handle` is `nullptr`, `name` must not be `nullptr`.
+///     - When `name` is `nullptr`, `handle` must not be `nullptr`.
+///     - When `flags` is ::ZE_EXTERNAL_MEMORY_TYPE_FLAG_OPAQUE_WIN32_KMT,
+///       `name` must be `nullptr`.
+///     - This structure may be passed to ::zeMemAllocDevice or
+///       ::zeMemAllocHost, via the `pNext` member of
+///       ::ze_device_mem_alloc_desc_t or of ::ze_host_mem_alloc_desc_t,
+///       respectively, to import memory from a Win32 handle.
+///     - This structure may be passed to ::zeImageCreate, via the `pNext`
+///       member of ::ze_image_desc_t, to import memory from a Win32 handle.
+typedef struct _ze_external_memory_import_win32_handle_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_external_memory_type_flags_t flags;                                  ///< [in] flags specifying the memory import type for the Win32 handle.
+                                                                            ///< must be 0 (default) or a valid combination of ::ze_external_memory_type_flags_t
+    void* handle;                                                           ///< [in][optional] the Win32 handle to import
+    const void* name;                                                       ///< [in][optional] name of a memory object to import
+
+} ze_external_memory_import_win32_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exports an allocation as a Win32 handle
+/// 
+/// @details
+///     - This structure may be passed to ::zeMemGetAllocProperties, via the
+///       `pNext` member of ::ze_memory_allocation_properties_t, to export a
+///       memory allocation as a Win32 handle.
+///     - This structure may be passed to ::zeImageGetAllocPropertiesExt, via
+///       the `pNext` member of ::ze_image_allocation_ext_properties_t, to
+///       export an image as a Win32 handle.
+///     - The requested memory export type must have been specified when the
+///       allocation was made.
+typedef struct _ze_external_memory_export_win32_handle_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_external_memory_type_flags_t flags;                                  ///< [in] flags specifying the memory export type for the Win32 handle.
+                                                                            ///< must be 0 (default) or a valid combination of ::ze_external_memory_type_flags_t
+    void* handle;                                                           ///< [out] the exported Win32 handle representing the allocation.
+
+} ze_external_memory_export_win32_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief atomic access attribute flags
+typedef uint32_t ze_memory_atomic_attr_exp_flags_t;
+typedef enum _ze_memory_atomic_attr_exp_flag_t
+{
+    ZE_MEMORY_ATOMIC_ATTR_EXP_FLAG_NO_ATOMICS = ZE_BIT(0),                  ///< Atomics on the pointer are not allowed
+    ZE_MEMORY_ATOMIC_ATTR_EXP_FLAG_NO_HOST_ATOMICS = ZE_BIT(1),             ///< Host atomics on the pointer are not allowed
+    ZE_MEMORY_ATOMIC_ATTR_EXP_FLAG_HOST_ATOMICS = ZE_BIT(2),                ///< Host atomics on the pointer are allowed. Requires
+                                                                            ///< ::ZE_MEMORY_ACCESS_CAP_FLAG_ATOMIC returned by
+                                                                            ///< ::zeDeviceGetMemoryAccessProperties.
+    ZE_MEMORY_ATOMIC_ATTR_EXP_FLAG_NO_DEVICE_ATOMICS = ZE_BIT(3),           ///< Device atomics on the pointer are not allowed
+    ZE_MEMORY_ATOMIC_ATTR_EXP_FLAG_DEVICE_ATOMICS = ZE_BIT(4),              ///< Device atomics on the pointer are allowed. Requires
+                                                                            ///< ::ZE_MEMORY_ACCESS_CAP_FLAG_ATOMIC returned by
+                                                                            ///< ::zeDeviceGetMemoryAccessProperties.
+    ZE_MEMORY_ATOMIC_ATTR_EXP_FLAG_NO_SYSTEM_ATOMICS = ZE_BIT(5),           ///< Concurrent atomics on the pointer from both host and device are not
+                                                                            ///< allowed
+    ZE_MEMORY_ATOMIC_ATTR_EXP_FLAG_SYSTEM_ATOMICS = ZE_BIT(6),              ///< Concurrent atomics on the pointer from both host and device are
+                                                                            ///< allowed. Requires ::ZE_MEMORY_ACCESS_CAP_FLAG_CONCURRENT_ATOMIC
+                                                                            ///< returned by ::zeDeviceGetMemoryAccessProperties.
+    ZE_MEMORY_ATOMIC_ATTR_EXP_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_memory_atomic_attr_exp_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Sets atomic access attributes for a shared allocation
+/// 
+/// @details
+///     - If the shared-allocation is owned by multiple devices (i.e. nullptr
+///       was passed to ::zeMemAllocShared when creating it), then hDevice may be
+///       passed to set the attributes in that specific device. If nullptr is
+///       passed in hDevice, then the atomic attributes are set in all devices
+///       associated with the allocation.
+///     - If the atomic access attribute select is not supported by the driver,
+///       ::ZE_RESULT_INVALID_ARGUMENT is returned.
+///     - The atomic access attribute may be only supported at a device-specific
+///       granularity, such as at a page boundary. In this case, the memory range
+///       may be expanded such that the start and end of the range satisfy granularity
+///       requirements.
+///     - When calling this function multiple times with different flags, only the
+///       attributes from last call are honored.
+///     - The application must not call this function for shared-allocations currently
+///       being used by the device.
+///     - The application must **not** call this function from simultaneous threads
+///       with the same pointer.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == ptr`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `0x7f < attr`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeMemSetAtomicAccessAttributeExp(
+    ze_context_handle_t hContext,                                           ///< [in] handle of context
+    ze_device_handle_t hDevice,                                             ///< [in] device associated with the memory advice
+    const void* ptr,                                                        ///< [in] Pointer to the start of the memory range
+    size_t size,                                                            ///< [in] Size in bytes of the memory range
+    ze_memory_atomic_attr_exp_flags_t attr                                  ///< [in] Atomic access attributes to set for the specified range.
+                                                                            ///< Must be 0 (default) or a valid combination of ::ze_memory_atomic_attr_exp_flag_t.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves the atomic access attributes previously set for a shared
+///        allocation
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads
+///       with the same pointer.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == ptr`
+///         + `nullptr == pAttr`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeMemGetAtomicAccessAttributeExp(
+    ze_context_handle_t hContext,                                           ///< [in] handle of context
+    ze_device_handle_t hDevice,                                             ///< [in] device associated with the memory advice
+    const void* ptr,                                                        ///< [in] Pointer to the start of the memory range
+    size_t size,                                                            ///< [in] Size in bytes of the memory range
+    ze_memory_atomic_attr_exp_flags_t* pAttr                                ///< [out] Atomic access attributes for the specified range
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero APIs for Module
+#if !defined(__GNUC__)
+#pragma region module
+#endif
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported module creation input formats
+typedef enum _ze_module_format_t
+{
+    ZE_MODULE_FORMAT_IL_SPIRV = 0,                                          ///< Format is SPIRV IL format
+    ZE_MODULE_FORMAT_NATIVE = 1,                                            ///< Format is device native format
+    ZE_MODULE_FORMAT_FORCE_UINT32 = 0x7fffffff
+
+} ze_module_format_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Specialization constants - User defined constants
+typedef struct _ze_module_constants_t
+{
+    uint32_t numConstants;                                                  ///< [in] Number of specialization constants.
+    const uint32_t* pConstantIds;                                           ///< [in][range(0, numConstants)] Array of IDs that is sized to
+                                                                            ///< numConstants.
+    const void** pConstantValues;                                           ///< [in][range(0, numConstants)] Array of pointers to values that is sized
+                                                                            ///< to numConstants.
+
+} ze_module_constants_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Module descriptor
+typedef struct _ze_module_desc_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_module_format_t format;                                              ///< [in] Module format passed in with pInputModule
+    size_t inputSize;                                                       ///< [in] size of input IL or ISA from pInputModule.
+    const uint8_t* pInputModule;                                            ///< [in] pointer to IL or ISA
+    const char* pBuildFlags;                                                ///< [in][optional] string containing one or more (comma-separated)
+                                                                            ///< compiler flags. If unsupported, flag is ignored with a warning.
+                                                                            ///<  - "-ze-opt-disable"
+                                                                            ///<       - Disable optimizations
+                                                                            ///<  - "-ze-opt-level"
+                                                                            ///<       - Specifies optimization level for compiler. Levels are
+                                                                            ///< implementation specific.
+                                                                            ///<           - 0 is no optimizations (equivalent to -ze-opt-disable)
+                                                                            ///<           - 1 is optimize minimally (may be the same as 2)
+                                                                            ///<           - 2 is optimize more (default)
+                                                                            ///<  - "-ze-opt-greater-than-4GB-buffer-required"
+                                                                            ///<       - Use 64-bit offset calculations for buffers.
+                                                                            ///<  - "-ze-opt-large-register-file"
+                                                                            ///<       - Increase number of registers available to threads.
+                                                                            ///<  - "-ze-opt-has-buffer-offset-arg"
+                                                                            ///<       - Extend stateless to stateful optimization to more
+                                                                            ///<         cases with the use of additional offset (e.g. 64-bit
+                                                                            ///<         pointer to binding table with 32-bit offset).
+                                                                            ///<  - "-g"
+                                                                            ///<       - Include debugging information.
+    const ze_module_constants_t* pConstants;                                ///< [in][optional] pointer to specialization constants. Valid only for
+                                                                            ///< SPIR-V input. This must be set to nullptr if no specialization
+                                                                            ///< constants are provided.
+
+} ze_module_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Creates a module on the context.
+/// 
+/// @details
+///     - Compiles the module for execution on the device.
+///     - The application must only use the module for the device, or its
+///       sub-devices, which was provided during creation.
+///     - The module can be copied to other devices and contexts within the same
+///       driver instance by using ::zeModuleGetNativeBinary.
+///     - A build log can optionally be returned to the caller. The caller is
+///       responsible for destroying build log using ::zeModuleBuildLogDestroy.
+///     - The module descriptor constants are only supported for SPIR-V
+///       specialization constants.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == desc`
+///         + `nullptr == desc->pInputModule`
+///         + `nullptr == phModule`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::ZE_MODULE_FORMAT_NATIVE < desc->format`
+///     - ::ZE_RESULT_ERROR_INVALID_NATIVE_BINARY
+///     - ::ZE_RESULT_ERROR_INVALID_SIZE
+///         + `0 == desc->inputSize`
+///     - ::ZE_RESULT_ERROR_MODULE_BUILD_FAILURE
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeModuleCreate(
+    ze_context_handle_t hContext,                                           ///< [in] handle of the context object
+    ze_device_handle_t hDevice,                                             ///< [in] handle of the device
+    const ze_module_desc_t* desc,                                           ///< [in] pointer to module descriptor
+    ze_module_handle_t* phModule,                                           ///< [out] pointer to handle of module object created
+    ze_module_build_log_handle_t* phBuildLog                                ///< [out][optional] pointer to handle of module's build log.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Destroys module
+/// 
+/// @details
+///     - The application must destroy all kernel handles created from the
+///       module before destroying the module itself.
+///     - The application must ensure the device is not currently referencing
+///       the module before it is deleted.
+///     - The implementation of this function may immediately free all Host and
+///       Device allocations associated with this module.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same module handle.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hModule`
+///     - ::ZE_RESULT_ERROR_HANDLE_OBJECT_IN_USE
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeModuleDestroy(
+    ze_module_handle_t hModule                                              ///< [in][release] handle of the module
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Dynamically link modules together that share import/export linkage
+///        dependencies.
+/// 
+/// @details
+///     - Modules support SPIR-V import and export linkage types for functions
+///       and global variables. See the SPIR-V specification for linkage
+///       details.
+///     - Modules can have both import and export linkage.
+///     - Modules that do not have any imports or exports do not need to be
+///       linked.
+///     - All module import requirements must be satisfied via linking before
+///       kernel objects can be created from them.
+///     - Modules cannot be partially linked. Unsatisfiable import dependencies
+///       in the set of modules passed to ::zeModuleDynamicLink will result in 
+///       ::ZE_RESULT_ERROR_MODULE_LINK_FAILURE being returned.
+///     - Modules will only be linked once. A module can be used in multiple
+///       link calls if it has exports but its imports will not be re-linked.
+///     - Ambiguous dependencies, where multiple modules satisfy the same import
+///       dependencies for a module, are not allowed.
+///     - The application must ensure the modules being linked were created on
+///       the same context.
+///     - The application may call this function from simultaneous threads as
+///       long as the import modules being linked are not the same.
+///     - ModuleGetNativeBinary can be called on any module regardless of
+///       whether it is linked or not.
+///     - A link log can optionally be returned to the caller. The caller is
+///       responsible for destroying the link log using
+///       ::zeModuleBuildLogDestroy.
+///     - The link log may contain a list of the unresolved import dependencies
+///       if present.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == phModules`
+///     - ::ZE_RESULT_ERROR_MODULE_LINK_FAILURE
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeModuleDynamicLink(
+    uint32_t numModules,                                                    ///< [in] number of modules to be linked pointed to by phModules.
+    ze_module_handle_t* phModules,                                          ///< [in][range(0, numModules)] pointer to an array of modules to
+                                                                            ///< dynamically link together.
+    ze_module_build_log_handle_t* phLinkLog                                 ///< [out][optional] pointer to handle of dynamic link log.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Destroys module build log object
+/// 
+/// @details
+///     - The implementation of this function may immediately free all Host
+///       allocations associated with this object.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same build log handle.
+///     - The implementation of this function should be lock-free.
+///     - This function can be called before or after ::zeModuleDestroy for the
+///       associated module.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hModuleBuildLog`
+///     - ::ZE_RESULT_ERROR_HANDLE_OBJECT_IN_USE
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeModuleBuildLogDestroy(
+    ze_module_build_log_handle_t hModuleBuildLog                            ///< [in][release] handle of the module build log object.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves text string for build log.
+/// 
+/// @details
+///     - The caller can pass nullptr for pBuildLog when querying only for size.
+///     - The caller must provide memory for build log.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hModuleBuildLog`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pSize`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeModuleBuildLogGetString(
+    ze_module_build_log_handle_t hModuleBuildLog,                           ///< [in] handle of the module build log object.
+    size_t* pSize,                                                          ///< [in,out] size of build log string.
+    char* pBuildLog                                                         ///< [in,out][optional] pointer to null-terminated string of the log.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieve native binary from Module.
+/// 
+/// @details
+///     - The native binary output can be cached to disk and new modules can be
+///       later constructed from the cached copy.
+///     - The native binary will retain debugging information that is associated
+///       with a module.
+///     - The caller can pass nullptr for pModuleNativeBinary when querying only
+///       for size.
+///     - The implementation will copy the native binary into a buffer supplied
+///       by the caller.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hModule`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pSize`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeModuleGetNativeBinary(
+    ze_module_handle_t hModule,                                             ///< [in] handle of the module
+    size_t* pSize,                                                          ///< [in,out] size of native binary in bytes.
+    uint8_t* pModuleNativeBinary                                            ///< [in,out][optional] byte pointer to native binary
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieve global variable pointer from Module.
+/// 
+/// @details
+///     - The application may query global pointer from any module that either
+///       exports or imports it.
+///     - The application must dynamically link a module that imports a global
+///       before the global pointer can be queried from it.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hModule`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pGlobalName`
+///     - ::ZE_RESULT_ERROR_INVALID_GLOBAL_NAME
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeModuleGetGlobalPointer(
+    ze_module_handle_t hModule,                                             ///< [in] handle of the module
+    const char* pGlobalName,                                                ///< [in] name of global variable in module
+    size_t* pSize,                                                          ///< [in,out][optional] size of global variable
+    void** pptr                                                             ///< [in,out][optional] device visible pointer
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieve all kernel names in the module.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hModule`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeModuleGetKernelNames(
+    ze_module_handle_t hModule,                                             ///< [in] handle of the module
+    uint32_t* pCount,                                                       ///< [in,out] pointer to the number of names.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of names available.
+                                                                            ///< if count is greater than the number of names available, then the
+                                                                            ///< driver shall update the value with the correct number of names available.
+    const char** pNames                                                     ///< [in,out][optional][range(0, *pCount)] array of names of functions.
+                                                                            ///< if count is less than the number of names available, then driver shall
+                                                                            ///< only retrieve that number of names.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported module property flags
+typedef uint32_t ze_module_property_flags_t;
+typedef enum _ze_module_property_flag_t
+{
+    ZE_MODULE_PROPERTY_FLAG_IMPORTS = ZE_BIT(0),                            ///< Module has imports (i.e. imported global variables and/or kernels).
+                                                                            ///< See ::zeModuleDynamicLink.
+    ZE_MODULE_PROPERTY_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_module_property_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Module properties
+typedef struct _ze_module_properties_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_module_property_flags_t flags;                                       ///< [out] 0 (none) or a valid combination of ::ze_module_property_flag_t
+
+} ze_module_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieve module properties.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hModule`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pModuleProperties`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeModuleGetProperties(
+    ze_module_handle_t hModule,                                             ///< [in] handle of the module
+    ze_module_properties_t* pModuleProperties                               ///< [in,out] query result for module properties.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported kernel creation flags
+typedef uint32_t ze_kernel_flags_t;
+typedef enum _ze_kernel_flag_t
+{
+    ZE_KERNEL_FLAG_FORCE_RESIDENCY = ZE_BIT(0),                             ///< force all device allocations to be resident during execution
+    ZE_KERNEL_FLAG_EXPLICIT_RESIDENCY = ZE_BIT(1),                          ///< application is responsible for all residency of device allocations.
+                                                                            ///< driver may disable implicit residency management.
+    ZE_KERNEL_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_kernel_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Kernel descriptor
+typedef struct _ze_kernel_desc_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_kernel_flags_t flags;                                                ///< [in] creation flags.
+                                                                            ///< must be 0 (default) or a valid combination of ::ze_kernel_flag_t;
+                                                                            ///< default behavior may use driver-based residency.
+    const char* pKernelName;                                                ///< [in] null-terminated name of kernel in module
+
+} ze_kernel_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Create a kernel from the module.
+/// 
+/// @details
+///     - Modules that have unresolved imports need to be dynamically linked
+///       before a kernel can be created from them. (See ::zeModuleDynamicLink)
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hModule`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == desc`
+///         + `nullptr == desc->pKernelName`
+///         + `nullptr == phKernel`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `0x3 < desc->flags`
+///     - ::ZE_RESULT_ERROR_INVALID_KERNEL_NAME
+///     - ::ZE_RESULT_ERROR_INVALID_MODULE_UNLINKED
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeKernelCreate(
+    ze_module_handle_t hModule,                                             ///< [in] handle of the module
+    const ze_kernel_desc_t* desc,                                           ///< [in] pointer to kernel descriptor
+    ze_kernel_handle_t* phKernel                                            ///< [out] handle of the Function object
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Destroys a kernel object
+/// 
+/// @details
+///     - The application must ensure the device is not currently referencing
+///       the kernel before it is deleted.
+///     - The implementation of this function may immediately free all Host and
+///       Device allocations associated with this kernel.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same kernel handle.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hKernel`
+///     - ::ZE_RESULT_ERROR_HANDLE_OBJECT_IN_USE
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeKernelDestroy(
+    ze_kernel_handle_t hKernel                                              ///< [in][release] handle of the kernel object
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieve a function pointer from a module by name
+/// 
+/// @details
+///     - The function pointer is unique for the device on which the module was
+///       created.
+///     - The function pointer is no longer valid if module is destroyed.
+///     - The function name should only refer to callable functions within the
+///       module.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hModule`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pFunctionName`
+///         + `nullptr == pfnFunction`
+///     - ::ZE_RESULT_ERROR_INVALID_FUNCTION_NAME
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeModuleGetFunctionPointer(
+    ze_module_handle_t hModule,                                             ///< [in] handle of the module
+    const char* pFunctionName,                                              ///< [in] Name of function to retrieve function pointer for.
+    void** pfnFunction                                                      ///< [out] pointer to function.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Set group size for a kernel.
+/// 
+/// @details
+///     - The group size will be used when a ::zeCommandListAppendLaunchKernel
+///       variant is called.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same kernel handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hKernel`
+///     - ::ZE_RESULT_ERROR_INVALID_GROUP_SIZE_DIMENSION
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeKernelSetGroupSize(
+    ze_kernel_handle_t hKernel,                                             ///< [in] handle of the kernel object
+    uint32_t groupSizeX,                                                    ///< [in] group size for X dimension to use for this kernel
+    uint32_t groupSizeY,                                                    ///< [in] group size for Y dimension to use for this kernel
+    uint32_t groupSizeZ                                                     ///< [in] group size for Z dimension to use for this kernel
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Query a suggested group size for a kernel given a global size for each
+///        dimension.
+/// 
+/// @details
+///     - This function ignores the group size that is set using
+///       ::zeKernelSetGroupSize.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hKernel`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == groupSizeX`
+///         + `nullptr == groupSizeY`
+///         + `nullptr == groupSizeZ`
+///     - ::ZE_RESULT_ERROR_INVALID_GLOBAL_WIDTH_DIMENSION
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeKernelSuggestGroupSize(
+    ze_kernel_handle_t hKernel,                                             ///< [in] handle of the kernel object
+    uint32_t globalSizeX,                                                   ///< [in] global width for X dimension
+    uint32_t globalSizeY,                                                   ///< [in] global width for Y dimension
+    uint32_t globalSizeZ,                                                   ///< [in] global width for Z dimension
+    uint32_t* groupSizeX,                                                   ///< [out] recommended size of group for X dimension
+    uint32_t* groupSizeY,                                                   ///< [out] recommended size of group for Y dimension
+    uint32_t* groupSizeZ                                                    ///< [out] recommended size of group for Z dimension
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Query a suggested max group count for a cooperative kernel.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hKernel`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == totalGroupCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeKernelSuggestMaxCooperativeGroupCount(
+    ze_kernel_handle_t hKernel,                                             ///< [in] handle of the kernel object
+    uint32_t* totalGroupCount                                               ///< [out] recommended total group count.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Set kernel argument for a kernel.
+/// 
+/// @details
+///     - The argument values will be used when a
+///       ::zeCommandListAppendLaunchKernel variant is called.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same kernel handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hKernel`
+///     - ::ZE_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
+///     - ::ZE_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeKernelSetArgumentValue(
+    ze_kernel_handle_t hKernel,                                             ///< [in] handle of the kernel object
+    uint32_t argIndex,                                                      ///< [in] argument index in range [0, num args - 1]
+    size_t argSize,                                                         ///< [in] size of argument type
+    const void* pArgValue                                                   ///< [in][optional] argument value represented as matching arg type. If
+                                                                            ///< null then argument value is considered null.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Kernel indirect access flags
+typedef uint32_t ze_kernel_indirect_access_flags_t;
+typedef enum _ze_kernel_indirect_access_flag_t
+{
+    ZE_KERNEL_INDIRECT_ACCESS_FLAG_HOST = ZE_BIT(0),                        ///< Indicates that the kernel accesses host allocations indirectly.
+    ZE_KERNEL_INDIRECT_ACCESS_FLAG_DEVICE = ZE_BIT(1),                      ///< Indicates that the kernel accesses device allocations indirectly.
+    ZE_KERNEL_INDIRECT_ACCESS_FLAG_SHARED = ZE_BIT(2),                      ///< Indicates that the kernel accesses shared allocations indirectly.
+    ZE_KERNEL_INDIRECT_ACCESS_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_kernel_indirect_access_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Sets kernel indirect access flags.
+/// 
+/// @details
+///     - The application should specify which allocations will be indirectly
+///       accessed by the kernel to allow driver to optimize which allocations
+///       are made resident
+///     - This function may **not** be called from simultaneous threads with the
+///       same Kernel handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hKernel`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `0x7 < flags`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeKernelSetIndirectAccess(
+    ze_kernel_handle_t hKernel,                                             ///< [in] handle of the kernel object
+    ze_kernel_indirect_access_flags_t flags                                 ///< [in] kernel indirect access flags
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieve kernel indirect access flags.
+/// 
+/// @details
+///     - This function may be called from simultaneous threads with the same
+///       Kernel handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hKernel`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pFlags`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeKernelGetIndirectAccess(
+    ze_kernel_handle_t hKernel,                                             ///< [in] handle of the kernel object
+    ze_kernel_indirect_access_flags_t* pFlags                               ///< [out] query result for kernel indirect access flags.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieve all declared kernel attributes (i.e. can be specified with
+///        __attribute__ in runtime language).
+/// 
+/// @details
+///     - This function may be called from simultaneous threads with the same
+///       Kernel handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hKernel`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pSize`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeKernelGetSourceAttributes(
+    ze_kernel_handle_t hKernel,                                             ///< [in] handle of the kernel object
+    uint32_t* pSize,                                                        ///< [in,out] pointer to size of string in bytes, including
+                                                                            ///< null-terminating character.
+    char** pString                                                          ///< [in,out][optional] pointer to application-managed character array
+                                                                            ///< (string data).
+                                                                            ///< If NULL, the string length of the kernel source attributes, including
+                                                                            ///< a null-terminating character, is returned in pSize.
+                                                                            ///< Otherwise, pString must point to valid application memory that is
+                                                                            ///< greater than or equal to *pSize bytes in length, and on return the
+                                                                            ///< pointed-to string will contain a space-separated list of kernel source attributes.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported Cache Config flags
+typedef uint32_t ze_cache_config_flags_t;
+typedef enum _ze_cache_config_flag_t
+{
+    ZE_CACHE_CONFIG_FLAG_LARGE_SLM = ZE_BIT(0),                             ///< Large SLM size
+    ZE_CACHE_CONFIG_FLAG_LARGE_DATA = ZE_BIT(1),                            ///< Large General Data size
+    ZE_CACHE_CONFIG_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_cache_config_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Sets the preferred cache configuration.
+/// 
+/// @details
+///     - The cache configuration will be used when a
+///       ::zeCommandListAppendLaunchKernel variant is called.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same kernel handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hKernel`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `0x3 < flags`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeKernelSetCacheConfig(
+    ze_kernel_handle_t hKernel,                                             ///< [in] handle of the kernel object
+    ze_cache_config_flags_t flags                                           ///< [in] cache configuration.
+                                                                            ///< must be 0 (default configuration) or a valid combination of ::ze_cache_config_flag_t.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_MAX_KERNEL_UUID_SIZE
+/// @brief Maximum kernel universal unique id (UUID) size in bytes
+#define ZE_MAX_KERNEL_UUID_SIZE  16
+#endif // ZE_MAX_KERNEL_UUID_SIZE
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_MAX_MODULE_UUID_SIZE
+/// @brief Maximum module universal unique id (UUID) size in bytes
+#define ZE_MAX_MODULE_UUID_SIZE  16
+#endif // ZE_MAX_MODULE_UUID_SIZE
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Kernel universal unique id (UUID)
+typedef struct _ze_kernel_uuid_t
+{
+    uint8_t kid[ZE_MAX_KERNEL_UUID_SIZE];                                   ///< [out] opaque data representing a kernel UUID
+    uint8_t mid[ZE_MAX_MODULE_UUID_SIZE];                                   ///< [out] opaque data representing the kernel's module UUID
+
+} ze_kernel_uuid_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Kernel properties
+typedef struct _ze_kernel_properties_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    uint32_t numKernelArgs;                                                 ///< [out] number of kernel arguments.
+    uint32_t requiredGroupSizeX;                                            ///< [out] required group size in the X dimension,
+                                                                            ///< or zero if there is no required group size
+    uint32_t requiredGroupSizeY;                                            ///< [out] required group size in the Y dimension,
+                                                                            ///< or zero if there is no required group size
+    uint32_t requiredGroupSizeZ;                                            ///< [out] required group size in the Z dimension,
+                                                                            ///< or zero if there is no required group size
+    uint32_t requiredNumSubGroups;                                          ///< [out] required number of subgroups per thread group,
+                                                                            ///< or zero if there is no required number of subgroups
+    uint32_t requiredSubgroupSize;                                          ///< [out] required subgroup size,
+                                                                            ///< or zero if there is no required subgroup size
+    uint32_t maxSubgroupSize;                                               ///< [out] maximum subgroup size
+    uint32_t maxNumSubgroups;                                               ///< [out] maximum number of subgroups per thread group
+    uint32_t localMemSize;                                                  ///< [out] local memory size used by each thread group
+    uint32_t privateMemSize;                                                ///< [out] private memory size allocated by compiler used by each thread
+    uint32_t spillMemSize;                                                  ///< [out] spill memory size allocated by compiler
+    ze_kernel_uuid_t uuid;                                                  ///< [out] universal unique identifier.
+
+} ze_kernel_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Additional kernel preferred group size properties
+/// 
+/// @details
+///     - This structure may be passed to ::zeKernelGetProperties, via the
+///       `pNext` member of ::ze_kernel_properties_t, to query additional kernel
+///       preferred group size properties.
+typedef struct _ze_kernel_preferred_group_size_properties_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    uint32_t preferredMultiple;                                             ///< [out] preferred group size multiple
+
+} ze_kernel_preferred_group_size_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieve kernel properties.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hKernel`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pKernelProperties`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeKernelGetProperties(
+    ze_kernel_handle_t hKernel,                                             ///< [in] handle of the kernel object
+    ze_kernel_properties_t* pKernelProperties                               ///< [in,out] query result for kernel properties.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieve kernel name from Kernel.
+/// 
+/// @details
+///     - The caller can pass nullptr for pName when querying only for size.
+///     - The implementation will copy the kernel name into a buffer supplied by
+///       the caller.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hKernel`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pSize`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeKernelGetName(
+    ze_kernel_handle_t hKernel,                                             ///< [in] handle of the kernel object
+    size_t* pSize,                                                          ///< [in,out] size of kernel name string, including null terminator, in
+                                                                            ///< bytes.
+    char* pName                                                             ///< [in,out][optional] char pointer to kernel name.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Kernel dispatch group count.
+typedef struct _ze_group_count_t
+{
+    uint32_t groupCountX;                                                   ///< [in] number of thread groups in X dimension
+    uint32_t groupCountY;                                                   ///< [in] number of thread groups in Y dimension
+    uint32_t groupCountZ;                                                   ///< [in] number of thread groups in Z dimension
+
+} ze_group_count_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Launch kernel over one or more work groups.
+/// 
+/// @details
+///     - The application must ensure the kernel and events are accessible by
+///       the device on which the command list was created.
+///     - This may **only** be called for a command list created with command
+///       queue group ordinal that supports compute.
+///     - The application must ensure the command list, kernel and events were
+///       created on the same context.
+///     - This function may **not** be called from simultaneous threads with the
+///       same command list handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandList`
+///         + `nullptr == hKernel`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pLaunchFuncArgs`
+///     - ::ZE_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT
+///     - ::ZE_RESULT_ERROR_INVALID_SIZE
+///         + `(nullptr == phWaitEvents) && (0 < numWaitEvents)`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandListAppendLaunchKernel(
+    ze_command_list_handle_t hCommandList,                                  ///< [in] handle of the command list
+    ze_kernel_handle_t hKernel,                                             ///< [in] handle of the kernel object
+    const ze_group_count_t* pLaunchFuncArgs,                                ///< [in] thread group launch arguments
+    ze_event_handle_t hSignalEvent,                                         ///< [in][optional] handle of the event to signal on completion
+    uint32_t numWaitEvents,                                                 ///< [in][optional] number of events to wait on before launching; must be 0
+                                                                            ///< if `nullptr == phWaitEvents`
+    ze_event_handle_t* phWaitEvents                                         ///< [in][optional][range(0, numWaitEvents)] handle of the events to wait
+                                                                            ///< on before launching
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Launch kernel cooperatively over one or more work groups.
+/// 
+/// @details
+///     - The application must ensure the kernel and events are accessible by
+///       the device on which the command list was created.
+///     - This may **only** be called for a command list created with command
+///       queue group ordinal that supports compute.
+///     - This may only be used for a command list that are submitted to command
+///       queue with cooperative flag set.
+///     - The application must ensure the command list, kernel and events were
+///       created on the same context.
+///     - This function may **not** be called from simultaneous threads with the
+///       same command list handle.
+///     - The implementation of this function should be lock-free.
+///     - Use ::zeKernelSuggestMaxCooperativeGroupCount to recommend max group
+///       count for device for cooperative functions that device supports.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandList`
+///         + `nullptr == hKernel`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pLaunchFuncArgs`
+///     - ::ZE_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT
+///     - ::ZE_RESULT_ERROR_INVALID_SIZE
+///         + `(nullptr == phWaitEvents) && (0 < numWaitEvents)`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandListAppendLaunchCooperativeKernel(
+    ze_command_list_handle_t hCommandList,                                  ///< [in] handle of the command list
+    ze_kernel_handle_t hKernel,                                             ///< [in] handle of the kernel object
+    const ze_group_count_t* pLaunchFuncArgs,                                ///< [in] thread group launch arguments
+    ze_event_handle_t hSignalEvent,                                         ///< [in][optional] handle of the event to signal on completion
+    uint32_t numWaitEvents,                                                 ///< [in][optional] number of events to wait on before launching; must be 0
+                                                                            ///< if `nullptr == phWaitEvents`
+    ze_event_handle_t* phWaitEvents                                         ///< [in][optional][range(0, numWaitEvents)] handle of the events to wait
+                                                                            ///< on before launching
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Launch kernel over one or more work groups using indirect arguments.
+/// 
+/// @details
+///     - The application must ensure the kernel and events are accessible by
+///       the device on which the command list was created.
+///     - The application must ensure the launch arguments are visible to the
+///       device on which the command list was created.
+///     - The implementation must not access the contents of the launch
+///       arguments as they are free to be modified by either the Host or device
+///       up until execution.
+///     - This may **only** be called for a command list created with command
+///       queue group ordinal that supports compute.
+///     - The application must ensure the command list, kernel and events were
+///       created, and the memory was allocated, on the same context.
+///     - This function may **not** be called from simultaneous threads with the
+///       same command list handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandList`
+///         + `nullptr == hKernel`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pLaunchArgumentsBuffer`
+///     - ::ZE_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT
+///     - ::ZE_RESULT_ERROR_INVALID_SIZE
+///         + `(nullptr == phWaitEvents) && (0 < numWaitEvents)`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandListAppendLaunchKernelIndirect(
+    ze_command_list_handle_t hCommandList,                                  ///< [in] handle of the command list
+    ze_kernel_handle_t hKernel,                                             ///< [in] handle of the kernel object
+    const ze_group_count_t* pLaunchArgumentsBuffer,                         ///< [in] pointer to device buffer that will contain thread group launch
+                                                                            ///< arguments
+    ze_event_handle_t hSignalEvent,                                         ///< [in][optional] handle of the event to signal on completion
+    uint32_t numWaitEvents,                                                 ///< [in][optional] number of events to wait on before launching; must be 0
+                                                                            ///< if `nullptr == phWaitEvents`
+    ze_event_handle_t* phWaitEvents                                         ///< [in][optional][range(0, numWaitEvents)] handle of the events to wait
+                                                                            ///< on before launching
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Launch multiple kernels over one or more work groups using an array of
+///        indirect arguments.
+/// 
+/// @details
+///     - The application must ensure the kernel and events are accessible by
+///       the device on which the command list was created.
+///     - The application must ensure the array of launch arguments and count
+///       buffer are visible to the device on which the command list was
+///       created.
+///     - The implementation must not access the contents of the array of launch
+///       arguments or count buffer as they are free to be modified by either
+///       the Host or device up until execution.
+///     - This may **only** be called for a command list created with command
+///       queue group ordinal that supports compute.
+///     - The application must enusre the command list, kernel and events were
+///       created, and the memory was allocated, on the same context.
+///     - This function may **not** be called from simultaneous threads with the
+///       same command list handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandList`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == phKernels`
+///         + `nullptr == pCountBuffer`
+///         + `nullptr == pLaunchArgumentsBuffer`
+///     - ::ZE_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT
+///     - ::ZE_RESULT_ERROR_INVALID_SIZE
+///         + `(nullptr == phWaitEvents) && (0 < numWaitEvents)`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandListAppendLaunchMultipleKernelsIndirect(
+    ze_command_list_handle_t hCommandList,                                  ///< [in] handle of the command list
+    uint32_t numKernels,                                                    ///< [in] maximum number of kernels to launch
+    ze_kernel_handle_t* phKernels,                                          ///< [in][range(0, numKernels)] handles of the kernel objects
+    const uint32_t* pCountBuffer,                                           ///< [in] pointer to device memory location that will contain the actual
+                                                                            ///< number of kernels to launch; value must be less than or equal to
+                                                                            ///< numKernels
+    const ze_group_count_t* pLaunchArgumentsBuffer,                         ///< [in][range(0, numKernels)] pointer to device buffer that will contain
+                                                                            ///< a contiguous array of thread group launch arguments
+    ze_event_handle_t hSignalEvent,                                         ///< [in][optional] handle of the event to signal on completion
+    uint32_t numWaitEvents,                                                 ///< [in][optional] number of events to wait on before launching; must be 0
+                                                                            ///< if `nullptr == phWaitEvents`
+    ze_event_handle_t* phWaitEvents                                         ///< [in][optional][range(0, numWaitEvents)] handle of the events to wait
+                                                                            ///< on before launching
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Extension for supporting module programs.
+#if !defined(__GNUC__)
+#pragma region program
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_MODULE_PROGRAM_EXP_NAME
+/// @brief Module Program Extension Name
+#define ZE_MODULE_PROGRAM_EXP_NAME  "ZE_experimental_module_program"
+#endif // ZE_MODULE_PROGRAM_EXP_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Module Program Extension Version(s)
+typedef enum _ze_module_program_exp_version_t
+{
+    ZE_MODULE_PROGRAM_EXP_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),            ///< version 1.0
+    ZE_MODULE_PROGRAM_EXP_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),        ///< latest known version
+    ZE_MODULE_PROGRAM_EXP_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} ze_module_program_exp_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Module extended descriptor to support multiple input modules.
+/// 
+/// @details
+///     - Implementation must support ::ZE_experimental_module_program extension
+///     - Modules support import and export linkage for functions and global
+///       variables.
+///     - SPIR-V import and export linkage types are used. See SPIR-V
+///       specification for linkage details.
+///     - pInputModules, pBuildFlags, and pConstants from ::ze_module_desc_t is
+///       ignored.
+///     - Format in ::ze_module_desc_t needs to be set to
+///       ::ZE_MODULE_FORMAT_IL_SPIRV.
+typedef struct _ze_module_program_exp_desc_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    uint32_t count;                                                         ///< [in] Count of input modules
+    const size_t* inputSizes;                                               ///< [in][range(0, count)] sizes of each input IL module in pInputModules.
+    const uint8_t** pInputModules;                                          ///< [in][range(0, count)] pointer to an array of IL (e.g. SPIR-V modules).
+                                                                            ///< Valid only for SPIR-V input.
+    const char** pBuildFlags;                                               ///< [in][optional][range(0, count)] array of strings containing build
+                                                                            ///< flags. See pBuildFlags in ::ze_module_desc_t.
+    const ze_module_constants_t** pConstants;                               ///< [in][optional][range(0, count)] pointer to array of specialization
+                                                                            ///< constant strings. Valid only for SPIR-V input. This must be set to
+                                                                            ///< nullptr if no specialization constants are provided.
+
+} ze_module_program_exp_desc_t;
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Extension APIs for Raytracing
+#if !defined(__GNUC__)
+#pragma region raytracing
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_RAYTRACING_EXT_NAME
+/// @brief Raytracing Extension Name
+#define ZE_RAYTRACING_EXT_NAME  "ZE_extension_raytracing"
+#endif // ZE_RAYTRACING_EXT_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Raytracing Extension Version(s)
+typedef enum _ze_raytracing_ext_version_t
+{
+    ZE_RAYTRACING_EXT_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),                ///< version 1.0
+    ZE_RAYTRACING_EXT_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),            ///< latest known version
+    ZE_RAYTRACING_EXT_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} ze_raytracing_ext_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported raytracing capability flags
+typedef uint32_t ze_device_raytracing_ext_flags_t;
+typedef enum _ze_device_raytracing_ext_flag_t
+{
+    ZE_DEVICE_RAYTRACING_EXT_FLAG_RAYQUERY = ZE_BIT(0),                     ///< Supports rayquery
+    ZE_DEVICE_RAYTRACING_EXT_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_device_raytracing_ext_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Raytracing properties queried using ::zeDeviceGetModuleProperties
+/// 
+/// @details
+///     - This structure may be returned from ::zeDeviceGetModuleProperties, via
+///       the `pNext` member of ::ze_device_module_properties_t.
+typedef struct _ze_device_raytracing_ext_properties_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_device_raytracing_ext_flags_t flags;                                 ///< [out] 0 or a valid combination of ::ze_device_raytracing_ext_flags_t
+    uint32_t maxBVHLevels;                                                  ///< [out] Maximum number of BVH levels supported
+
+} ze_device_raytracing_ext_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported raytracing memory allocation flags
+typedef uint32_t ze_raytracing_mem_alloc_ext_flags_t;
+typedef enum _ze_raytracing_mem_alloc_ext_flag_t
+{
+    ZE_RAYTRACING_MEM_ALLOC_EXT_FLAG_TBD = ZE_BIT(0),                       ///< reserved for future use
+    ZE_RAYTRACING_MEM_ALLOC_EXT_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_raytracing_mem_alloc_ext_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Raytracing memory allocation descriptor
+/// 
+/// @details
+///     - This structure must be passed to ::zeMemAllocShared or
+///       ::zeMemAllocDevice, via the `pNext` member of
+///       ::ze_device_mem_alloc_desc_t, for any memory allocation that is to be
+///       accessed by raytracing fixed-function of the device.
+typedef struct _ze_raytracing_mem_alloc_ext_desc_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_raytracing_mem_alloc_ext_flags_t flags;                              ///< [in] flags specifying additional allocation controls.
+                                                                            ///< must be 0 (default) or a valid combination of ::ze_raytracing_mem_alloc_ext_flag_t;
+                                                                            ///< default behavior may use implicit driver-based heuristics.
+
+} ze_raytracing_mem_alloc_ext_desc_t;
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero APIs for Memory Residency
+#if !defined(__GNUC__)
+#pragma region residency
+#endif
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Makes memory resident for the device.
+/// 
+/// @details
+///     - The application must ensure the memory is resident before being
+///       referenced by the device
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == ptr`
+///     - ::ZE_RESULT_ERROR_INVALID_ARGUMENT
+///         + ptr is not recognized by the implementation
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeContextMakeMemoryResident(
+    ze_context_handle_t hContext,                                           ///< [in] handle of context object
+    ze_device_handle_t hDevice,                                             ///< [in] handle of the device
+    void* ptr,                                                              ///< [in] pointer to memory to make resident
+    size_t size                                                             ///< [in] size in bytes to make resident
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Allows memory to be evicted from the device.
+/// 
+/// @details
+///     - The application must ensure the device is not currently referencing
+///       the memory before it is evicted
+///     - The application may free the memory without evicting; the memory is
+///       implicitly evicted when freed.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == ptr`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeContextEvictMemory(
+    ze_context_handle_t hContext,                                           ///< [in] handle of context object
+    ze_device_handle_t hDevice,                                             ///< [in] handle of the device
+    void* ptr,                                                              ///< [in] pointer to memory to evict
+    size_t size                                                             ///< [in] size in bytes to evict
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Makes image resident for the device.
+/// 
+/// @details
+///     - The application must ensure the image is resident before being
+///       referenced by the device
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+///         + `nullptr == hDevice`
+///         + `nullptr == hImage`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeContextMakeImageResident(
+    ze_context_handle_t hContext,                                           ///< [in] handle of context object
+    ze_device_handle_t hDevice,                                             ///< [in] handle of the device
+    ze_image_handle_t hImage                                                ///< [in] handle of image to make resident
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Allows image to be evicted from the device.
+/// 
+/// @details
+///     - The application must ensure the device is not currently referencing
+///       the image before it is evicted
+///     - The application may destroy the image without evicting; the image is
+///       implicitly evicted when destroyed.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+///         + `nullptr == hDevice`
+///         + `nullptr == hImage`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeContextEvictImage(
+    ze_context_handle_t hContext,                                           ///< [in] handle of context object
+    ze_device_handle_t hDevice,                                             ///< [in] handle of the device
+    ze_image_handle_t hImage                                                ///< [in] handle of image to make evict
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero APIs for Sampler
+#if !defined(__GNUC__)
+#pragma region sampler
+#endif
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Sampler addressing modes
+typedef enum _ze_sampler_address_mode_t
+{
+    ZE_SAMPLER_ADDRESS_MODE_NONE = 0,                                       ///< No coordinate modifications for out-of-bounds image access.
+    ZE_SAMPLER_ADDRESS_MODE_REPEAT = 1,                                     ///< Out-of-bounds coordinates are wrapped back around.
+    ZE_SAMPLER_ADDRESS_MODE_CLAMP = 2,                                      ///< Out-of-bounds coordinates are clamped to edge.
+    ZE_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER = 3,                            ///< Out-of-bounds coordinates are clamped to border color which is (0.0f,
+                                                                            ///< 0.0f, 0.0f, 0.0f) if image format swizzle contains alpha, otherwise
+                                                                            ///< (0.0f, 0.0f, 0.0f, 1.0f).
+    ZE_SAMPLER_ADDRESS_MODE_MIRROR = 4,                                     ///< Out-of-bounds coordinates are mirrored starting from edge.
+    ZE_SAMPLER_ADDRESS_MODE_FORCE_UINT32 = 0x7fffffff
+
+} ze_sampler_address_mode_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Sampler filtering modes
+typedef enum _ze_sampler_filter_mode_t
+{
+    ZE_SAMPLER_FILTER_MODE_NEAREST = 0,                                     ///< No coordinate modifications for out of bounds image access.
+    ZE_SAMPLER_FILTER_MODE_LINEAR = 1,                                      ///< Out-of-bounds coordinates are wrapped back around.
+    ZE_SAMPLER_FILTER_MODE_FORCE_UINT32 = 0x7fffffff
+
+} ze_sampler_filter_mode_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Sampler descriptor
+typedef struct _ze_sampler_desc_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_sampler_address_mode_t addressMode;                                  ///< [in] Sampler addressing mode to determine how out-of-bounds
+                                                                            ///< coordinates are handled.
+    ze_sampler_filter_mode_t filterMode;                                    ///< [in] Sampler filter mode to determine how samples are filtered.
+    ze_bool_t isNormalized;                                                 ///< [in] Are coordinates normalized [0, 1] or not.
+
+} ze_sampler_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Creates sampler on the context.
+/// 
+/// @details
+///     - The application must only use the sampler for the device, or its
+///       sub-devices, which was provided during creation.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == desc`
+///         + `nullptr == phSampler`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::ZE_SAMPLER_ADDRESS_MODE_MIRROR < desc->addressMode`
+///         + `::ZE_SAMPLER_FILTER_MODE_LINEAR < desc->filterMode`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeSamplerCreate(
+    ze_context_handle_t hContext,                                           ///< [in] handle of the context object
+    ze_device_handle_t hDevice,                                             ///< [in] handle of the device
+    const ze_sampler_desc_t* desc,                                          ///< [in] pointer to sampler descriptor
+    ze_sampler_handle_t* phSampler                                          ///< [out] handle of the sampler
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Destroys sampler object
+/// 
+/// @details
+///     - The application must ensure the device is not currently referencing
+///       the sampler before it is deleted.
+///     - The implementation of this function may immediately free all Host and
+///       Device allocations associated with this sampler.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same sampler handle.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hSampler`
+///     - ::ZE_RESULT_ERROR_HANDLE_OBJECT_IN_USE
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeSamplerDestroy(
+    ze_sampler_handle_t hSampler                                            ///< [in][release] handle of the sampler
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero APIs for Virtual Memory Management
+#if !defined(__GNUC__)
+#pragma region virtual
+#endif
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Virtual memory page access attributes
+typedef enum _ze_memory_access_attribute_t
+{
+    ZE_MEMORY_ACCESS_ATTRIBUTE_NONE = 0,                                    ///< Indicates the memory page is inaccessible.
+    ZE_MEMORY_ACCESS_ATTRIBUTE_READWRITE = 1,                               ///< Indicates the memory page supports read write access.
+    ZE_MEMORY_ACCESS_ATTRIBUTE_READONLY = 2,                                ///< Indicates the memory page supports read-only access.
+    ZE_MEMORY_ACCESS_ATTRIBUTE_FORCE_UINT32 = 0x7fffffff
+
+} ze_memory_access_attribute_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Reserves pages in virtual address space.
+/// 
+/// @details
+///     - The application must only use the memory allocation on the context for
+///       which it was created.
+///     - The starting address and size must be page aligned. See
+///       ::zeVirtualMemQueryPageSize.
+///     - If pStart is not null then implementation will attempt to reserve
+///       starting from that address. If not available then will find another
+///       suitable starting address.
+///     - The application may call this function from simultaneous threads.
+///     - The access attributes will default to none to indicate reservation is
+///       inaccessible.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pptr`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_SIZE
+///         + `0 == size`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeVirtualMemReserve(
+    ze_context_handle_t hContext,                                           ///< [in] handle of the context object
+    const void* pStart,                                                     ///< [in][optional] pointer to start of region to reserve. If nullptr then
+                                                                            ///< implementation will choose a start address.
+    size_t size,                                                            ///< [in] size in bytes to reserve; must be page aligned.
+    void** pptr                                                             ///< [out] pointer to virtual reservation.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Free pages in a reserved virtual address range.
+/// 
+/// @details
+///     - Any existing virtual mappings for the range will be unmapped.
+///     - Physical allocations objects that were mapped to this range will not
+///       be destroyed. These need to be destroyed explicitly.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == ptr`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_SIZE
+///         + `0 == size`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_ALIGNMENT
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeVirtualMemFree(
+    ze_context_handle_t hContext,                                           ///< [in] handle of the context object
+    const void* ptr,                                                        ///< [in] pointer to start of region to free.
+    size_t size                                                             ///< [in] size in bytes to free; must be page aligned.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Queries page size to use for aligning virtual memory reservations and
+///        physical memory allocations.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pagesize`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_SIZE
+///         + `0 == size`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeVirtualMemQueryPageSize(
+    ze_context_handle_t hContext,                                           ///< [in] handle of the context object
+    ze_device_handle_t hDevice,                                             ///< [in] handle of the device object
+    size_t size,                                                            ///< [in] unaligned allocation size in bytes
+    size_t* pagesize                                                        ///< [out] pointer to page size to use for start address and size
+                                                                            ///< alignments.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported physical memory creation flags
+typedef uint32_t ze_physical_mem_flags_t;
+typedef enum _ze_physical_mem_flag_t
+{
+    ZE_PHYSICAL_MEM_FLAG_ALLOCATE_ON_DEVICE = ZE_BIT(0),                    ///< [default] allocate physical device memory.
+    ZE_PHYSICAL_MEM_FLAG_ALLOCATE_ON_HOST = ZE_BIT(1),                      ///< Allocate physical host memory instead.
+    ZE_PHYSICAL_MEM_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_physical_mem_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Physical memory descriptor
+typedef struct _ze_physical_mem_desc_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_physical_mem_flags_t flags;                                          ///< [in] creation flags.
+                                                                            ///< must be 0 (default) or a valid combination of
+                                                                            ///< ::ze_physical_mem_flag_t; default is to create physical device memory.
+    size_t size;                                                            ///< [in] size in bytes to reserve; must be page aligned.
+
+} ze_physical_mem_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Creates a physical memory object for the context.
+/// 
+/// @details
+///     - The application must only use the physical memory object on the
+///       context for which it was created.
+///     - The size must be page aligned. For host memory, the operating system
+///       page size should be used. For device memory, see
+///       ::zeVirtualMemQueryPageSize.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == desc`
+///         + `nullptr == phPhysicalMemory`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `0x3 < desc->flags`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_SIZE
+///         + `0 == desc->size`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_ALIGNMENT
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zePhysicalMemCreate(
+    ze_context_handle_t hContext,                                           ///< [in] handle of the context object
+    ze_device_handle_t hDevice,                                             ///< [in] handle of the device object, can be `nullptr` if creating
+                                                                            ///< physical host memory.
+    ze_physical_mem_desc_t* desc,                                           ///< [in] pointer to physical memory descriptor.
+    ze_physical_mem_handle_t* phPhysicalMemory                              ///< [out] pointer to handle of physical memory object created
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Destroys a physical memory object.
+/// 
+/// @details
+///     - The application must ensure the device is not currently referencing
+///       the physical memory object before it is deleted
+///     - The application must **not** call this function from simultaneous
+///       threads with the same physical memory handle.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+///         + `nullptr == hPhysicalMemory`
+///     - ::ZE_RESULT_ERROR_HANDLE_OBJECT_IN_USE
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zePhysicalMemDestroy(
+    ze_context_handle_t hContext,                                           ///< [in] handle of the context object
+    ze_physical_mem_handle_t hPhysicalMemory                                ///< [in][release] handle of physical memory object to destroy
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Maps pages in virtual address space to pages from physical memory
+///        object.
+/// 
+/// @details
+///     - The virtual address range must have been reserved using
+///       ::zeVirtualMemReserve.
+///     - The application must only use the mapped memory allocation on the
+///       context for which it was created.
+///     - The virtual start address and size must be page aligned. See
+///       ::zeVirtualMemQueryPageSize.
+///     - The application should use, for the starting address and size, the
+///       same size alignment used for the physical allocation.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+///         + `nullptr == hPhysicalMemory`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == ptr`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::ZE_MEMORY_ACCESS_ATTRIBUTE_READONLY < access`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_SIZE
+///         + `0 == size`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_ALIGNMENT
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeVirtualMemMap(
+    ze_context_handle_t hContext,                                           ///< [in] handle of the context object
+    const void* ptr,                                                        ///< [in] pointer to start of virtual address range to map.
+    size_t size,                                                            ///< [in] size in bytes of virtual address range to map; must be page
+                                                                            ///< aligned.
+    ze_physical_mem_handle_t hPhysicalMemory,                               ///< [in] handle to physical memory object.
+    size_t offset,                                                          ///< [in] offset into physical memory allocation object; must be page
+                                                                            ///< aligned.
+    ze_memory_access_attribute_t access                                     ///< [in] specifies page access attributes to apply to the virtual address
+                                                                            ///< range.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Unmaps pages in virtual address space from pages from a physical
+///        memory object.
+/// 
+/// @details
+///     - The page access attributes for virtual address range will revert back
+///       to none.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == ptr`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_ALIGNMENT
+///         + Address must be page aligned
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_SIZE
+///         + `0 == size`
+///         + Size must be page aligned
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeVirtualMemUnmap(
+    ze_context_handle_t hContext,                                           ///< [in] handle of the context object
+    const void* ptr,                                                        ///< [in] pointer to start of region to unmap.
+    size_t size                                                             ///< [in] size in bytes to unmap; must be page aligned.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Set memory access attributes for a virtual address range.
+/// 
+/// @details
+///     - This function may be called from simultaneous threads with the same
+///       function handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == ptr`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::ZE_MEMORY_ACCESS_ATTRIBUTE_READONLY < access`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_ALIGNMENT
+///         + Address must be page aligned
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_SIZE
+///         + `0 == size`
+///         + Size must be page aligned
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeVirtualMemSetAccessAttribute(
+    ze_context_handle_t hContext,                                           ///< [in] handle of the context object
+    const void* ptr,                                                        ///< [in] pointer to start of reserved virtual address region.
+    size_t size,                                                            ///< [in] size in bytes; must be page aligned.
+    ze_memory_access_attribute_t access                                     ///< [in] specifies page access attributes to apply to the virtual address
+                                                                            ///< range.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get memory access attribute for a virtual address range.
+/// 
+/// @details
+///     - If size and outSize are equal then the pages in the specified virtual
+///       address range have the same access attributes.
+///     - This function may be called from simultaneous threads with the same
+///       function handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == ptr`
+///         + `nullptr == access`
+///         + `nullptr == outSize`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_ALIGNMENT
+///         + Address must be page aligned
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_SIZE
+///         + `0 == size`
+///         + Size must be page aligned
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeVirtualMemGetAccessAttribute(
+    ze_context_handle_t hContext,                                           ///< [in] handle of the context object
+    const void* ptr,                                                        ///< [in] pointer to start of virtual address region for query.
+    size_t size,                                                            ///< [in] size in bytes; must be page aligned.
+    ze_memory_access_attribute_t* access,                                   ///< [out] query result for page access attribute.
+    size_t* outSize                                                         ///< [out] query result for size of virtual address range, starting at ptr,
+                                                                            ///< that shares same access attribute.
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Extension APIs for Floating-Point Atomics
+#if !defined(__GNUC__)
+#pragma region floatAtomics
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_FLOAT_ATOMICS_EXT_NAME
+/// @brief Floating-Point Atomics Extension Name
+#define ZE_FLOAT_ATOMICS_EXT_NAME  "ZE_extension_float_atomics"
+#endif // ZE_FLOAT_ATOMICS_EXT_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Floating-Point Atomics Extension Version(s)
+typedef enum _ze_float_atomics_ext_version_t
+{
+    ZE_FLOAT_ATOMICS_EXT_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),             ///< version 1.0
+    ZE_FLOAT_ATOMICS_EXT_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),         ///< latest known version
+    ZE_FLOAT_ATOMICS_EXT_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} ze_float_atomics_ext_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported floating-point atomic capability flags
+typedef uint32_t ze_device_fp_atomic_ext_flags_t;
+typedef enum _ze_device_fp_atomic_ext_flag_t
+{
+    ZE_DEVICE_FP_ATOMIC_EXT_FLAG_GLOBAL_LOAD_STORE = ZE_BIT(0),             ///< Supports atomic load, store, and exchange
+    ZE_DEVICE_FP_ATOMIC_EXT_FLAG_GLOBAL_ADD = ZE_BIT(1),                    ///< Supports atomic add and subtract
+    ZE_DEVICE_FP_ATOMIC_EXT_FLAG_GLOBAL_MIN_MAX = ZE_BIT(2),                ///< Supports atomic min and max
+    ZE_DEVICE_FP_ATOMIC_EXT_FLAG_LOCAL_LOAD_STORE = ZE_BIT(16),             ///< Supports atomic load, store, and exchange
+    ZE_DEVICE_FP_ATOMIC_EXT_FLAG_LOCAL_ADD = ZE_BIT(17),                    ///< Supports atomic add and subtract
+    ZE_DEVICE_FP_ATOMIC_EXT_FLAG_LOCAL_MIN_MAX = ZE_BIT(18),                ///< Supports atomic min and max
+    ZE_DEVICE_FP_ATOMIC_EXT_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_device_fp_atomic_ext_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Device floating-point atomic properties queried using
+///        ::zeDeviceGetModuleProperties
+/// 
+/// @details
+///     - This structure may be returned from ::zeDeviceGetModuleProperties, via
+///       the `pNext` member of ::ze_device_module_properties_t.
+typedef struct _ze_float_atomic_ext_properties_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_device_fp_atomic_ext_flags_t fp16Flags;                              ///< [out] Capabilities for half-precision floating-point atomic operations
+    ze_device_fp_atomic_ext_flags_t fp32Flags;                              ///< [out] Capabilities for single-precision floating-point atomic
+                                                                            ///< operations
+    ze_device_fp_atomic_ext_flags_t fp64Flags;                              ///< [out] Capabilities for double-precision floating-point atomic
+                                                                            ///< operations
+
+} ze_float_atomic_ext_properties_t;
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Extension for supporting kernel global work offset.
+#if !defined(__GNUC__)
+#pragma region globaloffset
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_GLOBAL_OFFSET_EXP_NAME
+/// @brief Global Offset Extension Name
+#define ZE_GLOBAL_OFFSET_EXP_NAME  "ZE_experimental_global_offset"
+#endif // ZE_GLOBAL_OFFSET_EXP_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Global Offset Extension Version(s)
+typedef enum _ze_global_offset_exp_version_t
+{
+    ZE_GLOBAL_OFFSET_EXP_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),             ///< version 1.0
+    ZE_GLOBAL_OFFSET_EXP_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),         ///< latest known version
+    ZE_GLOBAL_OFFSET_EXP_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} ze_global_offset_exp_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Set global work offset for a kernel.
+/// 
+/// @details
+///     - The global work offset will be used when a
+///       ::zeCommandListAppendLaunchKernel() variant is called.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same kernel handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hKernel`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeKernelSetGlobalOffsetExp(
+    ze_kernel_handle_t hKernel,                                             ///< [in] handle of the kernel object
+    uint32_t offsetX,                                                       ///< [in] global offset for X dimension to use for this kernel
+    uint32_t offsetY,                                                       ///< [in] global offset for Y dimension to use for this kernel
+    uint32_t offsetZ                                                        ///< [in] global offset for Z dimension to use for this kernel
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Extension for supporting relaxed allocation limits.
+#if !defined(__GNUC__)
+#pragma region relaxedAllocLimits
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_RELAXED_ALLOCATION_LIMITS_EXP_NAME
+/// @brief Relaxed Allocation Limits Extension Name
+#define ZE_RELAXED_ALLOCATION_LIMITS_EXP_NAME  "ZE_experimental_relaxed_allocation_limits"
+#endif // ZE_RELAXED_ALLOCATION_LIMITS_EXP_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Relaxed Allocation Limits Extension Version(s)
+typedef enum _ze_relaxed_allocation_limits_exp_version_t
+{
+    ZE_RELAXED_ALLOCATION_LIMITS_EXP_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ), ///< version 1.0
+    ZE_RELAXED_ALLOCATION_LIMITS_EXP_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ), ///< latest known version
+    ZE_RELAXED_ALLOCATION_LIMITS_EXP_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} ze_relaxed_allocation_limits_exp_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported relaxed memory allocation flags
+typedef uint32_t ze_relaxed_allocation_limits_exp_flags_t;
+typedef enum _ze_relaxed_allocation_limits_exp_flag_t
+{
+    ZE_RELAXED_ALLOCATION_LIMITS_EXP_FLAG_MAX_SIZE = ZE_BIT(0),             ///< Allocation size may exceed the `maxMemAllocSize` member of
+                                                                            ///< ::ze_device_properties_t.
+    ZE_RELAXED_ALLOCATION_LIMITS_EXP_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_relaxed_allocation_limits_exp_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Relaxed limits memory allocation descriptor
+/// 
+/// @details
+///     - This structure may be passed to ::zeMemAllocShared or
+///       ::zeMemAllocDevice, via the `pNext` member of
+///       ::ze_device_mem_alloc_desc_t.
+///     - This structure may also be passed to ::zeMemAllocHost, via the `pNext`
+///       member of ::ze_host_mem_alloc_desc_t.
+typedef struct _ze_relaxed_allocation_limits_exp_desc_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_relaxed_allocation_limits_exp_flags_t flags;                         ///< [in] flags specifying allocation limits to relax.
+                                                                            ///< must be 0 (default) or a valid combination of ::ze_relaxed_allocation_limits_exp_flag_t;
+
+} ze_relaxed_allocation_limits_exp_desc_t;
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Extension for retrieving kernel binary program data.
+#if !defined(__GNUC__)
+#pragma region kernelBinary
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_GET_KERNEL_BINARY_EXP_NAME
+/// @brief Get Kernel Binary Extension Name
+#define ZE_GET_KERNEL_BINARY_EXP_NAME  "ZE_extension_kernel_binary_exp"
+#endif // ZE_GET_KERNEL_BINARY_EXP_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get Kernel Binary Extension Version(s)
+typedef enum _ze_kernel_get_binary_exp_version_t
+{
+    ZE_KERNEL_GET_BINARY_EXP_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),         ///< version 1.0
+    ZE_KERNEL_GET_BINARY_EXP_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),     ///< latest known version
+    ZE_KERNEL_GET_BINARY_EXP_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} ze_kernel_get_binary_exp_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves kernel binary program data (ISA GEN format).
+/// 
+/// @details
+///     - A valid kernel handle must be created with ::zeKernelCreate.
+///     - Returns Intel Graphics Assembly (GEN ISA) format binary program data
+///       for kernel handle.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hKernel`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pSize`
+///         + `nullptr == pKernelBinary`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeKernelGetBinaryExp(
+    ze_kernel_handle_t hKernel,                                             ///< [in] Kernel handle.
+    size_t* pSize,                                                          ///< [in,out] pointer to variable with size of GEN ISA binary.
+    uint8_t* pKernelBinary                                                  ///< [in,out] pointer to storage area for GEN ISA binary function.
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Extension for Driver Direct Device Interface (DDI) Handles
+#if !defined(__GNUC__)
+#pragma region driverDDIHandles
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_DRIVER_DDI_HANDLES_EXT_NAME
+/// @brief Driver Direct Device Interface (DDI) Handles Extension Name
+#define ZE_DRIVER_DDI_HANDLES_EXT_NAME  "ZE_extension_driver_ddi_handles"
+#endif // ZE_DRIVER_DDI_HANDLES_EXT_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Driver Direct Device Interface (DDI) Handles Extension Version(s)
+typedef enum _ze_driver_ddi_handles_ext_version_t
+{
+    ZE_DRIVER_DDI_HANDLES_EXT_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),        ///< version 1.0
+    ZE_DRIVER_DDI_HANDLES_EXT_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),    ///< latest known version
+    ZE_DRIVER_DDI_HANDLES_EXT_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} ze_driver_ddi_handles_ext_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Driver Direct Device Interface (DDI) Handle Extension Flags
+typedef uint32_t ze_driver_ddi_handle_ext_flags_t;
+typedef enum _ze_driver_ddi_handle_ext_flag_t
+{
+    ZE_DRIVER_DDI_HANDLE_EXT_FLAG_DDI_HANDLE_EXT_SUPPORTED = ZE_BIT(0),     ///< Driver Supports DDI Handles Extension
+    ZE_DRIVER_DDI_HANDLE_EXT_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_driver_ddi_handle_ext_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Driver DDI Handles properties queried using ::zeDriverGetProperties
+/// 
+/// @details
+///     - This structure may be returned from ::zeDriverGetProperties, via the
+///       `pNext` member of ::ze_driver_properties_t.
+typedef struct _ze_driver_ddi_handles_ext_properties_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_driver_ddi_handle_ext_flags_t flags;                                 ///< [out] 0 (none) or a valid combination of ::ze_driver_ddi_handle_ext_flags_t
+
+} ze_driver_ddi_handles_ext_properties_t;
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Extension for external semaphores
+#if !defined(__GNUC__)
+#pragma region externalSemaphores
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_EXTERNAL_SEMAPHORES_EXTENSION_NAME
+/// @brief External Semaphores Extension Name
+#define ZE_EXTERNAL_SEMAPHORES_EXTENSION_NAME  "ZE_extension_external_semaphores"
+#endif // ZE_EXTERNAL_SEMAPHORES_EXTENSION_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief External Semaphores Extension Version
+typedef enum _ze_external_semaphore_ext_version_t
+{
+    ZE_EXTERNAL_SEMAPHORE_EXT_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),        ///< version 1.0
+    ZE_EXTERNAL_SEMAPHORE_EXT_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),    ///< latest known version
+    ZE_EXTERNAL_SEMAPHORE_EXT_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} ze_external_semaphore_ext_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle of external semaphore object
+typedef struct _ze_external_semaphore_ext_handle_t *ze_external_semaphore_ext_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief External Semaphores Type Flags
+typedef uint32_t ze_external_semaphore_ext_flags_t;
+typedef enum _ze_external_semaphore_ext_flag_t
+{
+    ZE_EXTERNAL_SEMAPHORE_EXT_FLAG_OPAQUE_FD = ZE_BIT(0),                   ///< Semaphore is an Linux opaque file descriptor
+    ZE_EXTERNAL_SEMAPHORE_EXT_FLAG_OPAQUE_WIN32 = ZE_BIT(1),                ///< Semaphore is an opaque Win32 handle for monitored fence
+    ZE_EXTERNAL_SEMAPHORE_EXT_FLAG_OPAQUE_WIN32_KMT = ZE_BIT(2),            ///< Semaphore is an opaque Win32 KMT handle for monitored fence
+    ZE_EXTERNAL_SEMAPHORE_EXT_FLAG_D3D12_FENCE = ZE_BIT(3),                 ///< Semaphore is a D3D12 fence
+    ZE_EXTERNAL_SEMAPHORE_EXT_FLAG_D3D11_FENCE = ZE_BIT(4),                 ///< Semaphore is a D3D11 fence
+    ZE_EXTERNAL_SEMAPHORE_EXT_FLAG_KEYED_MUTEX = ZE_BIT(5),                 ///< Semaphore is a keyed mutex for Win32
+    ZE_EXTERNAL_SEMAPHORE_EXT_FLAG_KEYED_MUTEX_KMT = ZE_BIT(6),             ///< Semaphore is a keyed mutex for Win32 KMT
+    ZE_EXTERNAL_SEMAPHORE_EXT_FLAG_VK_TIMELINE_SEMAPHORE_FD = ZE_BIT(7),    ///< Semaphore is a Vulkan Timeline semaphore for Linux
+    ZE_EXTERNAL_SEMAPHORE_EXT_FLAG_VK_TIMELINE_SEMAPHORE_WIN32 = ZE_BIT(8), ///< Semaphore is a Vulkan Timeline semaphore for Win32
+    ZE_EXTERNAL_SEMAPHORE_EXT_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_external_semaphore_ext_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief External Semaphore Descriptor
+typedef struct _ze_external_semaphore_ext_desc_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_external_semaphore_ext_flags_t flags;                                ///< [in] The flags describing the type of the semaphore.
+                                                                            ///< must be 0 (default) or a valid combination of ::ze_external_semaphore_ext_flag_t.
+                                                                            ///< When importing a semaphore, pNext should be pointing to one of the
+                                                                            ///< following structures: ::ze_external_semaphore_win32_ext_desc_t or ::ze_external_semaphore_fd_ext_desc_t.
+
+} ze_external_semaphore_ext_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief External Semaphore Win32 Descriptor
+typedef struct _ze_external_semaphore_win32_ext_desc_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    void* handle;                                                           ///< [in] Win32 handle of the semaphore.
+                                                                            ///< Must be a valid Win32 handle.
+    const char* name;                                                       ///< [in] Name of the semaphore.
+                                                                            ///< Must be a valid null-terminated string.
+
+} ze_external_semaphore_win32_ext_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief External Semaphore FD Descriptor
+typedef struct _ze_external_semaphore_fd_ext_desc_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    int fd;                                                                 ///< [in] File descriptor of the semaphore.
+                                                                            ///< Must be a valid file descriptor.
+
+} ze_external_semaphore_fd_ext_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief External Semaphore Signal parameters
+typedef struct _ze_external_semaphore_signal_params_ext_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    uint64_t value;                                                         ///< [in] [optional] Value to signal.
+                                                                            ///< Specified by user as an expected value with some of semaphore types,
+                                                                            ///< such as ::ZE_EXTERNAL_SEMAPHORE_EXT_FLAG_D3D12_FENCE.
+
+} ze_external_semaphore_signal_params_ext_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief External Semaphore Wait parameters
+typedef struct _ze_external_semaphore_wait_params_ext_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    uint64_t value;                                                         ///< [in] [optional] Value to wait for.
+                                                                            ///< Specified by user as an expected value with some of semaphore types,
+                                                                            ///< such as ::ZE_EXTERNAL_SEMAPHORE_EXT_FLAG_D3D12_FENCE.
+
+} ze_external_semaphore_wait_params_ext_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Import an external semaphore
+/// 
+/// @details
+///     - Imports an external semaphore.
+///     - This function may be called from simultaneous threads with the same
+///       device handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == desc`
+///         + `nullptr == phSemaphore`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `0x1ff < desc->flags`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeDeviceImportExternalSemaphoreExt(
+    ze_device_handle_t hDevice,                                             ///< [in] The device handle.
+    const ze_external_semaphore_ext_desc_t* desc,                           ///< [in] The pointer to external semaphore descriptor.
+    ze_external_semaphore_ext_handle_t* phSemaphore                         ///< [out] The handle of the external semaphore imported.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Release an external semaphore
+/// 
+/// @details
+///     - The application must ensure the device is not currently referencing
+///       the semaphore before it is released.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same semaphore handle.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hSemaphore`
+///     - ::ZE_RESULT_ERROR_HANDLE_OBJECT_IN_USE
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeDeviceReleaseExternalSemaphoreExt(
+    ze_external_semaphore_ext_handle_t hSemaphore                           ///< [in] The handle of the external semaphore.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Signal an external semaphore
+/// 
+/// @details
+///     - Signals an external semaphore.
+///     - This function must only be used with an immediate command list.
+///     - This function may be called from simultaneous threads with the same
+///       command list handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandList`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == phSemaphores`
+///         + `nullptr == signalParams`
+///     - ::ZE_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT
+///     - ::ZE_RESULT_ERROR_INVALID_SIZE
+///         + `(nullptr == phWaitEvents) && (0 < numWaitEvents)`
+///         + `(nullptr == phSemaphores) && (0 < numSemaphores)`
+///         + `(nullptr == signalParams) && (0 < numSemaphores)`
+///     - ::ZE_RESULT_ERROR_INVALID_ARGUMENT
+///         + Commandlist handle does not correspond to an immediate command list
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandListAppendSignalExternalSemaphoreExt(
+    ze_command_list_handle_t hCommandList,                                  ///< [in] The command list handle.
+    uint32_t numSemaphores,                                                 ///< [in] The number of external semaphores.
+    ze_external_semaphore_ext_handle_t* phSemaphores,                       ///< [in][range(0, numSemaphores)] The vector of external semaphore handles
+                                                                            ///< to be appended into command list.
+    ze_external_semaphore_signal_params_ext_t* signalParams,                ///< [in] Signal parameters.
+    ze_event_handle_t hSignalEvent,                                         ///< [in][optional] handle of the event to signal on completion
+    uint32_t numWaitEvents,                                                 ///< [in][optional] number of events to wait on before launching; must be 0
+                                                                            ///< if `nullptr == phWaitEvents`
+    ze_event_handle_t* phWaitEvents                                         ///< [in][optional][range(0, numWaitEvents)] handle of the events to wait
+                                                                            ///< on before launching
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Wait on external semaphores
+/// 
+/// @details
+///     - Waits on external semaphores.
+///     - This function must only be used with an immediate command list.
+///     - This function may be called from simultaneous threads with the same
+///       command list handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandList`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == phSemaphores`
+///         + `nullptr == waitParams`
+///     - ::ZE_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT
+///     - ::ZE_RESULT_ERROR_INVALID_SIZE
+///         + `(nullptr == phWaitEvents) && (0 < numWaitEvents)`
+///         + `(nullptr == phSemaphores) && (0 < numSemaphores)`
+///         + `(nullptr == waitParams) && (0 < numSemaphores)`
+///     - ::ZE_RESULT_ERROR_INVALID_ARGUMENT
+///         + Commandlist handle does not correspond to an immediate command list
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandListAppendWaitExternalSemaphoreExt(
+    ze_command_list_handle_t hCommandList,                                  ///< [in] The command list handle.
+    uint32_t numSemaphores,                                                 ///< [in] The number of external semaphores.
+    ze_external_semaphore_ext_handle_t* phSemaphores,                       ///< [in] [range(0,numSemaphores)] The vector of external semaphore handles
+                                                                            ///< to append into command list.
+    ze_external_semaphore_wait_params_ext_t* waitParams,                    ///< [in] Wait parameters.
+    ze_event_handle_t hSignalEvent,                                         ///< [in][optional] handle of the event to signal on completion
+    uint32_t numWaitEvents,                                                 ///< [in][optional] number of events to wait on before launching; must be 0
+                                                                            ///< if `nullptr == phWaitEvents`
+    ze_event_handle_t* phWaitEvents                                         ///< [in][optional][range(0, numWaitEvents)] handle of the events to wait
+                                                                            ///< on before launching
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Extension APIs for Cache Reservation
+#if !defined(__GNUC__)
+#pragma region cacheReservation
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_CACHE_RESERVATION_EXT_NAME
+/// @brief Cache_Reservation Extension Name
+#define ZE_CACHE_RESERVATION_EXT_NAME  "ZE_extension_cache_reservation"
+#endif // ZE_CACHE_RESERVATION_EXT_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Cache_Reservation Extension Version(s)
+typedef enum _ze_cache_reservation_ext_version_t
+{
+    ZE_CACHE_RESERVATION_EXT_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),         ///< version 1.0
+    ZE_CACHE_RESERVATION_EXT_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),     ///< latest known version
+    ZE_CACHE_RESERVATION_EXT_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} ze_cache_reservation_ext_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Cache Reservation Region
+typedef enum _ze_cache_ext_region_t
+{
+    ZE_CACHE_EXT_REGION_ZE_CACHE_REGION_DEFAULT = 0,                        ///< [DEPRECATED] utilize driver default scheme. Use
+                                                                            ///< ::ZE_CACHE_EXT_REGION_DEFAULT.
+    ZE_CACHE_EXT_REGION_ZE_CACHE_RESERVE_REGION = 1,                        ///< [DEPRECATED] utilize reserved region. Use
+                                                                            ///< ::ZE_CACHE_EXT_REGION_RESERVED.
+    ZE_CACHE_EXT_REGION_ZE_CACHE_NON_RESERVED_REGION = 2,                   ///< [DEPRECATED] utilize non-reserverd region. Use
+                                                                            ///< ::ZE_CACHE_EXT_REGION_NON_RESERVED.
+    ZE_CACHE_EXT_REGION_DEFAULT = 0,                                        ///< utilize driver default scheme
+    ZE_CACHE_EXT_REGION_RESERVED = 1,                                       ///< utilize reserved region
+    ZE_CACHE_EXT_REGION_NON_RESERVED = 2,                                   ///< utilize non-reserverd region
+    ZE_CACHE_EXT_REGION_FORCE_UINT32 = 0x7fffffff
+
+} ze_cache_ext_region_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief CacheReservation structure
+/// 
+/// @details
+///     - This structure must be passed to ::zeDeviceGetCacheProperties via the
+///       `pNext` member of ::ze_device_cache_properties_t
+///     - Used for determining the max cache reservation allowed on device. Size
+///       of zero means no reservation available.
+typedef struct _ze_cache_reservation_ext_desc_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    size_t maxCacheReservationSize;                                         ///< [out] max cache reservation size
+
+} ze_cache_reservation_ext_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Reserve Cache on Device
+/// 
+/// @details
+///     - The application may call this function but may not be successful as
+///       some other application may have reserve prior
+/// 
+/// @remarks
+///   _Analogues_
+///     - None
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeDeviceReserveCacheExt(
+    ze_device_handle_t hDevice,                                             ///< [in] handle of the device object
+    size_t cacheLevel,                                                      ///< [in] cache level where application want to reserve. If zero, then the
+                                                                            ///< driver shall default to last level of cache and attempt to reserve in
+                                                                            ///< that cache.
+    size_t cacheReservationSize                                             ///< [in] value for reserving size, in bytes. If zero, then the driver
+                                                                            ///< shall remove prior reservation
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Assign VA section to use reserved section
+/// 
+/// @details
+///     - The application may call this function to assign VA to particular
+///       reservartion region
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == ptr`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::ZE_CACHE_EXT_REGION_NON_RESERVED < cacheRegion`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeDeviceSetCacheAdviceExt(
+    ze_device_handle_t hDevice,                                             ///< [in] handle of the device object
+    void* ptr,                                                              ///< [in] memory pointer to query
+    size_t regionSize,                                                      ///< [in] region size, in pages
+    ze_cache_ext_region_t cacheRegion                                       ///< [in] reservation region
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Extension for supporting event query timestamps.
+#if !defined(__GNUC__)
+#pragma region eventquerytimestamps
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_EVENT_QUERY_TIMESTAMPS_EXP_NAME
+/// @brief Event Query Timestamps Extension Name
+#define ZE_EVENT_QUERY_TIMESTAMPS_EXP_NAME  "ZE_experimental_event_query_timestamps"
+#endif // ZE_EVENT_QUERY_TIMESTAMPS_EXP_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Event Query Timestamps Extension Version(s)
+typedef enum _ze_event_query_timestamps_exp_version_t
+{
+    ZE_EVENT_QUERY_TIMESTAMPS_EXP_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),    ///< version 1.0
+    ZE_EVENT_QUERY_TIMESTAMPS_EXP_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),///< latest known version
+    ZE_EVENT_QUERY_TIMESTAMPS_EXP_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} ze_event_query_timestamps_exp_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Query event timestamps for a device or sub-device.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function must be thread-safe.
+///     - The implementation must support
+///       ::ZE_experimental_event_query_timestamps.
+///     - The implementation must return all timestamps for the specified event
+///       and device pair.
+///     - The implementation must return all timestamps for all sub-devices when
+///       device handle is parent device.
+///     - The implementation may return all timestamps for sub-devices when
+///       device handle is sub-device or may return 0 for count.
+/// 
+/// @remarks
+///   _Analogues_
+///     - None
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hEvent`
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeEventQueryTimestampsExp(
+    ze_event_handle_t hEvent,                                               ///< [in] handle of the event
+    ze_device_handle_t hDevice,                                             ///< [in] handle of the device to query
+    uint32_t* pCount,                                                       ///< [in,out] pointer to the number of timestamp results.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of timestamps available.
+                                                                            ///< if count is greater than the number of timestamps available, then the
+                                                                            ///< driver shall update the value with the correct number of timestamps available.
+    ze_kernel_timestamp_result_t* pTimestamps                               ///< [in,out][optional][range(0, *pCount)] array of timestamp results.
+                                                                            ///< if count is less than the number of timestamps available, then driver
+                                                                            ///< shall only retrieve that number of timestamps.
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Extension for supporting image memory properties.
+#if !defined(__GNUC__)
+#pragma region imagememoryproperties
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_IMAGE_MEMORY_PROPERTIES_EXP_NAME
+/// @brief Image Memory Properties Extension Name
+#define ZE_IMAGE_MEMORY_PROPERTIES_EXP_NAME  "ZE_experimental_image_memory_properties"
+#endif // ZE_IMAGE_MEMORY_PROPERTIES_EXP_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Image Memory Properties Extension Version(s)
+typedef enum _ze_image_memory_properties_exp_version_t
+{
+    ZE_IMAGE_MEMORY_PROPERTIES_EXP_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),   ///< version 1.0
+    ZE_IMAGE_MEMORY_PROPERTIES_EXP_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),   ///< latest known version
+    ZE_IMAGE_MEMORY_PROPERTIES_EXP_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} ze_image_memory_properties_exp_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Image memory properties
+typedef struct _ze_image_memory_properties_exp_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    uint64_t size;                                                          ///< [out] size of image allocation in bytes.
+    uint64_t rowPitch;                                                      ///< [out] size of image row in bytes.
+    uint64_t slicePitch;                                                    ///< [out] size of image slice in bytes.
+
+} ze_image_memory_properties_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Query image memory properties.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function must be thread-safe.
+///     - The implementation must support
+///       ::ZE_experimental_image_memory_properties extension.
+/// 
+/// @remarks
+///   _Analogues_
+///     - None
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hImage`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pMemoryProperties`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeImageGetMemoryPropertiesExp(
+    ze_image_handle_t hImage,                                               ///< [in] handle of image object
+    ze_image_memory_properties_exp_t* pMemoryProperties                     ///< [in,out] query result for image memory properties.
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Extension for supporting image views.
+#if !defined(__GNUC__)
+#pragma region imageview
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_IMAGE_VIEW_EXT_NAME
+/// @brief Image View Extension Name
+#define ZE_IMAGE_VIEW_EXT_NAME  "ZE_extension_image_view"
+#endif // ZE_IMAGE_VIEW_EXT_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Image View Extension Version(s)
+typedef enum _ze_image_view_ext_version_t
+{
+    ZE_IMAGE_VIEW_EXT_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),                ///< version 1.0
+    ZE_IMAGE_VIEW_EXT_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),            ///< latest known version
+    ZE_IMAGE_VIEW_EXT_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} ze_image_view_ext_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Create image view on the context.
+/// 
+/// @details
+///     - The application must only use the image view for the device, or its
+///       sub-devices, which was provided during creation.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function must be thread-safe.
+///     - The implementation must support ::ZE_extension_image_view extension.
+///     - Image views are treated as images from the API.
+///     - Image views provide a mechanism to redescribe how an image is
+///       interpreted (e.g. different format).
+///     - Image views become disabled when their corresponding image resource is
+///       destroyed.
+///     - Use ::zeImageDestroy to destroy image view objects.
+/// 
+/// @remarks
+///   _Analogues_
+///     - None
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+///         + `nullptr == hDevice`
+///         + `nullptr == hImage`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == desc`
+///         + `nullptr == phImageView`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `0x3 < desc->flags`
+///         + `::ZE_IMAGE_TYPE_BUFFER < desc->type`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_IMAGE_FORMAT
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeImageViewCreateExt(
+    ze_context_handle_t hContext,                                           ///< [in] handle of the context object
+    ze_device_handle_t hDevice,                                             ///< [in] handle of the device
+    const ze_image_desc_t* desc,                                            ///< [in] pointer to image descriptor
+    ze_image_handle_t hImage,                                               ///< [in] handle of image object to create view from
+    ze_image_handle_t* phImageView                                          ///< [out] pointer to handle of image object created for view
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_IMAGE_VIEW_EXP_NAME
+/// @brief Image View Extension Name
+#define ZE_IMAGE_VIEW_EXP_NAME  "ZE_experimental_image_view"
+#endif // ZE_IMAGE_VIEW_EXP_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Image View Extension Version(s)
+typedef enum _ze_image_view_exp_version_t
+{
+    ZE_IMAGE_VIEW_EXP_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),                ///< version 1.0
+    ZE_IMAGE_VIEW_EXP_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),            ///< latest known version
+    ZE_IMAGE_VIEW_EXP_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} ze_image_view_exp_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Create image view on the context.
+/// 
+/// @details
+///     - The application must only use the image view for the device, or its
+///       sub-devices, which was provided during creation.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function must be thread-safe.
+///     - The implementation must support ::ZE_experimental_image_view
+///       extension.
+///     - Image views are treated as images from the API.
+///     - Image views provide a mechanism to redescribe how an image is
+///       interpreted (e.g. different format).
+///     - Image views become disabled when their corresponding image resource is
+///       destroyed.
+///     - Use ::zeImageDestroy to destroy image view objects.
+///     - Note: This function is deprecated and replaced by
+///       ::zeImageViewCreateExt.
+/// 
+/// @remarks
+///   _Analogues_
+///     - None
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+///         + `nullptr == hDevice`
+///         + `nullptr == hImage`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == desc`
+///         + `nullptr == phImageView`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `0x3 < desc->flags`
+///         + `::ZE_IMAGE_TYPE_BUFFER < desc->type`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_IMAGE_FORMAT
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeImageViewCreateExp(
+    ze_context_handle_t hContext,                                           ///< [in] handle of the context object
+    ze_device_handle_t hDevice,                                             ///< [in] handle of the device
+    const ze_image_desc_t* desc,                                            ///< [in] pointer to image descriptor
+    ze_image_handle_t hImage,                                               ///< [in] handle of image object to create view from
+    ze_image_handle_t* phImageView                                          ///< [out] pointer to handle of image object created for view
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Extension for supporting image views for planar images.
+#if !defined(__GNUC__)
+#pragma region imageviewplanar
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_IMAGE_VIEW_PLANAR_EXT_NAME
+/// @brief Image View Planar Extension Name
+#define ZE_IMAGE_VIEW_PLANAR_EXT_NAME  "ZE_extension_image_view_planar"
+#endif // ZE_IMAGE_VIEW_PLANAR_EXT_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Image View Planar Extension Version(s)
+typedef enum _ze_image_view_planar_ext_version_t
+{
+    ZE_IMAGE_VIEW_PLANAR_EXT_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),         ///< version 1.0
+    ZE_IMAGE_VIEW_PLANAR_EXT_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),     ///< latest known version
+    ZE_IMAGE_VIEW_PLANAR_EXT_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} ze_image_view_planar_ext_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Image view planar descriptor
+typedef struct _ze_image_view_planar_ext_desc_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    uint32_t planeIndex;                                                    ///< [in] the 0-based plane index (e.g. NV12 is 0 = Y plane, 1 UV plane)
+
+} ze_image_view_planar_ext_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_IMAGE_VIEW_PLANAR_EXP_NAME
+/// @brief Image View Planar Extension Name
+#define ZE_IMAGE_VIEW_PLANAR_EXP_NAME  "ZE_experimental_image_view_planar"
+#endif // ZE_IMAGE_VIEW_PLANAR_EXP_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Image View Planar Extension Version(s)
+typedef enum _ze_image_view_planar_exp_version_t
+{
+    ZE_IMAGE_VIEW_PLANAR_EXP_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),         ///< version 1.0
+    ZE_IMAGE_VIEW_PLANAR_EXP_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),     ///< latest known version
+    ZE_IMAGE_VIEW_PLANAR_EXP_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} ze_image_view_planar_exp_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Image view planar descriptor
+typedef struct _ze_image_view_planar_exp_desc_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    uint32_t planeIndex;                                                    ///< [in] the 0-based plane index (e.g. NV12 is 0 = Y plane, 1 UV plane)
+
+} ze_image_view_planar_exp_desc_t;
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Extension for specifying kernel scheduling hints.
+#if !defined(__GNUC__)
+#pragma region kernelSchedulingHints
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_KERNEL_SCHEDULING_HINTS_EXP_NAME
+/// @brief Kernel Scheduling Hints Extension Name
+#define ZE_KERNEL_SCHEDULING_HINTS_EXP_NAME  "ZE_experimental_scheduling_hints"
+#endif // ZE_KERNEL_SCHEDULING_HINTS_EXP_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Kernel Scheduling Hints Extension Version(s)
+typedef enum _ze_scheduling_hints_exp_version_t
+{
+    ZE_SCHEDULING_HINTS_EXP_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),          ///< version 1.0
+    ZE_SCHEDULING_HINTS_EXP_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),      ///< latest known version
+    ZE_SCHEDULING_HINTS_EXP_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} ze_scheduling_hints_exp_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported kernel scheduling hint flags
+typedef uint32_t ze_scheduling_hint_exp_flags_t;
+typedef enum _ze_scheduling_hint_exp_flag_t
+{
+    ZE_SCHEDULING_HINT_EXP_FLAG_OLDEST_FIRST = ZE_BIT(0),                   ///< Hint that the kernel prefers oldest-first scheduling
+    ZE_SCHEDULING_HINT_EXP_FLAG_ROUND_ROBIN = ZE_BIT(1),                    ///< Hint that the kernel prefers round-robin scheduling
+    ZE_SCHEDULING_HINT_EXP_FLAG_STALL_BASED_ROUND_ROBIN = ZE_BIT(2),        ///< Hint that the kernel prefers stall-based round-robin scheduling
+    ZE_SCHEDULING_HINT_EXP_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_scheduling_hint_exp_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Device kernel scheduling hint properties queried using
+///        ::zeDeviceGetModuleProperties
+/// 
+/// @details
+///     - This structure may be returned from ::zeDeviceGetModuleProperties, via
+///       the `pNext` member of ::ze_device_module_properties_t.
+typedef struct _ze_scheduling_hint_exp_properties_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_scheduling_hint_exp_flags_t schedulingHintFlags;                     ///< [out] Supported kernel scheduling hints.
+                                                                            ///< May be 0 (none) or a valid combination of ::ze_scheduling_hint_exp_flag_t.
+
+} ze_scheduling_hint_exp_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Kernel scheduling hint descriptor
+/// 
+/// @details
+///     - This structure may be passed to ::zeKernelSchedulingHintExp.
+typedef struct _ze_scheduling_hint_exp_desc_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_scheduling_hint_exp_flags_t flags;                                   ///< [in] flags specifying kernel scheduling hints.
+                                                                            ///< must be 0 (default) or a valid combination of ::ze_scheduling_hint_exp_flag_t.
+
+} ze_scheduling_hint_exp_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Provide kernel scheduling hints that may improve performance
+/// 
+/// @details
+///     - The scheduling hints may improve performance only and are not required
+///       for correctness.
+///     - If a specified scheduling hint is unsupported it will be silently
+///       ignored.
+///     - If two conflicting scheduling hints are specified there is no defined behavior;
+///       the hints may be ignored or one hint may be chosen arbitrarily.
+///     - The application must not call this function from simultaneous threads
+///       with the same kernel handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hKernel`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pHint`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `0x7 < pHint->flags`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeKernelSchedulingHintExp(
+    ze_kernel_handle_t hKernel,                                             ///< [in] handle of the kernel object
+    ze_scheduling_hint_exp_desc_t* pHint                                    ///< [in] pointer to kernel scheduling hint descriptor
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Extension APIs for One-Definition-Rule Linkage Types
+#if !defined(__GNUC__)
+#pragma region linkonceodr
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_LINKONCE_ODR_EXT_NAME
+/// @brief Linkonce ODR Extension Name
+#define ZE_LINKONCE_ODR_EXT_NAME  "ZE_extension_linkonce_odr"
+#endif // ZE_LINKONCE_ODR_EXT_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Linkonce ODR Extension Version(s)
+typedef enum _ze_linkonce_odr_ext_version_t
+{
+    ZE_LINKONCE_ODR_EXT_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),              ///< version 1.0
+    ZE_LINKONCE_ODR_EXT_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),          ///< latest known version
+    ZE_LINKONCE_ODR_EXT_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} ze_linkonce_odr_ext_version_t;
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Extension for supporting power saving hint.
+#if !defined(__GNUC__)
+#pragma region powersavinghint
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_CONTEXT_POWER_SAVING_HINT_EXP_NAME
+/// @brief Power Saving Hint Extension Name
+#define ZE_CONTEXT_POWER_SAVING_HINT_EXP_NAME  "ZE_experimental_power_saving_hint"
+#endif // ZE_CONTEXT_POWER_SAVING_HINT_EXP_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Power Saving Hint Extension Version(s)
+typedef enum _ze_power_saving_hint_exp_version_t
+{
+    ZE_POWER_SAVING_HINT_EXP_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),         ///< version 1.0
+    ZE_POWER_SAVING_HINT_EXP_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),     ///< latest known version
+    ZE_POWER_SAVING_HINT_EXP_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} ze_power_saving_hint_exp_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported device types
+typedef enum _ze_power_saving_hint_type_t
+{
+    ZE_POWER_SAVING_HINT_TYPE_MIN = 0,                                      ///< Minumum power savings. The device will make no attempt to save power
+                                                                            ///< while executing work submitted to this context.
+    ZE_POWER_SAVING_HINT_TYPE_MAX = 100,                                    ///< Maximum power savings. The device will do everything to bring power to
+                                                                            ///< a minimum while executing work submitted to this context.
+    ZE_POWER_SAVING_HINT_TYPE_FORCE_UINT32 = 0x7fffffff
+
+} ze_power_saving_hint_type_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Extended context descriptor containing power saving hint.
+typedef struct _ze_context_power_saving_hint_exp_desc_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    uint32_t hint;                                                          ///< [in] power saving hint (default value = 0). This is value from [0,100]
+                                                                            ///< and can use pre-defined settings from ::ze_power_saving_hint_type_t.
+
+} ze_context_power_saving_hint_exp_desc_t;
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Extension APIs for Subgroups
+#if !defined(__GNUC__)
+#pragma region subgroups
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_SUBGROUPS_EXT_NAME
+/// @brief Subgroups Extension Name
+#define ZE_SUBGROUPS_EXT_NAME  "ZE_extension_subgroups"
+#endif // ZE_SUBGROUPS_EXT_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Subgroups Extension Version(s)
+typedef enum _ze_subgroup_ext_version_t
+{
+    ZE_SUBGROUP_EXT_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),                  ///< version 1.0
+    ZE_SUBGROUP_EXT_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),              ///< latest known version
+    ZE_SUBGROUP_EXT_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} ze_subgroup_ext_version_t;
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Extension APIs for EU Count
+#if !defined(__GNUC__)
+#pragma region EUCount
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_EU_COUNT_EXT_NAME
+/// @brief EU Count Extension Name
+#define ZE_EU_COUNT_EXT_NAME  "ZE_extension_eu_count"
+#endif // ZE_EU_COUNT_EXT_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief EU Count Extension Version(s)
+typedef enum _ze_eu_count_ext_version_t
+{
+    ZE_EU_COUNT_EXT_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),                  ///< version 1.0
+    ZE_EU_COUNT_EXT_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),              ///< latest known version
+    ZE_EU_COUNT_EXT_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} ze_eu_count_ext_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief EU count queried using ::zeDeviceGetProperties
+/// 
+/// @details
+///     - This structure may be returned from ::zeDeviceGetProperties via the
+///       `pNext` member of ::ze_device_properties_t.
+///     - Used for determining the total number of EUs available on device.
+typedef struct _ze_eu_count_ext_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    uint32_t numTotalEUs;                                                   ///< [out] Total number of EUs available
+
+} ze_eu_count_ext_t;
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Extension APIs for PCI Properties
+#if !defined(__GNUC__)
+#pragma region PCIProperties
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_PCI_PROPERTIES_EXT_NAME
+/// @brief PCI Properties Extension Name
+#define ZE_PCI_PROPERTIES_EXT_NAME  "ZE_extension_pci_properties"
+#endif // ZE_PCI_PROPERTIES_EXT_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief PCI Properties Extension Version(s)
+typedef enum _ze_pci_properties_ext_version_t
+{
+    ZE_PCI_PROPERTIES_EXT_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),            ///< version 1.0
+    ZE_PCI_PROPERTIES_EXT_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),        ///< latest known version
+    ZE_PCI_PROPERTIES_EXT_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} ze_pci_properties_ext_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Device PCI address
+/// 
+/// @details
+///     - This structure may be passed to ::zeDevicePciGetPropertiesExt as an
+///       attribute of ::ze_pci_ext_properties_t.
+///     - A PCI BDF address is the bus:device:function address of the device and
+///       is useful for locating the device in the PCI switch fabric.
+typedef struct _ze_pci_address_ext_t
+{
+    uint32_t domain;                                                        ///< [out] PCI domain number
+    uint32_t bus;                                                           ///< [out] PCI BDF bus number
+    uint32_t device;                                                        ///< [out] PCI BDF device number
+    uint32_t function;                                                      ///< [out] PCI BDF function number
+
+} ze_pci_address_ext_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Device PCI speed
+typedef struct _ze_pci_speed_ext_t
+{
+    int32_t genVersion;                                                     ///< [out] The link generation. A value of -1 means that this property is
+                                                                            ///< unknown.
+    int32_t width;                                                          ///< [out] The number of lanes. A value of -1 means that this property is
+                                                                            ///< unknown.
+    int64_t maxBandwidth;                                                   ///< [out] The theoretical maximum bandwidth in bytes/sec (sum of all
+                                                                            ///< lanes). A value of -1 means that this property is unknown.
+
+} ze_pci_speed_ext_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Static PCI properties
+typedef struct _ze_pci_ext_properties_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_pci_address_ext_t address;                                           ///< [out] The BDF address
+    ze_pci_speed_ext_t maxSpeed;                                            ///< [out] Fastest port configuration supported by the device (sum of all
+                                                                            ///< lanes)
+
+} ze_pci_ext_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get PCI properties - address, max speed
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @remarks
+///   _Analogues_
+///     - None
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pPciProperties`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeDevicePciGetPropertiesExt(
+    ze_device_handle_t hDevice,                                             ///< [in] handle of the device object.
+    ze_pci_ext_properties_t* pPciProperties                                 ///< [in,out] returns the PCI properties of the device.
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Extension APIs for sRGB
+#if !defined(__GNUC__)
+#pragma region SRGB
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_SRGB_EXT_NAME
+/// @brief sRGB Extension Name
+#define ZE_SRGB_EXT_NAME  "ZE_extension_srgb"
+#endif // ZE_SRGB_EXT_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief sRGB Extension Version(s)
+typedef enum _ze_srgb_ext_version_t
+{
+    ZE_SRGB_EXT_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),                      ///< version 1.0
+    ZE_SRGB_EXT_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),                  ///< latest known version
+    ZE_SRGB_EXT_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} ze_srgb_ext_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief sRGB image descriptor
+/// 
+/// @details
+///     - This structure may be passed to ::zeImageCreate via the `pNext` member
+///       of ::ze_image_desc_t
+///     - Used for specifying that the image is in sRGB format.
+typedef struct _ze_srgb_ext_desc_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_bool_t sRGB;                                                         ///< [in] Is sRGB.
+
+} ze_srgb_ext_desc_t;
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Extension APIs for Image Copy To/From Memory
+#if !defined(__GNUC__)
+#pragma region imageCopy
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_IMAGE_COPY_EXT_NAME
+/// @brief Image Copy Extension Name
+#define ZE_IMAGE_COPY_EXT_NAME  "ZE_extension_image_copy"
+#endif // ZE_IMAGE_COPY_EXT_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Image Copy Extension Version(s)
+typedef enum _ze_image_copy_ext_version_t
+{
+    ZE_IMAGE_COPY_EXT_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),                ///< version 1.0
+    ZE_IMAGE_COPY_EXT_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),            ///< latest known version
+    ZE_IMAGE_COPY_EXT_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} ze_image_copy_ext_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Copies from an image to device or shared memory.
+/// 
+/// @details
+///     - The application must ensure the memory pointed to by dstptr is
+///       accessible by the device on which the command list was created.
+///     - The implementation must not access the memory pointed to by dstptr as
+///       it is free to be modified by either the Host or device up until
+///       execution.
+///     - The application must ensure the image and events are accessible by the
+///       device on which the command list was created.
+///     - The application must ensure the image format descriptor for the source
+///       image is a single-planar format.
+///     - The application must ensure that the rowPitch is set to 0 if image is
+///       a 1D image. Otherwise the rowPitch must be greater than or equal to
+///       the element size in bytes x width.
+///     - If rowPitch is set to 0, the appropriate row pitch is calculated based
+///       on the size of each element in bytes multiplied by width
+///     - The application must ensure that the slicePitch is set to 0 if image
+///       is a 1D or 2D image. Otherwise this value must be greater than or
+///       equal to rowPitch x height.
+///     - If slicePitch is set to 0, the appropriate slice pitch is calculated
+///       based on the rowPitch x height.
+///     - The application must ensure the command list, image and events were
+///       created, and the memory was allocated, on the same context.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same command list handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @remarks
+///   _Analogues_
+///     - clEnqueueReadImage
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandList`
+///         + `nullptr == hSrcImage`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == dstptr`
+///     - ::ZE_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT
+///     - ::ZE_RESULT_ERROR_INVALID_SIZE
+///         + `(nullptr == phWaitEvents) && (0 < numWaitEvents)`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandListAppendImageCopyToMemoryExt(
+    ze_command_list_handle_t hCommandList,                                  ///< [in] handle of command list
+    void* dstptr,                                                           ///< [in] pointer to destination memory to copy to
+    ze_image_handle_t hSrcImage,                                            ///< [in] handle of source image to copy from
+    const ze_image_region_t* pSrcRegion,                                    ///< [in][optional] source region descriptor
+    uint32_t destRowPitch,                                                  ///< [in] size in bytes of the 1D slice of the 2D region of a 2D or 3D
+                                                                            ///< image or each image of a 1D or 2D image array being written
+    uint32_t destSlicePitch,                                                ///< [in] size in bytes of the 2D slice of the 3D region of a 3D image or
+                                                                            ///< each image of a 1D or 2D image array being written
+    ze_event_handle_t hSignalEvent,                                         ///< [in][optional] handle of the event to signal on completion
+    uint32_t numWaitEvents,                                                 ///< [in][optional] number of events to wait on before launching; must be 0
+                                                                            ///< if `nullptr == phWaitEvents`
+    ze_event_handle_t* phWaitEvents                                         ///< [in][optional][range(0, numWaitEvents)] handle of the events to wait
+                                                                            ///< on before launching
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Copies to an image from device or shared memory.
+/// 
+/// @details
+///     - The application must ensure the memory pointed to by srcptr is
+///       accessible by the device on which the command list was created.
+///     - The implementation must not access the memory pointed to by srcptr as
+///       it is free to be modified by either the Host or device up until
+///       execution.
+///     - The application must ensure the image and events are accessible by the
+///       device on which the command list was created.
+///     - The application must ensure the image format descriptor for the
+///       destination image is a single-planar format.
+///     - The application must ensure that the rowPitch is set to 0 if image is
+///       a 1D image. Otherwise the rowPitch must be greater than or equal to
+///       the element size in bytes x width.
+///     - If rowPitch is set to 0, the appropriate row pitch is calculated based
+///       on the size of each element in bytes multiplied by width
+///     - The application must ensure that the slicePitch is set to 0 if image
+///       is a 1D or 2D image. Otherwise this value must be greater than or
+///       equal to rowPitch x height.
+///     - If slicePitch is set to 0, the appropriate slice pitch is calculated
+///       based on the rowPitch x height.
+///     - The application must ensure the command list, image and events were
+///       created, and the memory was allocated, on the same context.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same command list handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @remarks
+///   _Analogues_
+///     - clEnqueueWriteImage
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandList`
+///         + `nullptr == hDstImage`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == srcptr`
+///     - ::ZE_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT
+///     - ::ZE_RESULT_ERROR_INVALID_SIZE
+///         + `(nullptr == phWaitEvents) && (0 < numWaitEvents)`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandListAppendImageCopyFromMemoryExt(
+    ze_command_list_handle_t hCommandList,                                  ///< [in] handle of command list
+    ze_image_handle_t hDstImage,                                            ///< [in] handle of destination image to copy to
+    const void* srcptr,                                                     ///< [in] pointer to source memory to copy from
+    const ze_image_region_t* pDstRegion,                                    ///< [in][optional] destination region descriptor
+    uint32_t srcRowPitch,                                                   ///< [in] size in bytes of the 1D slice of the 2D region of a 2D or 3D
+                                                                            ///< image or each image of a 1D or 2D image array being read
+    uint32_t srcSlicePitch,                                                 ///< [in] size in bytes of the 2D slice of the 3D region of a 3D image or
+                                                                            ///< each image of a 1D or 2D image array being read
+    ze_event_handle_t hSignalEvent,                                         ///< [in][optional] handle of the event to signal on completion
+    uint32_t numWaitEvents,                                                 ///< [in][optional] number of events to wait on before launching; must be 0
+                                                                            ///< if `nullptr == phWaitEvents`
+    ze_event_handle_t* phWaitEvents                                         ///< [in][optional][range(0, numWaitEvents)] handle of the events to wait
+                                                                            ///< on before launching
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Extension for Querying Image Allocation Properties.
+#if !defined(__GNUC__)
+#pragma region imageQueryAllocProperties
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_IMAGE_QUERY_ALLOC_PROPERTIES_EXT_NAME
+/// @brief Image Query Allocation Properties Extension Name
+#define ZE_IMAGE_QUERY_ALLOC_PROPERTIES_EXT_NAME  "ZE_extension_image_query_alloc_properties"
+#endif // ZE_IMAGE_QUERY_ALLOC_PROPERTIES_EXT_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Image Query Allocation Properties Extension Version(s)
+typedef enum _ze_image_query_alloc_properties_ext_version_t
+{
+    ZE_IMAGE_QUERY_ALLOC_PROPERTIES_EXT_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),  ///< version 1.0
+    ZE_IMAGE_QUERY_ALLOC_PROPERTIES_EXT_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),  ///< latest known version
+    ZE_IMAGE_QUERY_ALLOC_PROPERTIES_EXT_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} ze_image_query_alloc_properties_ext_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Image allocation properties queried using
+///        ::zeImageGetAllocPropertiesExt
+typedef struct _ze_image_allocation_ext_properties_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    uint64_t id;                                                            ///< [out] identifier for this allocation
+
+} ze_image_allocation_ext_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves attributes of an image allocation
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+///         + `nullptr == hImage`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pImageAllocProperties`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeImageGetAllocPropertiesExt(
+    ze_context_handle_t hContext,                                           ///< [in] handle of the context object
+    ze_image_handle_t hImage,                                               ///< [in] handle of image object to query
+    ze_image_allocation_ext_properties_t* pImageAllocProperties             ///< [in,out] query result for image allocation properties
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Extension APIs for Linkage Inspection
+#if !defined(__GNUC__)
+#pragma region linkageInspection
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_LINKAGE_INSPECTION_EXT_NAME
+/// @brief Linkage Inspection Extension Name
+#define ZE_LINKAGE_INSPECTION_EXT_NAME  "ZE_extension_linkage_inspection"
+#endif // ZE_LINKAGE_INSPECTION_EXT_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Linkage Inspection Extension Version(s)
+typedef enum _ze_linkage_inspection_ext_version_t
+{
+    ZE_LINKAGE_INSPECTION_EXT_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),        ///< version 1.0
+    ZE_LINKAGE_INSPECTION_EXT_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),    ///< latest known version
+    ZE_LINKAGE_INSPECTION_EXT_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} ze_linkage_inspection_ext_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported module linkage inspection flags
+typedef uint32_t ze_linkage_inspection_ext_flags_t;
+typedef enum _ze_linkage_inspection_ext_flag_t
+{
+    ZE_LINKAGE_INSPECTION_EXT_FLAG_IMPORTS = ZE_BIT(0),                     ///< List all imports of modules
+    ZE_LINKAGE_INSPECTION_EXT_FLAG_UNRESOLVABLE_IMPORTS = ZE_BIT(1),        ///< List all imports of modules that do not have a corresponding export
+    ZE_LINKAGE_INSPECTION_EXT_FLAG_EXPORTS = ZE_BIT(2),                     ///< List all exports of modules
+    ZE_LINKAGE_INSPECTION_EXT_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_linkage_inspection_ext_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Module linkage inspection descriptor
+/// 
+/// @details
+///     - This structure may be passed to ::zeModuleInspectLinkageExt.
+typedef struct _ze_linkage_inspection_ext_desc_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_linkage_inspection_ext_flags_t flags;                                ///< [in] flags specifying module linkage inspection.
+                                                                            ///< must be 0 (default) or a valid combination of ::ze_linkage_inspection_ext_flag_t.
+
+} ze_linkage_inspection_ext_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief List Imports & Exports
+/// 
+/// @details
+///     - List all the import & unresolveable import dependencies & exports of a
+///       set of modules
+/// 
+/// @remarks
+///   _Analogues_
+///     - None
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pInspectDesc`
+///         + `nullptr == phModules`
+///         + `nullptr == phLog`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `0x7 < pInspectDesc->flags`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeModuleInspectLinkageExt(
+    ze_linkage_inspection_ext_desc_t* pInspectDesc,                         ///< [in] pointer to linkage inspection descriptor structure.
+    uint32_t numModules,                                                    ///< [in] number of modules to be inspected pointed to by phModules.
+    ze_module_handle_t* phModules,                                          ///< [in][range(0, numModules)] pointer to an array of modules to be
+                                                                            ///< inspected for import dependencies.
+    ze_module_build_log_handle_t* phLog                                     ///< [out] pointer to handle of linkage inspection log. Log object will
+                                                                            ///< contain separate lists of imports, un-resolvable imports, and exports.
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Extension for supporting memory compression hints.
+#if !defined(__GNUC__)
+#pragma region memoryCompressionHints
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_MEMORY_COMPRESSION_HINTS_EXT_NAME
+/// @brief Memory Compression Hints Extension Name
+#define ZE_MEMORY_COMPRESSION_HINTS_EXT_NAME  "ZE_extension_memory_compression_hints"
+#endif // ZE_MEMORY_COMPRESSION_HINTS_EXT_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Memory Compression Hints Extension Version(s)
+typedef enum _ze_memory_compression_hints_ext_version_t
+{
+    ZE_MEMORY_COMPRESSION_HINTS_EXT_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),  ///< version 1.0
+    ZE_MEMORY_COMPRESSION_HINTS_EXT_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),  ///< latest known version
+    ZE_MEMORY_COMPRESSION_HINTS_EXT_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} ze_memory_compression_hints_ext_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported memory compression hints flags
+typedef uint32_t ze_memory_compression_hints_ext_flags_t;
+typedef enum _ze_memory_compression_hints_ext_flag_t
+{
+    ZE_MEMORY_COMPRESSION_HINTS_EXT_FLAG_COMPRESSED = ZE_BIT(0),            ///< Hint Driver implementation to make allocation compressible
+    ZE_MEMORY_COMPRESSION_HINTS_EXT_FLAG_UNCOMPRESSED = ZE_BIT(1),          ///< Hint Driver implementation to make allocation not compressible
+    ZE_MEMORY_COMPRESSION_HINTS_EXT_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_memory_compression_hints_ext_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Compression hints memory allocation descriptor
+/// 
+/// @details
+///     - This structure may be passed to ::zeMemAllocShared or
+///       ::zeMemAllocDevice, via the `pNext` member of
+///       ::ze_device_mem_alloc_desc_t.
+///     - This structure may be passed to ::zeMemAllocHost, via the `pNext`
+///       member of ::ze_host_mem_alloc_desc_t.
+///     - This structure may be passed to ::zeImageCreate, via the `pNext`
+///       member of ::ze_image_desc_t.
+typedef struct _ze_memory_compression_hints_ext_desc_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_memory_compression_hints_ext_flags_t flags;                          ///< [in] flags specifying if allocation should be compressible or not.
+                                                                            ///< Must be set to one of the ::ze_memory_compression_hints_ext_flag_t;
+
+} ze_memory_compression_hints_ext_desc_t;
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Extension APIs for Memory Free Policies
+#if !defined(__GNUC__)
+#pragma region memoryFreePolicies
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_MEMORY_FREE_POLICIES_EXT_NAME
+/// @brief Memory Free Policies Extension Name
+#define ZE_MEMORY_FREE_POLICIES_EXT_NAME  "ZE_extension_memory_free_policies"
+#endif // ZE_MEMORY_FREE_POLICIES_EXT_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Memory Free Policies Extension Version(s)
+typedef enum _ze_memory_free_policies_ext_version_t
+{
+    ZE_MEMORY_FREE_POLICIES_EXT_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),      ///< version 1.0
+    ZE_MEMORY_FREE_POLICIES_EXT_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),  ///< latest known version
+    ZE_MEMORY_FREE_POLICIES_EXT_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} ze_memory_free_policies_ext_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported memory free policy capability flags
+typedef uint32_t ze_driver_memory_free_policy_ext_flags_t;
+typedef enum _ze_driver_memory_free_policy_ext_flag_t
+{
+    ZE_DRIVER_MEMORY_FREE_POLICY_EXT_FLAG_BLOCKING_FREE = ZE_BIT(0),        ///< blocks until all commands using the memory are complete before freeing
+    ZE_DRIVER_MEMORY_FREE_POLICY_EXT_FLAG_DEFER_FREE = ZE_BIT(1),           ///< schedules the memory to be freed but does not free immediately
+    ZE_DRIVER_MEMORY_FREE_POLICY_EXT_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_driver_memory_free_policy_ext_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Driver memory free properties queried using ::zeDriverGetProperties
+/// 
+/// @details
+///     - All drivers must support an immediate free policy, which is the
+///       default free policy.
+///     - This structure may be returned from ::zeDriverGetProperties, via the
+///       `pNext` member of ::ze_driver_properties_t.
+typedef struct _ze_driver_memory_free_ext_properties_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_driver_memory_free_policy_ext_flags_t freePolicies;                  ///< [out] Supported memory free policies.
+                                                                            ///< must be 0 or a combination of ::ze_driver_memory_free_policy_ext_flag_t.
+
+} ze_driver_memory_free_ext_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Memory free descriptor with free policy
+typedef struct _ze_memory_free_ext_desc_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_driver_memory_free_policy_ext_flags_t freePolicy;                    ///< [in] flags specifying the memory free policy.
+                                                                            ///< must be 0 (default) or a supported ::ze_driver_memory_free_policy_ext_flag_t;
+                                                                            ///< default behavior is to free immediately.
+
+} ze_memory_free_ext_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Frees allocated host memory, device memory, or shared memory using the
+///        specified free policy.
+/// 
+/// @details
+///     - The memory free policy is specified by the memory free descriptor.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same pointer.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pMemFreeDesc`
+///         + `nullptr == ptr`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `0x3 < pMemFreeDesc->freePolicy`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeMemFreeExt(
+    ze_context_handle_t hContext,                                           ///< [in] handle of the context object
+    const ze_memory_free_ext_desc_t* pMemFreeDesc,                          ///< [in] pointer to memory free descriptor
+    void* ptr                                                               ///< [in][release] pointer to memory to free
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Extension APIs for Bandwidth
+#if !defined(__GNUC__)
+#pragma region bandwidth
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_BANDWIDTH_PROPERTIES_EXP_NAME
+/// @brief Bandwidth Extension Name
+#define ZE_BANDWIDTH_PROPERTIES_EXP_NAME  "ZE_experimental_bandwidth_properties"
+#endif // ZE_BANDWIDTH_PROPERTIES_EXP_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief P2P Bandwidth Properties
+/// 
+/// @details
+///     - This structure may be passed to ::zeDeviceGetP2PProperties by having
+///       the pNext member of ::ze_device_p2p_properties_t point at this struct.
+typedef struct _ze_device_p2p_bandwidth_exp_properties_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    uint32_t logicalBandwidth;                                              ///< [out] total logical design bandwidth for all links connecting the two
+                                                                            ///< devices
+    uint32_t physicalBandwidth;                                             ///< [out] total physical design bandwidth for all links connecting the two
+                                                                            ///< devices
+    ze_bandwidth_unit_t bandwidthUnit;                                      ///< [out] bandwidth unit
+    uint32_t logicalLatency;                                                ///< [out] average logical design latency for all links connecting the two
+                                                                            ///< devices
+    uint32_t physicalLatency;                                               ///< [out] average physical design latency for all links connecting the two
+                                                                            ///< devices
+    ze_latency_unit_t latencyUnit;                                          ///< [out] latency unit
+
+} ze_device_p2p_bandwidth_exp_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Copy Bandwidth Properties
+/// 
+/// @details
+///     - This structure may be passed to
+///       ::zeDeviceGetCommandQueueGroupProperties by having the pNext member of
+///       ::ze_command_queue_group_properties_t point at this struct.
+typedef struct _ze_copy_bandwidth_exp_properties_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    uint32_t copyBandwidth;                                                 ///< [out] design bandwidth supported by this engine type for copy
+                                                                            ///< operations
+    ze_bandwidth_unit_t copyBandwidthUnit;                                  ///< [out] copy bandwidth unit
+
+} ze_copy_bandwidth_exp_properties_t;
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Extension APIs for Device Local Identifier (LUID)
+#if !defined(__GNUC__)
+#pragma region deviceLUID
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_DEVICE_LUID_EXT_NAME
+/// @brief Device Local Identifier (LUID) Extension Name
+#define ZE_DEVICE_LUID_EXT_NAME  "ZE_extension_device_luid"
+#endif // ZE_DEVICE_LUID_EXT_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Device Local Identifier (LUID) Extension Version(s)
+typedef enum _ze_device_luid_ext_version_t
+{
+    ZE_DEVICE_LUID_EXT_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),               ///< version 1.0
+    ZE_DEVICE_LUID_EXT_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),           ///< latest known version
+    ZE_DEVICE_LUID_EXT_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} ze_device_luid_ext_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_MAX_DEVICE_LUID_SIZE_EXT
+/// @brief Maximum device local identifier (LUID) size in bytes
+#define ZE_MAX_DEVICE_LUID_SIZE_EXT  8
+#endif // ZE_MAX_DEVICE_LUID_SIZE_EXT
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Device local identifier (LUID)
+typedef struct _ze_device_luid_ext_t
+{
+    uint8_t id[ZE_MAX_DEVICE_LUID_SIZE_EXT];                                ///< [out] opaque data representing a device LUID
+
+} ze_device_luid_ext_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Device LUID properties queried using ::zeDeviceGetProperties
+/// 
+/// @details
+///     - This structure may be returned from ::zeDeviceGetProperties, via the
+///       `pNext` member of ::ze_device_properties_t.
+typedef struct _ze_device_luid_ext_properties_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_device_luid_ext_t luid;                                              ///< [out] locally unique identifier (LUID).
+                                                                            ///< The returned LUID can be cast to a LUID object and must be equal to
+                                                                            ///< the locally
+                                                                            ///< unique identifier of an IDXGIAdapter1 object that corresponds to the device.
+    uint32_t nodeMask;                                                      ///< [out] node mask.
+                                                                            ///< The returned node mask must contain exactly one bit.
+                                                                            ///< If the device is running on an operating system that supports the
+                                                                            ///< Direct3D 12 API
+                                                                            ///< and the device corresponds to an individual device in a linked device
+                                                                            ///< adapter, the
+                                                                            ///< returned node mask identifies the Direct3D 12 node corresponding to
+                                                                            ///< the device.
+                                                                            ///< Otherwise, the returned node mask must be 1.
+
+} ze_device_luid_ext_properties_t;
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Extension APIs for Fabric Topology Discovery
+#if !defined(__GNUC__)
+#pragma region fabric
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_FABRIC_EXP_NAME
+/// @brief Fabric Topology Discovery Extension Name
+#define ZE_FABRIC_EXP_NAME  "ZE_experimental_fabric"
+#endif // ZE_FABRIC_EXP_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_MAX_FABRIC_EDGE_MODEL_EXP_SIZE
+/// @brief Maximum fabric edge model string size
+#define ZE_MAX_FABRIC_EDGE_MODEL_EXP_SIZE  256
+#endif // ZE_MAX_FABRIC_EDGE_MODEL_EXP_SIZE
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Fabric Vertex types
+typedef enum _ze_fabric_vertex_exp_type_t
+{
+    ZE_FABRIC_VERTEX_EXP_TYPE_UNKNOWN = 0,                                  ///< Fabric vertex type is unknown
+    ZE_FABRIC_VERTEX_EXP_TYPE_DEVICE = 1,                                   ///< Fabric vertex represents a device
+    ZE_FABRIC_VERTEX_EXP_TYPE_SUBDEVICE = 2,                                ///< Fabric vertex represents a subdevice
+    ZE_FABRIC_VERTEX_EXP_TYPE_SWITCH = 3,                                   ///< Fabric vertex represents a switch
+    ZE_FABRIC_VERTEX_EXP_TYPE_FORCE_UINT32 = 0x7fffffff
+
+} ze_fabric_vertex_exp_type_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Fabric edge duplexity
+typedef enum _ze_fabric_edge_exp_duplexity_t
+{
+    ZE_FABRIC_EDGE_EXP_DUPLEXITY_UNKNOWN = 0,                               ///< Fabric edge duplexity is unknown
+    ZE_FABRIC_EDGE_EXP_DUPLEXITY_HALF_DUPLEX = 1,                           ///< Fabric edge is half duplex, i.e. stated bandwidth is obtained in only
+                                                                            ///< one direction at time
+    ZE_FABRIC_EDGE_EXP_DUPLEXITY_FULL_DUPLEX = 2,                           ///< Fabric edge is full duplex, i.e. stated bandwidth is supported in both
+                                                                            ///< directions simultaneously
+    ZE_FABRIC_EDGE_EXP_DUPLEXITY_FORCE_UINT32 = 0x7fffffff
+
+} ze_fabric_edge_exp_duplexity_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief PCI address
+/// 
+/// @details
+///     - A PCI BDF address is the bus:device:function address of the device and
+///       is useful for locating the device in the PCI switch fabric.
+typedef struct _ze_fabric_vertex_pci_exp_address_t
+{
+    uint32_t domain;                                                        ///< [out] PCI domain number
+    uint32_t bus;                                                           ///< [out] PCI BDF bus number
+    uint32_t device;                                                        ///< [out] PCI BDF device number
+    uint32_t function;                                                      ///< [out] PCI BDF function number
+
+} ze_fabric_vertex_pci_exp_address_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Fabric Vertex properties
+typedef struct _ze_fabric_vertex_exp_properties_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_uuid_t uuid;                                                         ///< [out] universal unique identifier. If the vertex is co-located with a
+                                                                            ///< device/subdevice, then this uuid will match that of the corresponding
+                                                                            ///< device/subdevice
+    ze_fabric_vertex_exp_type_t type;                                       ///< [out] does the fabric vertex represent a device, subdevice, or switch?
+    ze_bool_t remote;                                                       ///< [out] does the fabric vertex live on the local node or on a remote
+                                                                            ///< node?
+    ze_fabric_vertex_pci_exp_address_t address;                             ///< [out] B/D/F address of fabric vertex & associated device/subdevice if
+                                                                            ///< available
+
+} ze_fabric_vertex_exp_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Fabric Edge properties
+typedef struct _ze_fabric_edge_exp_properties_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_uuid_t uuid;                                                         ///< [out] universal unique identifier.
+    char model[ZE_MAX_FABRIC_EDGE_MODEL_EXP_SIZE];                          ///< [out] Description of fabric edge technology. Will be set to the string
+                                                                            ///< "unkown" if this cannot be determined for this edge
+    uint32_t bandwidth;                                                     ///< [out] design bandwidth
+    ze_bandwidth_unit_t bandwidthUnit;                                      ///< [out] bandwidth unit
+    uint32_t latency;                                                       ///< [out] design latency
+    ze_latency_unit_t latencyUnit;                                          ///< [out] latency unit
+    ze_fabric_edge_exp_duplexity_t duplexity;                               ///< [out] Duplexity of the fabric edge
+
+} ze_fabric_edge_exp_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves fabric vertices within a driver
+/// 
+/// @details
+///     - A fabric vertex represents either a device or a switch connected to
+///       other fabric vertices.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDriver`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeFabricVertexGetExp(
+    ze_driver_handle_t hDriver,                                             ///< [in] handle of the driver instance
+    uint32_t* pCount,                                                       ///< [in,out] pointer to the number of fabric vertices.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of fabric vertices available.
+                                                                            ///< if count is greater than the number of fabric vertices available, then
+                                                                            ///< the driver shall update the value with the correct number of fabric
+                                                                            ///< vertices available.
+    ze_fabric_vertex_handle_t* phVertices                                   ///< [in,out][optional][range(0, *pCount)] array of handle of fabric vertices.
+                                                                            ///< if count is less than the number of fabric vertices available, then
+                                                                            ///< driver shall only retrieve that number of fabric vertices.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves a fabric sub-vertex from a fabric vertex
+/// 
+/// @details
+///     - Multiple calls to this function will return identical fabric vertex
+///       handles, in the same order.
+///     - The number of handles returned from this function is affected by the
+///       ::ZE_AFFINITY_MASK environment variable.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hVertex`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeFabricVertexGetSubVerticesExp(
+    ze_fabric_vertex_handle_t hVertex,                                      ///< [in] handle of the fabric vertex object
+    uint32_t* pCount,                                                       ///< [in,out] pointer to the number of sub-vertices.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of sub-vertices available.
+                                                                            ///< if count is greater than the number of sub-vertices available, then
+                                                                            ///< the driver shall update the value with the correct number of
+                                                                            ///< sub-vertices available.
+    ze_fabric_vertex_handle_t* phSubvertices                                ///< [in,out][optional][range(0, *pCount)] array of handle of sub-vertices.
+                                                                            ///< if count is less than the number of sub-vertices available, then
+                                                                            ///< driver shall only retrieve that number of sub-vertices.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves properties of the fabric vertex.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hVertex`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pVertexProperties`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeFabricVertexGetPropertiesExp(
+    ze_fabric_vertex_handle_t hVertex,                                      ///< [in] handle of the fabric vertex
+    ze_fabric_vertex_exp_properties_t* pVertexProperties                    ///< [in,out] query result for fabric vertex properties
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Returns device handle from fabric vertex handle.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hVertex`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == phDevice`
+///     - ::ZE_RESULT_EXP_ERROR_VERTEX_IS_NOT_DEVICE
+///         + Provided fabric vertex handle does not correspond to a device or subdevice.
+///     - ::ZE_RESULT_EXP_ERROR_REMOTE_DEVICE
+///         + Provided fabric vertex handle corresponds to remote device or subdevice.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeFabricVertexGetDeviceExp(
+    ze_fabric_vertex_handle_t hVertex,                                      ///< [in] handle of the fabric vertex
+    ze_device_handle_t* phDevice                                            ///< [out] device handle corresponding to fabric vertex
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Returns fabric vertex handle from device handle.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == phVertex`
+///     - ::ZE_RESULT_EXP_ERROR_DEVICE_IS_NOT_VERTEX
+///         + Provided device handle does not correspond to a fabric vertex.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeDeviceGetFabricVertexExp(
+    ze_device_handle_t hDevice,                                             ///< [in] handle of the device
+    ze_fabric_vertex_handle_t* phVertex                                     ///< [out] fabric vertex handle corresponding to device
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves all fabric edges between provided pair of fabric vertices
+/// 
+/// @details
+///     - A fabric edge represents one or more physical links between two fabric
+///       vertices.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hVertexA`
+///         + `nullptr == hVertexB`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeFabricEdgeGetExp(
+    ze_fabric_vertex_handle_t hVertexA,                                     ///< [in] handle of first fabric vertex instance
+    ze_fabric_vertex_handle_t hVertexB,                                     ///< [in] handle of second fabric vertex instance
+    uint32_t* pCount,                                                       ///< [in,out] pointer to the number of fabric edges.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of fabric edges available.
+                                                                            ///< if count is greater than the number of fabric edges available, then
+                                                                            ///< the driver shall update the value with the correct number of fabric
+                                                                            ///< edges available.
+    ze_fabric_edge_handle_t* phEdges                                        ///< [in,out][optional][range(0, *pCount)] array of handle of fabric edges.
+                                                                            ///< if count is less than the number of fabric edges available, then
+                                                                            ///< driver shall only retrieve that number of fabric edges.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves fabric vertices connected by a fabric edge
+/// 
+/// @details
+///     - A fabric vertex represents either a device or a switch connected to
+///       other fabric vertices via a fabric edge.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hEdge`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == phVertexA`
+///         + `nullptr == phVertexB`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeFabricEdgeGetVerticesExp(
+    ze_fabric_edge_handle_t hEdge,                                          ///< [in] handle of the fabric edge instance
+    ze_fabric_vertex_handle_t* phVertexA,                                   ///< [out] fabric vertex connected to one end of the given fabric edge.
+    ze_fabric_vertex_handle_t* phVertexB                                    ///< [out] fabric vertex connected to other end of the given fabric edge.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves properties of the fabric edge.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hEdge`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pEdgeProperties`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeFabricEdgeGetPropertiesExp(
+    ze_fabric_edge_handle_t hEdge,                                          ///< [in] handle of the fabric edge
+    ze_fabric_edge_exp_properties_t* pEdgeProperties                        ///< [in,out] query result for fabric edge properties
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Extension APIs for Device Memory Properties
+#if !defined(__GNUC__)
+#pragma region memoryProperties
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_DEVICE_MEMORY_PROPERTIES_EXT_NAME
+/// @brief Device Memory Properties Extension Name
+#define ZE_DEVICE_MEMORY_PROPERTIES_EXT_NAME  "ZE_extension_device_memory_properties"
+#endif // ZE_DEVICE_MEMORY_PROPERTIES_EXT_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Device Memory Properties Extension Version(s)
+typedef enum _ze_device_memory_properties_ext_version_t
+{
+    ZE_DEVICE_MEMORY_PROPERTIES_EXT_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),  ///< version 1.0
+    ZE_DEVICE_MEMORY_PROPERTIES_EXT_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),  ///< latest known version
+    ZE_DEVICE_MEMORY_PROPERTIES_EXT_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} ze_device_memory_properties_ext_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Memory module types
+typedef enum _ze_device_memory_ext_type_t
+{
+    ZE_DEVICE_MEMORY_EXT_TYPE_HBM = 0,                                      ///< HBM memory
+    ZE_DEVICE_MEMORY_EXT_TYPE_HBM2 = 1,                                     ///< HBM2 memory
+    ZE_DEVICE_MEMORY_EXT_TYPE_DDR = 2,                                      ///< DDR memory
+    ZE_DEVICE_MEMORY_EXT_TYPE_DDR2 = 3,                                     ///< DDR2 memory
+    ZE_DEVICE_MEMORY_EXT_TYPE_DDR3 = 4,                                     ///< DDR3 memory
+    ZE_DEVICE_MEMORY_EXT_TYPE_DDR4 = 5,                                     ///< DDR4 memory
+    ZE_DEVICE_MEMORY_EXT_TYPE_DDR5 = 6,                                     ///< DDR5 memory
+    ZE_DEVICE_MEMORY_EXT_TYPE_LPDDR = 7,                                    ///< LPDDR memory
+    ZE_DEVICE_MEMORY_EXT_TYPE_LPDDR3 = 8,                                   ///< LPDDR3 memory
+    ZE_DEVICE_MEMORY_EXT_TYPE_LPDDR4 = 9,                                   ///< LPDDR4 memory
+    ZE_DEVICE_MEMORY_EXT_TYPE_LPDDR5 = 10,                                  ///< LPDDR5 memory
+    ZE_DEVICE_MEMORY_EXT_TYPE_SRAM = 11,                                    ///< SRAM memory
+    ZE_DEVICE_MEMORY_EXT_TYPE_L1 = 12,                                      ///< L1 cache
+    ZE_DEVICE_MEMORY_EXT_TYPE_L3 = 13,                                      ///< L3 cache
+    ZE_DEVICE_MEMORY_EXT_TYPE_GRF = 14,                                     ///< Execution unit register file
+    ZE_DEVICE_MEMORY_EXT_TYPE_SLM = 15,                                     ///< Execution unit shared local memory
+    ZE_DEVICE_MEMORY_EXT_TYPE_GDDR4 = 16,                                   ///< GDDR4 memory
+    ZE_DEVICE_MEMORY_EXT_TYPE_GDDR5 = 17,                                   ///< GDDR5 memory
+    ZE_DEVICE_MEMORY_EXT_TYPE_GDDR5X = 18,                                  ///< GDDR5X memory
+    ZE_DEVICE_MEMORY_EXT_TYPE_GDDR6 = 19,                                   ///< GDDR6 memory
+    ZE_DEVICE_MEMORY_EXT_TYPE_GDDR6X = 20,                                  ///< GDDR6X memory
+    ZE_DEVICE_MEMORY_EXT_TYPE_GDDR7 = 21,                                   ///< GDDR7 memory
+    ZE_DEVICE_MEMORY_EXT_TYPE_FORCE_UINT32 = 0x7fffffff
+
+} ze_device_memory_ext_type_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Memory properties
+/// 
+/// @details
+///     - This structure may be returned from ::zeDeviceGetMemoryProperties via
+///       the `pNext` member of ::ze_device_memory_properties_t
+typedef struct _ze_device_memory_ext_properties_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_device_memory_ext_type_t type;                                       ///< [out] The memory type
+    uint64_t physicalSize;                                                  ///< [out] Physical memory size in bytes. A value of 0 indicates that this
+                                                                            ///< property is not known. However, a call to ::zesMemoryGetState() will
+                                                                            ///< correctly return the total size of usable memory.
+    uint32_t readBandwidth;                                                 ///< [out] Design bandwidth for reads
+    uint32_t writeBandwidth;                                                ///< [out] Design bandwidth for writes
+    ze_bandwidth_unit_t bandwidthUnit;                                      ///< [out] bandwidth unit
+
+} ze_device_memory_ext_properties_t;
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Extension APIs for Bfloat16 Conversions
+#if !defined(__GNUC__)
+#pragma region bfloat16conversions
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_BFLOAT16_CONVERSIONS_EXT_NAME
+/// @brief Bfloat16 Conversions Extension Name
+#define ZE_BFLOAT16_CONVERSIONS_EXT_NAME  "ZE_extension_bfloat16_conversions"
+#endif // ZE_BFLOAT16_CONVERSIONS_EXT_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Bfloat16 Conversions Extension Version(s)
+typedef enum _ze_bfloat16_conversions_ext_version_t
+{
+    ZE_BFLOAT16_CONVERSIONS_EXT_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),      ///< version 1.0
+    ZE_BFLOAT16_CONVERSIONS_EXT_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),  ///< latest known version
+    ZE_BFLOAT16_CONVERSIONS_EXT_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} ze_bfloat16_conversions_ext_version_t;
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Extension APIs for Device IP Version
+#if !defined(__GNUC__)
+#pragma region deviceipversion
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_DEVICE_IP_VERSION_EXT_NAME
+/// @brief Device IP Version Extension Name
+#define ZE_DEVICE_IP_VERSION_EXT_NAME  "ZE_extension_device_ip_version"
+#endif // ZE_DEVICE_IP_VERSION_EXT_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Device IP Version Extension Version(s)
+typedef enum _ze_device_ip_version_version_t
+{
+    ZE_DEVICE_IP_VERSION_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),             ///< version 1.0
+    ZE_DEVICE_IP_VERSION_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),         ///< latest known version
+    ZE_DEVICE_IP_VERSION_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} ze_device_ip_version_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Device IP version queried using ::zeDeviceGetProperties
+/// 
+/// @details
+///     - This structure may be returned from ::zeDeviceGetProperties via the
+///       `pNext` member of ::ze_device_properties_t
+typedef struct _ze_device_ip_version_ext_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    uint32_t ipVersion;                                                     ///< [out] Device IP version. The meaning of the device IP version is
+                                                                            ///< implementation-defined, but newer devices should have a higher
+                                                                            ///< version than older devices.
+
+} ze_device_ip_version_ext_t;
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Extension for querying kernel max group size properties.
+#if !defined(__GNUC__)
+#pragma region kernelMaxGroupSizeProperties
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_KERNEL_MAX_GROUP_SIZE_PROPERTIES_EXT_NAME
+/// @brief Kernel Max Group Size Properties Extension Name
+#define ZE_KERNEL_MAX_GROUP_SIZE_PROPERTIES_EXT_NAME  "ZE_extension_kernel_max_group_size_properties"
+#endif // ZE_KERNEL_MAX_GROUP_SIZE_PROPERTIES_EXT_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Kernel Max Group Size Properties Extension Version(s)
+typedef enum _ze_kernel_max_group_size_properties_ext_version_t
+{
+    ZE_KERNEL_MAX_GROUP_SIZE_PROPERTIES_EXT_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),  ///< version 1.0
+    ZE_KERNEL_MAX_GROUP_SIZE_PROPERTIES_EXT_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),  ///< latest known version
+    ZE_KERNEL_MAX_GROUP_SIZE_PROPERTIES_EXT_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} ze_kernel_max_group_size_properties_ext_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Additional kernel max group size properties
+/// 
+/// @details
+///     - This structure may be passed to ::zeKernelGetProperties, via the
+///       `pNext` member of ::ze_kernel_properties_t, to query additional kernel
+///       max group size properties.
+typedef struct _ze_kernel_max_group_size_properties_ext_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    uint32_t maxGroupSize;                                                  ///< [out] maximum group size that can be used to execute the kernel. This
+                                                                            ///< value may be less than or equal to the `maxTotalGroupSize` member of
+                                                                            ///< ::ze_device_compute_properties_t.
+
+} ze_kernel_max_group_size_properties_ext_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief compiler-independent type
+typedef ze_kernel_max_group_size_properties_ext_t ze_kernel_max_group_size_ext_properties_t;
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Extension for querying sub-allocations properties.
+#if !defined(__GNUC__)
+#pragma region subAllocationsProperties
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_SUB_ALLOCATIONS_EXP_NAME
+/// @brief Sub-Allocations Properties Extension Name
+#define ZE_SUB_ALLOCATIONS_EXP_NAME  "ZE_experimental_sub_allocations"
+#endif // ZE_SUB_ALLOCATIONS_EXP_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Sub-Allocations Properties Extension Version(s)
+typedef enum _ze_sub_allocations_exp_version_t
+{
+    ZE_SUB_ALLOCATIONS_EXP_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),           ///< version 1.0
+    ZE_SUB_ALLOCATIONS_EXP_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),       ///< latest known version
+    ZE_SUB_ALLOCATIONS_EXP_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} ze_sub_allocations_exp_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Properties returned for a sub-allocation
+typedef struct _ze_sub_allocation_t
+{
+    void* base;                                                             ///< [in,out][optional] base address of the sub-allocation
+    size_t size;                                                            ///< [in,out][optional] size of the allocation
+
+} ze_sub_allocation_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Sub-Allocations Properties
+/// 
+/// @details
+///     - This structure may be passed to ::zeMemGetAllocProperties, via the
+///       `pNext` member of ::ze_memory_allocation_properties_t.
+typedef struct _ze_memory_sub_allocations_exp_properties_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    uint32_t* pCount;                                                       ///< [in,out] pointer to the number of sub-allocations.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of sub-allocations on which the allocation has been divided.
+                                                                            ///< if count is greater than the number of sub-allocations, then the
+                                                                            ///< driver shall update the value with the correct number of sub-allocations.
+    ze_sub_allocation_t* pSubAllocations;                                   ///< [in,out][optional][range(0, *pCount)] array of properties for sub-allocations.
+                                                                            ///< if count is less than the number of sub-allocations available, then
+                                                                            ///< driver shall only retrieve properties for that number of sub-allocations.
+
+} ze_memory_sub_allocations_exp_properties_t;
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Extension for supporting the querying of synchronized event timestamps.
+#if !defined(__GNUC__)
+#pragma region eventQueryKernelTimestamps
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_EVENT_QUERY_KERNEL_TIMESTAMPS_EXT_NAME
+/// @brief Event Query Kernel Timestamps Extension Name
+#define ZE_EVENT_QUERY_KERNEL_TIMESTAMPS_EXT_NAME  "ZE_extension_event_query_kernel_timestamps"
+#endif // ZE_EVENT_QUERY_KERNEL_TIMESTAMPS_EXT_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Event Query Kernel Timestamps Extension Version(s)
+typedef enum _ze_event_query_kernel_timestamps_ext_version_t
+{
+    ZE_EVENT_QUERY_KERNEL_TIMESTAMPS_EXT_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ), ///< version 1.0
+    ZE_EVENT_QUERY_KERNEL_TIMESTAMPS_EXT_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ), ///< latest known version
+    ZE_EVENT_QUERY_KERNEL_TIMESTAMPS_EXT_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} ze_event_query_kernel_timestamps_ext_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Event query kernel timestamps flags
+typedef uint32_t ze_event_query_kernel_timestamps_ext_flags_t;
+typedef enum _ze_event_query_kernel_timestamps_ext_flag_t
+{
+    ZE_EVENT_QUERY_KERNEL_TIMESTAMPS_EXT_FLAG_KERNEL = ZE_BIT(0),           ///< Kernel timestamp results
+    ZE_EVENT_QUERY_KERNEL_TIMESTAMPS_EXT_FLAG_SYNCHRONIZED = ZE_BIT(1),     ///< Device event timestamps synchronized to the host time domain
+    ZE_EVENT_QUERY_KERNEL_TIMESTAMPS_EXT_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_event_query_kernel_timestamps_ext_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Event query kernel timestamps properties
+/// 
+/// @details
+///     - This structure may be returned from ::zeDeviceGetProperties, via the
+///       `pNext` member of ::ze_device_properties_t.
+typedef struct _ze_event_query_kernel_timestamps_ext_properties_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_event_query_kernel_timestamps_ext_flags_t flags;                     ///< [out] 0 or some combination of
+                                                                            ///< ::ze_event_query_kernel_timestamps_ext_flag_t flags
+
+} ze_event_query_kernel_timestamps_ext_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Kernel timestamp clock data synchronized to the host time domain
+typedef struct _ze_synchronized_timestamp_data_ext_t
+{
+    uint64_t kernelStart;                                                   ///< [out] synchronized clock at start of kernel execution
+    uint64_t kernelEnd;                                                     ///< [out] synchronized clock at end of kernel execution
+
+} ze_synchronized_timestamp_data_ext_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Synchronized kernel timestamp result
+typedef struct _ze_synchronized_timestamp_result_ext_t
+{
+    ze_synchronized_timestamp_data_ext_t global;                            ///< [out] wall-clock data
+    ze_synchronized_timestamp_data_ext_t context;                           ///< [out] context-active data; only includes clocks while device context
+                                                                            ///< was actively executing.
+
+} ze_synchronized_timestamp_result_ext_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Event query kernel timestamps results properties
+typedef struct _ze_event_query_kernel_timestamps_results_ext_properties_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_kernel_timestamp_result_t* pKernelTimestampsBuffer;                  ///< [in,out][optional][range(0, *pCount)] pointer to destination buffer of
+                                                                            ///< kernel timestamp results
+    ze_synchronized_timestamp_result_ext_t* pSynchronizedTimestampsBuffer;  ///< [in,out][optional][range(0, *pCount)] pointer to destination buffer of
+                                                                            ///< synchronized timestamp results
+
+} ze_event_query_kernel_timestamps_results_ext_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Query an event's timestamp value on the host, with domain preference.
+/// 
+/// @details
+///     - For collecting *only* kernel timestamps, the application must ensure
+///       the event was created from an event pool that was created using
+///       ::ZE_EVENT_POOL_FLAG_KERNEL_TIMESTAMP flag.
+///     - For collecting synchronized timestamps, the application must ensure
+///       the event was created from an event pool that was created using
+///       ::ZE_EVENT_POOL_FLAG_KERNEL_MAPPED_TIMESTAMP flag. Kernel timestamps
+///       are also available from this type of event pool, but there is a
+///       performance cost.
+///     - The destination memory will be unmodified if the event has not been
+///       signaled.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function must be thread-safe.
+///     - The implementation must support
+///       ::ZE_extension_event_query_kernel_timestamps.
+///     - The implementation must return all timestamps for the specified event
+///       and device pair.
+///     - The implementation must return all timestamps for all sub-devices when
+///       device handle is parent device.
+///     - The implementation may return all timestamps for sub-devices when
+///       device handle is sub-device or may return 0 for count.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hEvent`
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeEventQueryKernelTimestampsExt(
+    ze_event_handle_t hEvent,                                               ///< [in] handle of the event
+    ze_device_handle_t hDevice,                                             ///< [in] handle of the device to query
+    uint32_t* pCount,                                                       ///< [in,out] pointer to the number of event packets available.
+                                                                            ///<    - This value is implementation specific.
+                                                                            ///<    - if `*pCount` is zero, then the driver shall update the value with
+                                                                            ///< the total number of event packets available.
+                                                                            ///<    - if `*pCount` is greater than the number of event packets
+                                                                            ///< available, the driver shall update the value with the correct value.
+                                                                            ///<    - Buffer(s) for query results must be sized by the application to
+                                                                            ///< accommodate a minimum of `*pCount` elements.
+    ze_event_query_kernel_timestamps_results_ext_properties_t* pResults     ///< [in,out][optional][range(0, *pCount)] pointer to event query
+                                                                            ///< properties structure(s).
+                                                                            ///<    - This parameter may be null when `*pCount` is zero.
+                                                                            ///<    - if `*pCount` is less than the number of event packets available,
+                                                                            ///< the driver may only update `*pCount` elements, starting at element zero.
+                                                                            ///<    - if `*pCount` is greater than the number of event packets
+                                                                            ///< available, the driver may only update the valid elements.
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Extension for supporting ray tracing acceleration structure builder.
+#if !defined(__GNUC__)
+#pragma region RTASBuilder
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_RTAS_BUILDER_EXP_NAME
+/// @brief Ray Tracing Acceleration Structure Builder Extension Name
+#define ZE_RTAS_BUILDER_EXP_NAME  "ZE_experimental_rtas_builder"
+#endif // ZE_RTAS_BUILDER_EXP_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Ray Tracing Acceleration Structure Builder Extension Version(s)
+typedef enum _ze_rtas_builder_exp_version_t
+{
+    ZE_RTAS_BUILDER_EXP_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),              ///< version 1.0
+    ZE_RTAS_BUILDER_EXP_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),          ///< latest known version
+    ZE_RTAS_BUILDER_EXP_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} ze_rtas_builder_exp_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Ray tracing acceleration structure device flags
+typedef uint32_t ze_rtas_device_exp_flags_t;
+typedef enum _ze_rtas_device_exp_flag_t
+{
+    ZE_RTAS_DEVICE_EXP_FLAG_RESERVED = ZE_BIT(0),                           ///< reserved for future use
+    ZE_RTAS_DEVICE_EXP_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_rtas_device_exp_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Ray tracing acceleration structure format
+/// 
+/// @details
+///     - This is an opaque ray tracing acceleration structure format
+///       identifier.
+typedef enum _ze_rtas_format_exp_t
+{
+    ZE_RTAS_FORMAT_EXP_INVALID = 0,                                         ///< Invalid acceleration structure format
+    ZE_RTAS_FORMAT_EXP_FORCE_UINT32 = 0x7fffffff
+
+} ze_rtas_format_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Ray tracing acceleration structure builder flags
+typedef uint32_t ze_rtas_builder_exp_flags_t;
+typedef enum _ze_rtas_builder_exp_flag_t
+{
+    ZE_RTAS_BUILDER_EXP_FLAG_RESERVED = ZE_BIT(0),                          ///< Reserved for future use
+    ZE_RTAS_BUILDER_EXP_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_rtas_builder_exp_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Ray tracing acceleration structure builder parallel operation flags
+typedef uint32_t ze_rtas_parallel_operation_exp_flags_t;
+typedef enum _ze_rtas_parallel_operation_exp_flag_t
+{
+    ZE_RTAS_PARALLEL_OPERATION_EXP_FLAG_RESERVED = ZE_BIT(0),               ///< Reserved for future use
+    ZE_RTAS_PARALLEL_OPERATION_EXP_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_rtas_parallel_operation_exp_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Ray tracing acceleration structure builder geometry flags
+typedef uint32_t ze_rtas_builder_geometry_exp_flags_t;
+typedef enum _ze_rtas_builder_geometry_exp_flag_t
+{
+    ZE_RTAS_BUILDER_GEOMETRY_EXP_FLAG_NON_OPAQUE = ZE_BIT(0),               ///< non-opaque geometries invoke an any-hit shader
+    ZE_RTAS_BUILDER_GEOMETRY_EXP_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_rtas_builder_geometry_exp_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Packed ray tracing acceleration structure builder geometry flags (see
+///        ::ze_rtas_builder_geometry_exp_flags_t)
+typedef uint8_t ze_rtas_builder_packed_geometry_exp_flags_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Ray tracing acceleration structure builder instance flags
+typedef uint32_t ze_rtas_builder_instance_exp_flags_t;
+typedef enum _ze_rtas_builder_instance_exp_flag_t
+{
+    ZE_RTAS_BUILDER_INSTANCE_EXP_FLAG_TRIANGLE_CULL_DISABLE = ZE_BIT(0),    ///< disables culling of front-facing and back-facing triangles
+    ZE_RTAS_BUILDER_INSTANCE_EXP_FLAG_TRIANGLE_FRONT_COUNTERCLOCKWISE = ZE_BIT(1),  ///< reverses front and back face of triangles
+    ZE_RTAS_BUILDER_INSTANCE_EXP_FLAG_TRIANGLE_FORCE_OPAQUE = ZE_BIT(2),    ///< forces instanced geometry to be opaque, unless ray flag forces it to
+                                                                            ///< be non-opaque
+    ZE_RTAS_BUILDER_INSTANCE_EXP_FLAG_TRIANGLE_FORCE_NON_OPAQUE = ZE_BIT(3),///< forces instanced geometry to be non-opaque, unless ray flag forces it
+                                                                            ///< to be opaque
+    ZE_RTAS_BUILDER_INSTANCE_EXP_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_rtas_builder_instance_exp_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Packed ray tracing acceleration structure builder instance flags (see
+///        ::ze_rtas_builder_instance_exp_flags_t)
+typedef uint8_t ze_rtas_builder_packed_instance_exp_flags_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Ray tracing acceleration structure builder build operation flags
+/// 
+/// @details
+///     - These flags allow the application to tune the acceleration structure
+///       build operation.
+///     - The acceleration structure builder implementation might choose to use
+///       spatial splitting to split large or long primitives into smaller
+///       pieces. This may result in any-hit shaders being invoked multiple
+///       times for non-opaque primitives, unless
+///       ::ZE_RTAS_BUILDER_BUILD_OP_EXP_FLAG_NO_DUPLICATE_ANYHIT_INVOCATION is specified.
+///     - Usage of any of these flags may reduce ray tracing performance.
+typedef uint32_t ze_rtas_builder_build_op_exp_flags_t;
+typedef enum _ze_rtas_builder_build_op_exp_flag_t
+{
+    ZE_RTAS_BUILDER_BUILD_OP_EXP_FLAG_COMPACT = ZE_BIT(0),                  ///< build more compact acceleration structure
+    ZE_RTAS_BUILDER_BUILD_OP_EXP_FLAG_NO_DUPLICATE_ANYHIT_INVOCATION = ZE_BIT(1),   ///< guarantees single any-hit shader invocation per primitive
+    ZE_RTAS_BUILDER_BUILD_OP_EXP_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_rtas_builder_build_op_exp_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Ray tracing acceleration structure builder build quality hint
+/// 
+/// @details
+///     - Depending on use case different quality modes for acceleration
+///       structure build are supported.
+///     - A low-quality build builds an acceleration structure fast, but at the
+///       cost of some reduction in ray tracing performance. This mode is
+///       recommended for dynamic content, such as animated characters.
+///     - A medium-quality build uses a compromise between build quality and ray
+///       tracing performance. This mode should be used by default.
+///     - Higher ray tracing performance can be achieved by using a high-quality
+///       build, but acceleration structure build performance might be
+///       significantly reduced.
+typedef enum _ze_rtas_builder_build_quality_hint_exp_t
+{
+    ZE_RTAS_BUILDER_BUILD_QUALITY_HINT_EXP_LOW = 0,                         ///< build low-quality acceleration structure (fast)
+    ZE_RTAS_BUILDER_BUILD_QUALITY_HINT_EXP_MEDIUM = 1,                      ///< build medium-quality acceleration structure (slower)
+    ZE_RTAS_BUILDER_BUILD_QUALITY_HINT_EXP_HIGH = 2,                        ///< build high-quality acceleration structure (slow)
+    ZE_RTAS_BUILDER_BUILD_QUALITY_HINT_EXP_FORCE_UINT32 = 0x7fffffff
+
+} ze_rtas_builder_build_quality_hint_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Ray tracing acceleration structure builder geometry type
+typedef enum _ze_rtas_builder_geometry_type_exp_t
+{
+    ZE_RTAS_BUILDER_GEOMETRY_TYPE_EXP_TRIANGLES = 0,                        ///< triangle mesh geometry type
+    ZE_RTAS_BUILDER_GEOMETRY_TYPE_EXP_QUADS = 1,                            ///< quad mesh geometry type
+    ZE_RTAS_BUILDER_GEOMETRY_TYPE_EXP_PROCEDURAL = 2,                       ///< procedural geometry type
+    ZE_RTAS_BUILDER_GEOMETRY_TYPE_EXP_INSTANCE = 3,                         ///< instance geometry type
+    ZE_RTAS_BUILDER_GEOMETRY_TYPE_EXP_FORCE_UINT32 = 0x7fffffff
+
+} ze_rtas_builder_geometry_type_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Packed ray tracing acceleration structure builder geometry type (see
+///        ::ze_rtas_builder_geometry_type_exp_t)
+typedef uint8_t ze_rtas_builder_packed_geometry_type_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Ray tracing acceleration structure data buffer element format
+/// 
+/// @details
+///     - Specifies the format of data buffer elements.
+///     - Data buffers may contain instancing transform matrices, triangle/quad
+///       vertex indices, etc...
+typedef enum _ze_rtas_builder_input_data_format_exp_t
+{
+    ZE_RTAS_BUILDER_INPUT_DATA_FORMAT_EXP_FLOAT3 = 0,                       ///< 3-component float vector (see ::ze_rtas_float3_exp_t)
+    ZE_RTAS_BUILDER_INPUT_DATA_FORMAT_EXP_FLOAT3X4_COLUMN_MAJOR = 1,        ///< 3x4 affine transformation in column-major format (see
+                                                                            ///< ::ze_rtas_transform_float3x4_column_major_exp_t)
+    ZE_RTAS_BUILDER_INPUT_DATA_FORMAT_EXP_FLOAT3X4_ALIGNED_COLUMN_MAJOR = 2,///< 3x4 affine transformation in column-major format (see
+                                                                            ///< ::ze_rtas_transform_float3x4_aligned_column_major_exp_t)
+    ZE_RTAS_BUILDER_INPUT_DATA_FORMAT_EXP_FLOAT3X4_ROW_MAJOR = 3,           ///< 3x4 affine transformation in row-major format (see
+                                                                            ///< ::ze_rtas_transform_float3x4_row_major_exp_t)
+    ZE_RTAS_BUILDER_INPUT_DATA_FORMAT_EXP_AABB = 4,                         ///< 3-dimensional axis-aligned bounding-box (see ::ze_rtas_aabb_exp_t)
+    ZE_RTAS_BUILDER_INPUT_DATA_FORMAT_EXP_TRIANGLE_INDICES_UINT32 = 5,      ///< Unsigned 32-bit triangle indices (see
+                                                                            ///< ::ze_rtas_triangle_indices_uint32_exp_t)
+    ZE_RTAS_BUILDER_INPUT_DATA_FORMAT_EXP_QUAD_INDICES_UINT32 = 6,          ///< Unsigned 32-bit quad indices (see ::ze_rtas_quad_indices_uint32_exp_t)
+    ZE_RTAS_BUILDER_INPUT_DATA_FORMAT_EXP_FORCE_UINT32 = 0x7fffffff
+
+} ze_rtas_builder_input_data_format_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Packed ray tracing acceleration structure data buffer element format
+///        (see ::ze_rtas_builder_input_data_format_exp_t)
+typedef uint8_t ze_rtas_builder_packed_input_data_format_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle of ray tracing acceleration structure builder object
+typedef struct _ze_rtas_builder_exp_handle_t *ze_rtas_builder_exp_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle of ray tracing acceleration structure builder parallel
+///        operation object
+typedef struct _ze_rtas_parallel_operation_exp_handle_t *ze_rtas_parallel_operation_exp_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Ray tracing acceleration structure builder descriptor
+typedef struct _ze_rtas_builder_exp_desc_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_rtas_builder_exp_version_t builderVersion;                           ///< [in] ray tracing acceleration structure builder version
+
+} ze_rtas_builder_exp_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Ray tracing acceleration structure builder properties
+typedef struct _ze_rtas_builder_exp_properties_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_rtas_builder_exp_flags_t flags;                                      ///< [out] ray tracing acceleration structure builder flags
+    size_t rtasBufferSizeBytesExpected;                                     ///< [out] expected size (in bytes) required for acceleration structure buffer
+                                                                            ///<    - When using an acceleration structure buffer of this size, the
+                                                                            ///< build is expected to succeed; however, it is possible that the build
+                                                                            ///< may fail with ::ZE_RESULT_EXP_RTAS_BUILD_RETRY
+    size_t rtasBufferSizeBytesMaxRequired;                                  ///< [out] worst-case size (in bytes) required for acceleration structure buffer
+                                                                            ///<    - When using an acceleration structure buffer of this size, the
+                                                                            ///< build is guaranteed to not run out of memory.
+    size_t scratchBufferSizeBytes;                                          ///< [out] scratch buffer size (in bytes) required for acceleration
+                                                                            ///< structure build.
+
+} ze_rtas_builder_exp_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Ray tracing acceleration structure builder parallel operation
+///        properties
+typedef struct _ze_rtas_parallel_operation_exp_properties_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_rtas_parallel_operation_exp_flags_t flags;                           ///< [out] ray tracing acceleration structure builder parallel operation
+                                                                            ///< flags
+    uint32_t maxConcurrency;                                                ///< [out] maximum number of threads that may join the parallel operation
+
+} ze_rtas_parallel_operation_exp_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Ray tracing acceleration structure device properties
+/// 
+/// @details
+///     - This structure may be passed to ::zeDeviceGetProperties, via `pNext`
+///       member of ::ze_device_properties_t.
+///     - The implementation shall populate `format` with a value other than
+///       ::ZE_RTAS_FORMAT_EXP_INVALID when the device supports ray tracing.
+typedef struct _ze_rtas_device_exp_properties_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_rtas_device_exp_flags_t flags;                                       ///< [out] ray tracing acceleration structure device flags
+    ze_rtas_format_exp_t rtasFormat;                                        ///< [out] ray tracing acceleration structure format
+    uint32_t rtasBufferAlignment;                                           ///< [out] required alignment of acceleration structure buffer
+
+} ze_rtas_device_exp_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief A 3-component vector type
+typedef struct _ze_rtas_float3_exp_t
+{
+    float x;                                                                ///< [in] x-coordinate of float3 vector
+    float y;                                                                ///< [in] y-coordinate of float3 vector
+    float z;                                                                ///< [in] z-coordinate of float3 vector
+
+} ze_rtas_float3_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief 3x4 affine transformation in column-major layout
+/// 
+/// @details
+///     - A 3x4 affine transformation in column major layout, consisting of vectors
+///          - vx=(vx_x, vx_y, vx_z),
+///          - vy=(vy_x, vy_y, vy_z),
+///          - vz=(vz_x, vz_y, vz_z), and
+///          - p=(p_x, p_y, p_z)
+///     - The transformation transforms a point (x, y, z) to: `x*vx + y*vy +
+///       z*vz + p`.
+typedef struct _ze_rtas_transform_float3x4_column_major_exp_t
+{
+    float vx_x;                                                             ///< [in] element 0 of column 0 of 3x4 matrix
+    float vx_y;                                                             ///< [in] element 1 of column 0 of 3x4 matrix
+    float vx_z;                                                             ///< [in] element 2 of column 0 of 3x4 matrix
+    float vy_x;                                                             ///< [in] element 0 of column 1 of 3x4 matrix
+    float vy_y;                                                             ///< [in] element 1 of column 1 of 3x4 matrix
+    float vy_z;                                                             ///< [in] element 2 of column 1 of 3x4 matrix
+    float vz_x;                                                             ///< [in] element 0 of column 2 of 3x4 matrix
+    float vz_y;                                                             ///< [in] element 1 of column 2 of 3x4 matrix
+    float vz_z;                                                             ///< [in] element 2 of column 2 of 3x4 matrix
+    float p_x;                                                              ///< [in] element 0 of column 3 of 3x4 matrix
+    float p_y;                                                              ///< [in] element 1 of column 3 of 3x4 matrix
+    float p_z;                                                              ///< [in] element 2 of column 3 of 3x4 matrix
+
+} ze_rtas_transform_float3x4_column_major_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief 3x4 affine transformation in column-major layout with aligned column
+///        vectors
+/// 
+/// @details
+///     - A 3x4 affine transformation in column major layout, consisting of vectors
+///        - vx=(vx_x, vx_y, vx_z),
+///        - vy=(vy_x, vy_y, vy_z),
+///        - vz=(vz_x, vz_y, vz_z), and
+///        - p=(p_x, p_y, p_z)
+///     - The transformation transforms a point (x, y, z) to: `x*vx + y*vy +
+///       z*vz + p`.
+///     - The column vectors are aligned to 16-bytes and pad members are
+///       ignored.
+typedef struct _ze_rtas_transform_float3x4_aligned_column_major_exp_t
+{
+    float vx_x;                                                             ///< [in] element 0 of column 0 of 3x4 matrix
+    float vx_y;                                                             ///< [in] element 1 of column 0 of 3x4 matrix
+    float vx_z;                                                             ///< [in] element 2 of column 0 of 3x4 matrix
+    float pad0;                                                             ///< [in] ignored padding
+    float vy_x;                                                             ///< [in] element 0 of column 1 of 3x4 matrix
+    float vy_y;                                                             ///< [in] element 1 of column 1 of 3x4 matrix
+    float vy_z;                                                             ///< [in] element 2 of column 1 of 3x4 matrix
+    float pad1;                                                             ///< [in] ignored padding
+    float vz_x;                                                             ///< [in] element 0 of column 2 of 3x4 matrix
+    float vz_y;                                                             ///< [in] element 1 of column 2 of 3x4 matrix
+    float vz_z;                                                             ///< [in] element 2 of column 2 of 3x4 matrix
+    float pad2;                                                             ///< [in] ignored padding
+    float p_x;                                                              ///< [in] element 0 of column 3 of 3x4 matrix
+    float p_y;                                                              ///< [in] element 1 of column 3 of 3x4 matrix
+    float p_z;                                                              ///< [in] element 2 of column 3 of 3x4 matrix
+    float pad3;                                                             ///< [in] ignored padding
+
+} ze_rtas_transform_float3x4_aligned_column_major_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief 3x4 affine transformation in row-major layout
+/// 
+/// @details
+///     - A 3x4 affine transformation in row-major layout, consisting of vectors
+///          - vx=(vx_x, vx_y, vx_z),
+///          - vy=(vy_x, vy_y, vy_z),
+///          - vz=(vz_x, vz_y, vz_z), and
+///          - p=(p_x, p_y, p_z)
+///     - The transformation transforms a point (x, y, z) to: `x*vx + y*vy +
+///       z*vz + p`.
+typedef struct _ze_rtas_transform_float3x4_row_major_exp_t
+{
+    float vx_x;                                                             ///< [in] element 0 of row 0 of 3x4 matrix
+    float vy_x;                                                             ///< [in] element 1 of row 0 of 3x4 matrix
+    float vz_x;                                                             ///< [in] element 2 of row 0 of 3x4 matrix
+    float p_x;                                                              ///< [in] element 3 of row 0 of 3x4 matrix
+    float vx_y;                                                             ///< [in] element 0 of row 1 of 3x4 matrix
+    float vy_y;                                                             ///< [in] element 1 of row 1 of 3x4 matrix
+    float vz_y;                                                             ///< [in] element 2 of row 1 of 3x4 matrix
+    float p_y;                                                              ///< [in] element 3 of row 1 of 3x4 matrix
+    float vx_z;                                                             ///< [in] element 0 of row 2 of 3x4 matrix
+    float vy_z;                                                             ///< [in] element 1 of row 2 of 3x4 matrix
+    float vz_z;                                                             ///< [in] element 2 of row 2 of 3x4 matrix
+    float p_z;                                                              ///< [in] element 3 of row 2 of 3x4 matrix
+
+} ze_rtas_transform_float3x4_row_major_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief A 3-dimensional axis-aligned bounding-box with lower and upper bounds
+///        in each dimension
+typedef struct _ze_rtas_aabb_exp_t
+{
+    ze_rtas_float3_exp_t lower;                                             ///< [in] lower bounds of AABB
+    ze_rtas_float3_exp_t upper;                                             ///< [in] upper bounds of AABB
+
+} ze_rtas_aabb_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Triangle represented using 3 vertex indices
+/// 
+/// @details
+///     - Represents a triangle using 3 vertex indices that index into a vertex
+///       array that needs to be provided together with the index array.
+///     - The linear barycentric u/v parametrization of the triangle is defined as:
+///          - (u=0, v=0) at v0,
+///          - (u=1, v=0) at v1, and
+///          - (u=0, v=1) at v2
+typedef struct _ze_rtas_triangle_indices_uint32_exp_t
+{
+    uint32_t v0;                                                            ///< [in] first index pointing to the first triangle vertex in vertex array
+    uint32_t v1;                                                            ///< [in] second index pointing to the second triangle vertex in vertex
+                                                                            ///< array
+    uint32_t v2;                                                            ///< [in] third index pointing to the third triangle vertex in vertex array
+
+} ze_rtas_triangle_indices_uint32_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Quad represented using 4 vertex indices
+/// 
+/// @details
+///     - Represents a quad composed of 4 indices that index into a vertex array
+///       that needs to be provided together with the index array.
+///     - A quad is a triangle pair represented using 4 vertex indices v0, v1,
+///       v2, v3.
+///       The first triangle is made out of indices v0, v1, v3 and the second triangle
+///       from indices v2, v3, v1. The piecewise linear barycentric u/v parametrization
+///       of the quad is defined as:
+///          - (u=0, v=0) at v0,
+///          - (u=1, v=0) at v1,
+///          - (u=0, v=1) at v3, and
+///          - (u=1, v=1) at v2
+///       This is achieved by correcting the u'/v' coordinates of the second
+///       triangle by
+///       *u = 1-u'* and *v = 1-v'*, yielding a piecewise linear parametrization.
+typedef struct _ze_rtas_quad_indices_uint32_exp_t
+{
+    uint32_t v0;                                                            ///< [in] first index pointing to the first quad vertex in vertex array
+    uint32_t v1;                                                            ///< [in] second index pointing to the second quad vertex in vertex array
+    uint32_t v2;                                                            ///< [in] third index pointing to the third quad vertex in vertex array
+    uint32_t v3;                                                            ///< [in] fourth index pointing to the fourth quad vertex in vertex array
+
+} ze_rtas_quad_indices_uint32_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Ray tracing acceleration structure builder geometry info
+typedef struct _ze_rtas_builder_geometry_info_exp_t
+{
+    ze_rtas_builder_packed_geometry_type_exp_t geometryType;                ///< [in] geometry type
+
+} ze_rtas_builder_geometry_info_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Ray tracing acceleration structure builder triangle mesh geometry info
+/// 
+/// @details
+///     - The linear barycentric u/v parametrization of the triangle is defined as:
+///          - (u=0, v=0) at v0,
+///          - (u=1, v=0) at v1, and
+///          - (u=0, v=1) at v2
+typedef struct _ze_rtas_builder_triangles_geometry_info_exp_t
+{
+    ze_rtas_builder_packed_geometry_type_exp_t geometryType;                ///< [in] geometry type, must be
+                                                                            ///< ::ZE_RTAS_BUILDER_GEOMETRY_TYPE_EXP_TRIANGLES
+    ze_rtas_builder_packed_geometry_exp_flags_t geometryFlags;              ///< [in] 0 or some combination of ::ze_rtas_builder_geometry_exp_flag_t
+                                                                            ///< bits representing the geometry flags for all primitives of this
+                                                                            ///< geometry
+    uint8_t geometryMask;                                                   ///< [in] 8-bit geometry mask for ray masking
+    ze_rtas_builder_packed_input_data_format_exp_t triangleFormat;          ///< [in] format of triangle buffer data, must be
+                                                                            ///< ::ZE_RTAS_BUILDER_INPUT_DATA_FORMAT_EXP_TRIANGLE_INDICES_UINT32
+    ze_rtas_builder_packed_input_data_format_exp_t vertexFormat;            ///< [in] format of vertex buffer data, must be
+                                                                            ///< ::ZE_RTAS_BUILDER_INPUT_DATA_FORMAT_EXP_FLOAT3
+    uint32_t triangleCount;                                                 ///< [in] number of triangles in triangle buffer
+    uint32_t vertexCount;                                                   ///< [in] number of vertices in vertex buffer
+    uint32_t triangleStride;                                                ///< [in] stride (in bytes) of triangles in triangle buffer
+    uint32_t vertexStride;                                                  ///< [in] stride (in bytes) of vertices in vertex buffer
+    void* pTriangleBuffer;                                                  ///< [in] pointer to array of triangle indices in specified format
+    void* pVertexBuffer;                                                    ///< [in] pointer to array of triangle vertices in specified format
+
+} ze_rtas_builder_triangles_geometry_info_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Ray tracing acceleration structure builder quad mesh geometry info
+/// 
+/// @details
+///     - A quad is a triangle pair represented using 4 vertex indices v0, v1,
+///       v2, v3.
+///       The first triangle is made out of indices v0, v1, v3 and the second triangle
+///       from indices v2, v3, v1. The piecewise linear barycentric u/v parametrization
+///       of the quad is defined as:
+///          - (u=0, v=0) at v0,
+///          - (u=1, v=0) at v1,
+///          - (u=0, v=1) at v3, and
+///          - (u=1, v=1) at v2
+///       This is achieved by correcting the u'/v' coordinates of the second
+///       triangle by
+///       *u = 1-u'* and *v = 1-v'*, yielding a piecewise linear parametrization.
+typedef struct _ze_rtas_builder_quads_geometry_info_exp_t
+{
+    ze_rtas_builder_packed_geometry_type_exp_t geometryType;                ///< [in] geometry type, must be ::ZE_RTAS_BUILDER_GEOMETRY_TYPE_EXP_QUADS
+    ze_rtas_builder_packed_geometry_exp_flags_t geometryFlags;              ///< [in] 0 or some combination of ::ze_rtas_builder_geometry_exp_flag_t
+                                                                            ///< bits representing the geometry flags for all primitives of this
+                                                                            ///< geometry
+    uint8_t geometryMask;                                                   ///< [in] 8-bit geometry mask for ray masking
+    ze_rtas_builder_packed_input_data_format_exp_t quadFormat;              ///< [in] format of quad buffer data, must be
+                                                                            ///< ::ZE_RTAS_BUILDER_INPUT_DATA_FORMAT_EXP_QUAD_INDICES_UINT32
+    ze_rtas_builder_packed_input_data_format_exp_t vertexFormat;            ///< [in] format of vertex buffer data, must be
+                                                                            ///< ::ZE_RTAS_BUILDER_INPUT_DATA_FORMAT_EXP_FLOAT3
+    uint32_t quadCount;                                                     ///< [in] number of quads in quad buffer
+    uint32_t vertexCount;                                                   ///< [in] number of vertices in vertex buffer
+    uint32_t quadStride;                                                    ///< [in] stride (in bytes) of quads in quad buffer
+    uint32_t vertexStride;                                                  ///< [in] stride (in bytes) of vertices in vertex buffer
+    void* pQuadBuffer;                                                      ///< [in] pointer to array of quad indices in specified format
+    void* pVertexBuffer;                                                    ///< [in] pointer to array of quad vertices in specified format
+
+} ze_rtas_builder_quads_geometry_info_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief AABB callback function parameters
+typedef struct _ze_rtas_geometry_aabbs_exp_cb_params_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    uint32_t primID;                                                        ///< [in] first primitive to return bounds for
+    uint32_t primIDCount;                                                   ///< [in] number of primitives to return bounds for
+    void* pGeomUserPtr;                                                     ///< [in] pointer provided through geometry descriptor
+    void* pBuildUserPtr;                                                    ///< [in] pointer provided through ::zeRTASBuilderBuildExp function
+    ze_rtas_aabb_exp_t* pBoundsOut;                                         ///< [out] destination buffer to write AABB bounds to
+
+} ze_rtas_geometry_aabbs_exp_cb_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function pointer type to return AABBs for a range of
+///        procedural primitives
+typedef void (*ze_rtas_geometry_aabbs_cb_exp_t)(
+        ze_rtas_geometry_aabbs_exp_cb_params_t* params                          ///< [in] callback function parameters structure
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Ray tracing acceleration structure builder procedural primitives
+///        geometry info
+/// 
+/// @details
+///     - A host-side bounds callback function is invoked by the acceleration
+///       structure builder to query the bounds of procedural primitives on
+///       demand. The callback is passed some `pGeomUserPtr` that can point to
+///       an application-side representation of the procedural primitives.
+///       Further, a second `pBuildUserPtr`, which is set by a parameter to
+///       ::zeRTASBuilderBuildExp, is passed to the callback. This allows the
+///       build to change the bounds of the procedural geometry, for example, to
+///       build a BVH only over a short time range to implement multi-segment
+///       motion blur.
+typedef struct _ze_rtas_builder_procedural_geometry_info_exp_t
+{
+    ze_rtas_builder_packed_geometry_type_exp_t geometryType;                ///< [in] geometry type, must be
+                                                                            ///< ::ZE_RTAS_BUILDER_GEOMETRY_TYPE_EXP_PROCEDURAL
+    ze_rtas_builder_packed_geometry_exp_flags_t geometryFlags;              ///< [in] 0 or some combination of ::ze_rtas_builder_geometry_exp_flag_t
+                                                                            ///< bits representing the geometry flags for all primitives of this
+                                                                            ///< geometry
+    uint8_t geometryMask;                                                   ///< [in] 8-bit geometry mask for ray masking
+    uint8_t reserved;                                                       ///< [in] reserved for future use
+    uint32_t primCount;                                                     ///< [in] number of primitives in geometry
+    ze_rtas_geometry_aabbs_cb_exp_t pfnGetBoundsCb;                         ///< [in] pointer to callback function to get the axis-aligned bounding-box
+                                                                            ///< for a range of primitives
+    void* pGeomUserPtr;                                                     ///< [in] user data pointer passed to callback
+
+} ze_rtas_builder_procedural_geometry_info_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Ray tracing acceleration structure builder instance geometry info
+typedef struct _ze_rtas_builder_instance_geometry_info_exp_t
+{
+    ze_rtas_builder_packed_geometry_type_exp_t geometryType;                ///< [in] geometry type, must be
+                                                                            ///< ::ZE_RTAS_BUILDER_GEOMETRY_TYPE_EXP_INSTANCE
+    ze_rtas_builder_packed_instance_exp_flags_t instanceFlags;              ///< [in] 0 or some combination of ::ze_rtas_builder_geometry_exp_flag_t
+                                                                            ///< bits representing the geometry flags for all primitives of this
+                                                                            ///< geometry
+    uint8_t geometryMask;                                                   ///< [in] 8-bit geometry mask for ray masking
+    ze_rtas_builder_packed_input_data_format_exp_t transformFormat;         ///< [in] format of the specified transformation
+    uint32_t instanceUserID;                                                ///< [in] user-specified identifier for the instance
+    void* pTransform;                                                       ///< [in] object-to-world instance transformation in specified format
+    ze_rtas_aabb_exp_t* pBounds;                                            ///< [in] object-space axis-aligned bounding-box of the instanced
+                                                                            ///< acceleration structure
+    void* pAccelerationStructure;                                           ///< [in] pointer to acceleration structure to instantiate
+
+} ze_rtas_builder_instance_geometry_info_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief 
+typedef struct _ze_rtas_builder_build_op_exp_desc_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_rtas_format_exp_t rtasFormat;                                        ///< [in] ray tracing acceleration structure format
+    ze_rtas_builder_build_quality_hint_exp_t buildQuality;                  ///< [in] acceleration structure build quality hint
+    ze_rtas_builder_build_op_exp_flags_t buildFlags;                        ///< [in] 0 or some combination of ::ze_rtas_builder_build_op_exp_flag_t
+                                                                            ///< flags
+    const ze_rtas_builder_geometry_info_exp_t** ppGeometries;               ///< [in][optional][range(0, `numGeometries`)] NULL or a valid array of
+                                                                            ///< pointers to geometry infos
+    uint32_t numGeometries;                                                 ///< [in] number of geometries in geometry infos array, can be zero when
+                                                                            ///< `ppGeometries` is NULL
+
+} ze_rtas_builder_build_op_exp_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Creates a ray tracing acceleration structure builder object
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function must be thread-safe.
+///     - The implementation must support ::ZE_experimental_rtas_builder
+///       extension.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDriver`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pDescriptor`
+///         + `nullptr == phBuilder`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::ZE_RTAS_BUILDER_EXP_VERSION_CURRENT < pDescriptor->builderVersion`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeRTASBuilderCreateExp(
+    ze_driver_handle_t hDriver,                                             ///< [in] handle of driver object
+    const ze_rtas_builder_exp_desc_t* pDescriptor,                          ///< [in] pointer to builder descriptor
+    ze_rtas_builder_exp_handle_t* phBuilder                                 ///< [out] handle of builder object
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves ray tracing acceleration structure builder properties
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hBuilder`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pBuildOpDescriptor`
+///         + `nullptr == pProperties`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::ZE_RTAS_FORMAT_EXP_INVALID < pBuildOpDescriptor->rtasFormat`
+///         + `::ZE_RTAS_BUILDER_BUILD_QUALITY_HINT_EXP_HIGH < pBuildOpDescriptor->buildQuality`
+///         + `0x3 < pBuildOpDescriptor->buildFlags`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeRTASBuilderGetBuildPropertiesExp(
+    ze_rtas_builder_exp_handle_t hBuilder,                                  ///< [in] handle of builder object
+    const ze_rtas_builder_build_op_exp_desc_t* pBuildOpDescriptor,          ///< [in] pointer to build operation descriptor
+    ze_rtas_builder_exp_properties_t* pProperties                           ///< [in,out] query result for builder properties
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Checks ray tracing acceleration structure format compatibility
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDriver`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::ZE_RTAS_FORMAT_EXP_INVALID < rtasFormatA`
+///         + `::ZE_RTAS_FORMAT_EXP_INVALID < rtasFormatB`
+///     - ::ZE_RESULT_SUCCESS
+///         + An acceleration structure built with `rtasFormatA` is compatible with devices that report `rtasFormatB`.
+///     - ::ZE_RESULT_EXP_ERROR_OPERANDS_INCOMPATIBLE
+///         + An acceleration structure built with `rtasFormatA` is **not** compatible with devices that report `rtasFormatB`.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeDriverRTASFormatCompatibilityCheckExp(
+    ze_driver_handle_t hDriver,                                             ///< [in] handle of driver object
+    ze_rtas_format_exp_t rtasFormatA,                                       ///< [in] operand A
+    ze_rtas_format_exp_t rtasFormatB                                        ///< [in] operand B
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Build ray tracing acceleration structure
+/// 
+/// @details
+///     - This function builds an acceleration structure of the scene consisting
+///       of the specified geometry information and writes the acceleration
+///       structure to the provided destination buffer. All types of geometries
+///       can get freely mixed inside a scene.
+///     - It is the user's responsibility to manage the acceleration structure
+///       buffer allocation, de-allocation, and potential prefetching to the
+///       device memory. The required size of the acceleration structure buffer
+///       can be queried with the ::zeRTASBuilderGetBuildPropertiesExp function.
+///       The acceleration structure buffer must be a shared USM allocation and
+///       should be present on the host at build time. The referenced scene data
+///       (index- and vertex- buffers) can be standard host allocations, and
+///       will not be referenced into by the build acceleration structure.
+///     - Before an acceleration structure can be built, the user must allocate
+///       the memory for the acceleration structure buffer and scratch buffer
+///       using sizes based on a query for the estimated size properties.
+///     - When using the "worst-case" size for the acceleration structure
+///       buffer, the acceleration structure construction will never fail with ::ZE_RESULT_EXP_RTAS_BUILD_RETRY.
+///     - When using the "expected" size for the acceleration structure buffer,
+///       the acceleration structure construction may fail with
+///       ::ZE_RESULT_EXP_RTAS_BUILD_RETRY. If this happens, the user may resize
+///       their acceleration structure buffer using the returned
+///       `*pRtasBufferSizeBytes` value, which will be updated with an improved
+///       size estimate that will likely result in a successful build.
+///     - The acceleration structure construction is run on the host and is
+///       synchronous, thus after the function returns with a successful result,
+///       the acceleration structure may be used.
+///     - All provided data buffers must be host-accessible.
+///     - The acceleration structure buffer must be a USM allocation.
+///     - A successfully constructed acceleration structure is entirely
+///       self-contained. There is no requirement for input data to persist
+///       beyond build completion.
+///     - A successfully constructed acceleration structure is non-copyable.
+///     - Acceleration structure construction may be parallelized by passing a
+///       valid handle to a parallel operation object and joining that parallel
+///       operation using ::zeRTASParallelOperationJoinExp with user-provided
+///       worker threads.
+///     - **Additional Notes**
+///        - "The geometry infos array, geometry infos, and scratch buffer must
+///       all be standard host memory allocations."
+///        - "A pointer to a geometry info can be a null pointer, in which case
+///       the geometry is treated as empty."
+///        - "If no parallel operation handle is provided, the build is run
+///       sequentially on the current thread."
+///        - "A parallel operation object may only be associated with a single
+///       acceleration structure build at a time."
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hBuilder`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pBuildOpDescriptor`
+///         + `nullptr == pScratchBuffer`
+///         + `nullptr == pRtasBuffer`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::ZE_RTAS_FORMAT_EXP_INVALID < pBuildOpDescriptor->rtasFormat`
+///         + `::ZE_RTAS_BUILDER_BUILD_QUALITY_HINT_EXP_HIGH < pBuildOpDescriptor->buildQuality`
+///         + `0x3 < pBuildOpDescriptor->buildFlags`
+///     - ::ZE_RESULT_EXP_RTAS_BUILD_DEFERRED
+///         + Acceleration structure build completion is deferred to parallel operation join.
+///     - ::ZE_RESULT_EXP_RTAS_BUILD_RETRY
+///         + Acceleration structure build failed due to insufficient resources, retry the build operation with a larger acceleration structure buffer allocation.
+///     - ::ZE_RESULT_ERROR_HANDLE_OBJECT_IN_USE
+///         + Acceleration structure build failed due to parallel operation object participation in another build operation.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeRTASBuilderBuildExp(
+    ze_rtas_builder_exp_handle_t hBuilder,                                  ///< [in] handle of builder object
+    const ze_rtas_builder_build_op_exp_desc_t* pBuildOpDescriptor,          ///< [in] pointer to build operation descriptor
+    void* pScratchBuffer,                                                   ///< [in][range(0, `scratchBufferSizeBytes`)] scratch buffer to be used
+                                                                            ///< during acceleration structure construction
+    size_t scratchBufferSizeBytes,                                          ///< [in] size of scratch buffer, in bytes
+    void* pRtasBuffer,                                                      ///< [in] pointer to destination buffer
+    size_t rtasBufferSizeBytes,                                             ///< [in] destination buffer size, in bytes
+    ze_rtas_parallel_operation_exp_handle_t hParallelOperation,             ///< [in][optional] handle to parallel operation object
+    void* pBuildUserPtr,                                                    ///< [in][optional] pointer passed to callbacks
+    ze_rtas_aabb_exp_t* pBounds,                                            ///< [in,out][optional] pointer to destination address for acceleration
+                                                                            ///< structure bounds
+    size_t* pRtasBufferSizeBytes                                            ///< [out][optional] updated acceleration structure size requirement, in
+                                                                            ///< bytes
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Destroys a ray tracing acceleration structure builder object
+/// 
+/// @details
+///     - The implementation of this function may immediately release any
+///       internal Host and Device resources associated with this builder.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same builder handle.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hBuilder`
+///     - ::ZE_RESULT_ERROR_HANDLE_OBJECT_IN_USE
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeRTASBuilderDestroyExp(
+    ze_rtas_builder_exp_handle_t hBuilder                                   ///< [in][release] handle of builder object to destroy
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Creates a ray tracing acceleration structure builder parallel
+///        operation object
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function must be thread-safe.
+///     - The implementation must support ::ZE_experimental_rtas_builder
+///       extension.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDriver`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == phParallelOperation`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeRTASParallelOperationCreateExp(
+    ze_driver_handle_t hDriver,                                             ///< [in] handle of driver object
+    ze_rtas_parallel_operation_exp_handle_t* phParallelOperation            ///< [out] handle of parallel operation object
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves ray tracing acceleration structure builder parallel
+///        operation properties
+/// 
+/// @details
+///     - The application must first bind the parallel operation object to a
+///       build operation before it may query the parallel operation properties.
+///       In other words, the application must first call
+///       ::zeRTASBuilderBuildExp with **hParallelOperation** before calling
+///       this function.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hParallelOperation`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pProperties`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeRTASParallelOperationGetPropertiesExp(
+    ze_rtas_parallel_operation_exp_handle_t hParallelOperation,             ///< [in] handle of parallel operation object
+    ze_rtas_parallel_operation_exp_properties_t* pProperties                ///< [in,out] query result for parallel operation properties
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Joins a parallel build operation
+/// 
+/// @details
+///     - All worker threads return the same error code for the parallel build
+///       operation upon build completion
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hParallelOperation`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeRTASParallelOperationJoinExp(
+    ze_rtas_parallel_operation_exp_handle_t hParallelOperation              ///< [in] handle of parallel operation object
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Destroys a ray tracing acceleration structure builder parallel
+///        operation object
+/// 
+/// @details
+///     - The implementation of this function may immediately release any
+///       internal Host and Device resources associated with this parallel
+///       operation.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same parallel operation handle.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hParallelOperation`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeRTASParallelOperationDestroyExp(
+    ze_rtas_parallel_operation_exp_handle_t hParallelOperation              ///< [in][release] handle of parallel operation object to destroy
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Extension APIs for Counter-based Event Pools
+#if !defined(__GNUC__)
+#pragma region counterbasedeventpool
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_EVENT_POOL_COUNTER_BASED_EXP_NAME
+/// @brief Counter-based Event Pools Extension Name
+#define ZE_EVENT_POOL_COUNTER_BASED_EXP_NAME  "ZE_experimental_event_pool_counter_based"
+#endif // ZE_EVENT_POOL_COUNTER_BASED_EXP_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Counter-based Event Pools Extension Version(s)
+typedef enum _ze_event_pool_counter_based_exp_version_t
+{
+    ZE_EVENT_POOL_COUNTER_BASED_EXP_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),  ///< version 1.0
+    ZE_EVENT_POOL_COUNTER_BASED_EXP_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),  ///< latest known version
+    ZE_EVENT_POOL_COUNTER_BASED_EXP_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} ze_event_pool_counter_based_exp_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported event flags for defining counter-based event pools.
+typedef uint32_t ze_event_pool_counter_based_exp_flags_t;
+typedef enum _ze_event_pool_counter_based_exp_flag_t
+{
+    ZE_EVENT_POOL_COUNTER_BASED_EXP_FLAG_IMMEDIATE = ZE_BIT(0),             ///< Counter-based event pool is used for immediate command lists (default)
+    ZE_EVENT_POOL_COUNTER_BASED_EXP_FLAG_NON_IMMEDIATE = ZE_BIT(1),         ///< Counter-based event pool is for non-immediate command lists
+    ZE_EVENT_POOL_COUNTER_BASED_EXP_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_event_pool_counter_based_exp_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Event pool descriptor for counter-based events. This structure may be
+///        passed to ::zeEventPoolCreate as pNext member of
+///        ::ze_event_pool_desc_t.
+typedef struct _ze_event_pool_counter_based_exp_desc_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_event_pool_counter_based_exp_flags_t flags;                          ///< [in] mode flags.
+                                                                            ///< must be 0 (default) or a valid value of ::ze_event_pool_counter_based_exp_flag_t
+                                                                            ///< default behavior is counter-based event pool is only used for
+                                                                            ///< immediate command lists.
+
+} ze_event_pool_counter_based_exp_desc_t;
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Extension for supporting bindless images.
+#if !defined(__GNUC__)
+#pragma region bindlessimages
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_BINDLESS_IMAGE_EXP_NAME
+/// @brief Image Memory Properties Extension Name
+#define ZE_BINDLESS_IMAGE_EXP_NAME  "ZE_experimental_bindless_image"
+#endif // ZE_BINDLESS_IMAGE_EXP_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Bindless Image Extension Version(s)
+typedef enum _ze_bindless_image_exp_version_t
+{
+    ZE_BINDLESS_IMAGE_EXP_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),            ///< version 1.0
+    ZE_BINDLESS_IMAGE_EXP_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),        ///< latest known version
+    ZE_BINDLESS_IMAGE_EXP_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} ze_bindless_image_exp_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Image flags for Bindless images
+typedef uint32_t ze_image_bindless_exp_flags_t;
+typedef enum _ze_image_bindless_exp_flag_t
+{
+    ZE_IMAGE_BINDLESS_EXP_FLAG_BINDLESS = ZE_BIT(0),                        ///< Bindless images are created with ::zeImageCreate. The image handle
+                                                                            ///< created with this flag is valid on both host and device.
+    ZE_IMAGE_BINDLESS_EXP_FLAG_SAMPLED_IMAGE = ZE_BIT(1),                   ///< Bindless sampled images are created with ::zeImageCreate by combining
+                                                                            ///< BINDLESS and SAMPLED_IMAGE.
+                                                                            ///< Create sampled image view from bindless unsampled image using SAMPLED_IMAGE.
+    ZE_IMAGE_BINDLESS_EXP_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_image_bindless_exp_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Image descriptor for bindless images. This structure may be passed to
+///        ::zeImageCreate via pNext member of ::ze_image_desc_t.
+typedef struct _ze_image_bindless_exp_desc_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_image_bindless_exp_flags_t flags;                                    ///< [in] image flags.
+                                                                            ///< must be 0 (default) or a valid value of ::ze_image_bindless_exp_flag_t
+                                                                            ///< default behavior is bindless images are not used when creating handles
+                                                                            ///< via ::zeImageCreate.
+                                                                            ///< When the flag is passed to ::zeImageCreate, then only the memory for
+                                                                            ///< the image is allocated.
+                                                                            ///< Additional image handles can be created with ::zeImageViewCreateExt.
+                                                                            ///< When ::ZE_IMAGE_BINDLESS_EXP_FLAG_SAMPLED_IMAGE flag is passed,
+                                                                            ///< ::ze_sampler_desc_t must be attached via pNext member of ::ze_image_bindless_exp_desc_t.
+
+} ze_image_bindless_exp_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Image descriptor for bindless images created from pitched allocations.
+///        This structure may be passed to ::zeImageCreate via pNext member of
+///        ::ze_image_desc_t.
+typedef struct _ze_image_pitched_exp_desc_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    void* ptr;                                                              ///< [in] pointer to pitched device allocation allocated using ::zeMemAllocDevice
+
+} ze_image_pitched_exp_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Device specific properties for pitched allocations
+/// 
+/// @details
+///     - This structure may be passed to ::zeDeviceGetImageProperties via the
+///       pNext member of ::ze_device_image_properties_t.
+typedef struct _ze_device_pitched_alloc_exp_properties_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    size_t maxImageLinearWidth;                                             ///< [out] Maximum image linear width.
+    size_t maxImageLinearHeight;                                            ///< [out] Maximum image linear height.
+
+} ze_device_pitched_alloc_exp_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Allocate pitched USM memory for images
+/// 
+/// @details
+///     - Retrieves pitch for 2D image given the width, height and size in bytes
+///     - The memory is then allocated using ::zeMemAllocDevice by providing
+///       input size calculated as the returned pitch value multiplied by image height
+///     - The application may call this function from simultaneous threads
+///     - The implementation of this function must be thread-safe.
+///     - The implementation of this function should be lock-free.
+///     - The implementation must support ::ZE_experimental_bindless_image extension.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+///         + `nullptr == hDevice`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeMemGetPitchFor2dImage(
+    ze_context_handle_t hContext,                                           ///< [in] handle of the context object
+    ze_device_handle_t hDevice,                                             ///< [in] handle of the device
+    size_t imageWidth,                                                      ///< [in] imageWidth
+    size_t imageHeight,                                                     ///< [in] imageHeight
+    unsigned int elementSizeInBytes,                                        ///< [in] Element size in bytes
+    size_t * rowPitch                                                       ///< [out] rowPitch
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get bindless device offset for image
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads
+///     - The implementation of this function must be thread-safe.
+///     - The implementation of this function should be lock-free.
+///     - The implementation must support ::ZE_experimental_bindless_image
+///       extension.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hImage`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pDeviceOffset`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeImageGetDeviceOffsetExp(
+    ze_image_handle_t hImage,                                               ///< [in] handle of the image
+    uint64_t* pDeviceOffset                                                 ///< [out] bindless device offset for image
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Extension for supporting compute graphs.
+#if !defined(__GNUC__)
+#pragma region commandListClone
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_COMMAND_LIST_CLONE_EXP_NAME
+/// @brief Command List Clone Extension Name
+#define ZE_COMMAND_LIST_CLONE_EXP_NAME  "ZE_experimental_command_list_clone"
+#endif // ZE_COMMAND_LIST_CLONE_EXP_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Command List Clone Extension Version(s)
+typedef enum _ze_command_list_clone_exp_version_t
+{
+    ZE_COMMAND_LIST_CLONE_EXP_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),        ///< version 1.0
+    ZE_COMMAND_LIST_CLONE_EXP_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),    ///< latest known version
+    ZE_COMMAND_LIST_CLONE_EXP_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} ze_command_list_clone_exp_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Creates a command list as the clone of another command list.
+/// 
+/// @details
+///     - The source command list must be created with the
+///       ::ZE_COMMAND_LIST_FLAG_EXP_CLONEABLE flag.
+///     - The source command list must be closed prior to cloning.
+///     - The source command list may be cloned while it is running on the
+///       device.
+///     - The cloned command list inherits all properties of the source command
+///       list.
+///     - The cloned command list must be destroyed prior to the source command
+///       list.
+///     - The application must only use the command list for the device, or its
+///       sub-devices, which was provided during creation.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandList`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == phClonedCommandList`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandListCreateCloneExp(
+    ze_command_list_handle_t hCommandList,                                  ///< [in] handle to source command list (the command list to clone)
+    ze_command_list_handle_t* phClonedCommandList                           ///< [out] pointer to handle of the cloned command list
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Extension for supporting compute graphs.
+#if !defined(__GNUC__)
+#pragma region immediateCommandListAppend
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_IMMEDIATE_COMMAND_LIST_APPEND_EXP_NAME
+/// @brief Immediate Command List Append Extension Name
+#define ZE_IMMEDIATE_COMMAND_LIST_APPEND_EXP_NAME  "ZE_experimental_immediate_command_list_append"
+#endif // ZE_IMMEDIATE_COMMAND_LIST_APPEND_EXP_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Immediate Command List Append Extension Version(s)
+typedef enum _ze_immediate_command_list_append_exp_version_t
+{
+    ZE_IMMEDIATE_COMMAND_LIST_APPEND_EXP_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ), ///< version 1.0
+    ZE_IMMEDIATE_COMMAND_LIST_APPEND_EXP_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ), ///< latest known version
+    ZE_IMMEDIATE_COMMAND_LIST_APPEND_EXP_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} ze_immediate_command_list_append_exp_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Appends command lists to dispatch from an immediate command list.
+/// 
+/// @details
+///     - The application must call this function only with command lists
+///       created with ::zeCommandListCreateImmediate.
+///     - The command lists passed to this function in the `phCommandLists`
+///       argument must be regular command lists (i.e. not immediate command
+///       lists).
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandListImmediate`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == phCommandLists`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandListImmediateAppendCommandListsExp(
+    ze_command_list_handle_t hCommandListImmediate,                         ///< [in] handle of the immediate command list
+    uint32_t numCommandLists,                                               ///< [in] number of command lists
+    ze_command_list_handle_t* phCommandLists,                               ///< [in][range(0, numCommandLists)] handles of command lists
+    ze_event_handle_t hSignalEvent,                                         ///< [in][optional] handle of the event to signal on completion
+                                                                            ///<    - if not null, this event is signaled after the completion of all
+                                                                            ///< appended command lists
+    uint32_t numWaitEvents,                                                 ///< [in][optional] number of events to wait on before executing appended
+                                                                            ///< command lists; must be 0 if nullptr == phWaitEvents
+    ze_event_handle_t* phWaitEvents                                         ///< [in][optional][range(0, numWaitEvents)] handle of the events to wait
+                                                                            ///< on before executing appended command lists.
+                                                                            ///<    - if not null, all wait events must be satisfied prior to the start
+                                                                            ///< of any appended command list(s)
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Extension for supporting compute graphs with dynamic properties.
+#if !defined(__GNUC__)
+#pragma region mutableCommandList
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_MUTABLE_COMMAND_LIST_EXP_NAME
+/// @brief Mutable Command List Extension Name
+#define ZE_MUTABLE_COMMAND_LIST_EXP_NAME  "ZE_experimental_mutable_command_list"
+#endif // ZE_MUTABLE_COMMAND_LIST_EXP_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Mutable Command List Extension Version(s)
+typedef enum _ze_mutable_command_list_exp_version_t
+{
+    ZE_MUTABLE_COMMAND_LIST_EXP_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),      ///< version 1.0
+    ZE_MUTABLE_COMMAND_LIST_EXP_VERSION_1_1 = ZE_MAKE_VERSION( 1, 1 ),      ///< version 1.1
+    ZE_MUTABLE_COMMAND_LIST_EXP_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 1 ),  ///< latest known version
+    ZE_MUTABLE_COMMAND_LIST_EXP_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} ze_mutable_command_list_exp_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Mutable command flags
+typedef uint32_t ze_mutable_command_exp_flags_t;
+typedef enum _ze_mutable_command_exp_flag_t
+{
+    ZE_MUTABLE_COMMAND_EXP_FLAG_KERNEL_ARGUMENTS = ZE_BIT(0),               ///< kernel arguments
+    ZE_MUTABLE_COMMAND_EXP_FLAG_GROUP_COUNT = ZE_BIT(1),                    ///< kernel group count
+    ZE_MUTABLE_COMMAND_EXP_FLAG_GROUP_SIZE = ZE_BIT(2),                     ///< kernel group size
+    ZE_MUTABLE_COMMAND_EXP_FLAG_GLOBAL_OFFSET = ZE_BIT(3),                  ///< kernel global offset
+    ZE_MUTABLE_COMMAND_EXP_FLAG_SIGNAL_EVENT = ZE_BIT(4),                   ///< command signal event
+    ZE_MUTABLE_COMMAND_EXP_FLAG_WAIT_EVENTS = ZE_BIT(5),                    ///< command wait events
+    ZE_MUTABLE_COMMAND_EXP_FLAG_KERNEL_INSTRUCTION = ZE_BIT(6),             ///< command kernel
+    ZE_MUTABLE_COMMAND_EXP_FLAG_GRAPH_ARGUMENTS = ZE_BIT(7),                ///< graph arguments
+    ZE_MUTABLE_COMMAND_EXP_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_mutable_command_exp_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Mutable command identifier descriptor
+typedef struct _ze_mutable_command_id_exp_desc_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_mutable_command_exp_flags_t flags;                                   ///< [in] mutable command flags.
+                                                                            ///<  - must be 0 (default, equivalent to setting all flags bar kernel
+                                                                            ///< instruction), or a valid combination of ::ze_mutable_command_exp_flag_t
+                                                                            ///<  - in order to include kernel instruction mutation,
+                                                                            ///< ::ZE_MUTABLE_COMMAND_EXP_FLAG_KERNEL_INSTRUCTION must be explictly included
+
+} ze_mutable_command_id_exp_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Mutable command list flags
+typedef uint32_t ze_mutable_command_list_exp_flags_t;
+typedef enum _ze_mutable_command_list_exp_flag_t
+{
+    ZE_MUTABLE_COMMAND_LIST_EXP_FLAG_RESERVED = ZE_BIT(0),                  ///< reserved
+    ZE_MUTABLE_COMMAND_LIST_EXP_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_mutable_command_list_exp_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Mutable command list properties
+typedef struct _ze_mutable_command_list_exp_properties_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_mutable_command_list_exp_flags_t mutableCommandListFlags;            ///< [out] mutable command list flags
+    ze_mutable_command_exp_flags_t mutableCommandFlags;                     ///< [out] mutable command flags
+
+} ze_mutable_command_list_exp_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Mutable command list descriptor
+typedef struct _ze_mutable_command_list_exp_desc_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_mutable_command_list_exp_flags_t flags;                              ///< [in] mutable command list flags.
+                                                                            ///<  - must be 0 (default) or a valid combination of ::ze_mutable_command_list_exp_flag_t
+
+} ze_mutable_command_list_exp_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Mutable commands descriptor
+typedef struct _ze_mutable_commands_exp_desc_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    uint32_t flags;                                                         ///< [in] must be 0, this field is reserved for future use
+
+} ze_mutable_commands_exp_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Mutable kernel argument descriptor
+typedef struct _ze_mutable_kernel_argument_exp_desc_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    uint64_t commandId;                                                     ///< [in] command identifier
+    uint32_t argIndex;                                                      ///< [in] kernel argument index
+    size_t argSize;                                                         ///< [in] kernel argument size
+    const void* pArgValue;                                                  ///< [in] pointer to kernel argument value
+
+} ze_mutable_kernel_argument_exp_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Mutable kernel group count descriptor
+typedef struct _ze_mutable_group_count_exp_desc_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    uint64_t commandId;                                                     ///< [in] command identifier
+    const ze_group_count_t* pGroupCount;                                    ///< [in] pointer to group count
+
+} ze_mutable_group_count_exp_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Mutable kernel group size descriptor
+typedef struct _ze_mutable_group_size_exp_desc_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    uint64_t commandId;                                                     ///< [in] command identifier
+    uint32_t groupSizeX;                                                    ///< [in] group size for X dimension to use for the kernel
+    uint32_t groupSizeY;                                                    ///< [in] group size for Y dimension to use for the kernel
+    uint32_t groupSizeZ;                                                    ///< [in] group size for Z dimension to use for the kernel
+
+} ze_mutable_group_size_exp_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Mutable kernel global offset descriptor
+typedef struct _ze_mutable_global_offset_exp_desc_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    uint64_t commandId;                                                     ///< [in] command identifier
+    uint32_t offsetX;                                                       ///< [in] global offset for X dimension to use for this kernel
+    uint32_t offsetY;                                                       ///< [in] global offset for Y dimension to use for this kernel
+    uint32_t offsetZ;                                                       ///< [in] global offset for Z dimension to use for this kernel
+
+} ze_mutable_global_offset_exp_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Mutable graph argument descriptor
+typedef struct _ze_mutable_graph_argument_exp_desc_t
+{
+    ze_structure_type_t stype;                                              ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    uint64_t commandId;                                                     ///< [in] command identifier
+    uint32_t argIndex;                                                      ///< [in] graph argument index
+    const void* pArgValue;                                                  ///< [in] pointer to graph argument value
+
+} ze_mutable_graph_argument_exp_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Returns a unique command identifier for the next command to be
+///        appended to a command list.
+/// 
+/// @details
+///     - This function may only be called for a mutable command list.
+///     - This function may not be called on a closed command list.
+///     - This function may be called from simultaneous threads with the same
+///       command list handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandList`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == desc`
+///         + `nullptr == pCommandId`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `0xff < desc->flags`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandListGetNextCommandIdExp(
+    ze_command_list_handle_t hCommandList,                                  ///< [in] handle of the command list
+    const ze_mutable_command_id_exp_desc_t* desc,                           ///< [in] pointer to mutable command identifier descriptor
+    uint64_t* pCommandId                                                    ///< [out] pointer to mutable command identifier to be written
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Returns a unique command identifier for the next command to be
+///        appended to a command list. Provides possible kernel handles for
+///        kernel mutation when ::ZE_MUTABLE_COMMAND_EXP_FLAG_KERNEL_INSTRUCTION
+///        flag is present.
+/// 
+/// @details
+///     - This function may only be called for a mutable command list.
+///     - This function may not be called on a closed command list.
+///     - This function may be called from simultaneous threads with the same
+///       command list handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandList`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == desc`
+///         + `nullptr == pCommandId`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `0xff < desc->flags`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandListGetNextCommandIdWithKernelsExp(
+    ze_command_list_handle_t hCommandList,                                  ///< [in] handle of the command list
+    const ze_mutable_command_id_exp_desc_t* desc,                           ///< [in][out] pointer to mutable command identifier descriptor
+    uint32_t numKernels,                                                    ///< [in][optional] number of entries on phKernels list
+    ze_kernel_handle_t* phKernels,                                          ///< [in][optional][range(0, numKernels)] list of kernels that user can
+                                                                            ///< switch between using ::zeCommandListUpdateMutableCommandKernelsExp
+                                                                            ///< call
+    uint64_t* pCommandId                                                    ///< [out] pointer to mutable command identifier to be written
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Updates mutable commands.
+/// 
+/// @details
+///     - This function may only be called for a mutable command list.
+///     - The application must synchronize mutable command list execution before
+///       calling this function.
+///     - The application must close a mutable command list after completing all
+///       updates.
+///     - This function must not be called from simultaneous threads with the
+///       same command list handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandList`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == desc`
+///     - ::ZE_RESULT_ERROR_INVALID_ARGUMENT
+///         + Invalid kernel argument or not matching update descriptor provided
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandListUpdateMutableCommandsExp(
+    ze_command_list_handle_t hCommandList,                                  ///< [in] handle of the command list
+    const ze_mutable_commands_exp_desc_t* desc                              ///< [in] pointer to mutable commands descriptor; multiple descriptors may
+                                                                            ///< be chained via `pNext` member
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Updates the signal event for a mutable command in a mutable command
+///        list.
+/// 
+/// @details
+///     - This function may only be called for a mutable command list.
+///     - The type, scope and flags of the signal event must match those of the
+///       source command.
+///     - The application must synchronize mutable command list execution before
+///       calling this function.
+///     - The application must close a mutable command list after completing all
+///       updates.
+///     - This function must not be called from simultaneous threads with the
+///       same command list handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandList`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandListUpdateMutableCommandSignalEventExp(
+    ze_command_list_handle_t hCommandList,                                  ///< [in] handle of the command list
+    uint64_t commandId,                                                     ///< [in] command identifier
+    ze_event_handle_t hSignalEvent                                          ///< [in][optional] handle of the event to signal on completion
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Updates the wait events for a mutable command in a mutable command
+///        list.
+/// 
+/// @details
+///     - This function may only be called for a mutable command list.
+///     - The number of wait events must match that of the source command.
+///     - The type, scope and flags of the wait events must match those of the
+///       source command.
+///     - Passing `nullptr` as the wait events will update the command to not
+///       wait on any events prior to dispatch.
+///     - Passing `nullptr` as an event on event wait list will remove event
+///       dependency from this wait list slot.
+///     - The application must synchronize mutable command list execution before
+///       calling this function.
+///     - The application must close a mutable command list after completing all
+///       updates.
+///     - This function must not be called from simultaneous threads with the
+///       same command list handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandList`
+///     - ::ZE_RESULT_ERROR_INVALID_SIZE
+///         + The `numWaitEvents` parameter does not match that of the original command.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandListUpdateMutableCommandWaitEventsExp(
+    ze_command_list_handle_t hCommandList,                                  ///< [in] handle of the command list
+    uint64_t commandId,                                                     ///< [in] command identifier
+    uint32_t numWaitEvents,                                                 ///< [in][optional] the number of wait events
+    ze_event_handle_t* phWaitEvents                                         ///< [in][optional][range(0, numWaitEvents)] handle of the events to wait
+                                                                            ///< on before launching
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Updates the kernel for a mutable command in a mutable command list.
+/// 
+/// @details
+///     - This function may only be called for a mutable command list.
+///     - The kernel handle must be from the provided list for given command id.
+///     - The application must synchronize mutable command list execution before
+///       calling this function.
+///     - The application must close a mutable command list after completing all
+///       updates.
+///     - This function must not be called from simultaneous threads with the
+///       same command list handle.
+///     - This function must be called before updating kernel arguments and
+///       dispatch parameters, when kernel is mutated.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandList`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCommandId`
+///         + `nullptr == phKernels`
+///     - ::ZE_RESULT_ERROR_INVALID_KERNEL_HANDLE
+///         + Invalid kernel handle provided for the mutation kernel instruction operation.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zeCommandListUpdateMutableCommandKernelsExp(
+    ze_command_list_handle_t hCommandList,                                  ///< [in] handle of the command list
+    uint32_t numKernels,                                                    ///< [in] the number of kernels to update
+    uint64_t* pCommandId,                                                   ///< [in][range(0, numKernels)] command identifier
+    ze_kernel_handle_t* phKernels                                           ///< [in][range(0, numKernels)] handle of the kernel for a command
+                                                                            ///< identifier to switch to
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero API Callbacks
+#if !defined(__GNUC__)
+#pragma region callbacks
+#endif
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeInit 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_init_params_t
+{
+    ze_init_flags_t* pflags;
+} ze_init_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeInit 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnInitCb_t)(
+    ze_init_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Global callback functions pointers
+typedef struct _ze_global_callbacks_t
+{
+    ze_pfnInitCb_t                                                  pfnInitCb;
+} ze_global_callbacks_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeDriverGet 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_driver_get_params_t
+{
+    uint32_t** ppCount;
+    ze_driver_handle_t** pphDrivers;
+} ze_driver_get_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeDriverGet 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnDriverGetCb_t)(
+    ze_driver_get_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeDriverGetApiVersion 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_driver_get_api_version_params_t
+{
+    ze_driver_handle_t* phDriver;
+    ze_api_version_t** pversion;
+} ze_driver_get_api_version_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeDriverGetApiVersion 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnDriverGetApiVersionCb_t)(
+    ze_driver_get_api_version_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeDriverGetProperties 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_driver_get_properties_params_t
+{
+    ze_driver_handle_t* phDriver;
+    ze_driver_properties_t** ppDriverProperties;
+} ze_driver_get_properties_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeDriverGetProperties 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnDriverGetPropertiesCb_t)(
+    ze_driver_get_properties_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeDriverGetIpcProperties 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_driver_get_ipc_properties_params_t
+{
+    ze_driver_handle_t* phDriver;
+    ze_driver_ipc_properties_t** ppIpcProperties;
+} ze_driver_get_ipc_properties_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeDriverGetIpcProperties 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnDriverGetIpcPropertiesCb_t)(
+    ze_driver_get_ipc_properties_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeDriverGetExtensionProperties 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_driver_get_extension_properties_params_t
+{
+    ze_driver_handle_t* phDriver;
+    uint32_t** ppCount;
+    ze_driver_extension_properties_t** ppExtensionProperties;
+} ze_driver_get_extension_properties_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeDriverGetExtensionProperties 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnDriverGetExtensionPropertiesCb_t)(
+    ze_driver_get_extension_properties_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Driver callback functions pointers
+typedef struct _ze_driver_callbacks_t
+{
+    ze_pfnDriverGetCb_t                                             pfnGetCb;
+    ze_pfnDriverGetApiVersionCb_t                                   pfnGetApiVersionCb;
+    ze_pfnDriverGetPropertiesCb_t                                   pfnGetPropertiesCb;
+    ze_pfnDriverGetIpcPropertiesCb_t                                pfnGetIpcPropertiesCb;
+    ze_pfnDriverGetExtensionPropertiesCb_t                          pfnGetExtensionPropertiesCb;
+} ze_driver_callbacks_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeDeviceGet 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_device_get_params_t
+{
+    ze_driver_handle_t* phDriver;
+    uint32_t** ppCount;
+    ze_device_handle_t** pphDevices;
+} ze_device_get_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeDeviceGet 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnDeviceGetCb_t)(
+    ze_device_get_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeDeviceGetSubDevices 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_device_get_sub_devices_params_t
+{
+    ze_device_handle_t* phDevice;
+    uint32_t** ppCount;
+    ze_device_handle_t** pphSubdevices;
+} ze_device_get_sub_devices_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeDeviceGetSubDevices 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnDeviceGetSubDevicesCb_t)(
+    ze_device_get_sub_devices_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeDeviceGetProperties 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_device_get_properties_params_t
+{
+    ze_device_handle_t* phDevice;
+    ze_device_properties_t** ppDeviceProperties;
+} ze_device_get_properties_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeDeviceGetProperties 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnDeviceGetPropertiesCb_t)(
+    ze_device_get_properties_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeDeviceGetComputeProperties 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_device_get_compute_properties_params_t
+{
+    ze_device_handle_t* phDevice;
+    ze_device_compute_properties_t** ppComputeProperties;
+} ze_device_get_compute_properties_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeDeviceGetComputeProperties 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnDeviceGetComputePropertiesCb_t)(
+    ze_device_get_compute_properties_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeDeviceGetModuleProperties 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_device_get_module_properties_params_t
+{
+    ze_device_handle_t* phDevice;
+    ze_device_module_properties_t** ppModuleProperties;
+} ze_device_get_module_properties_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeDeviceGetModuleProperties 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnDeviceGetModulePropertiesCb_t)(
+    ze_device_get_module_properties_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeDeviceGetCommandQueueGroupProperties 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_device_get_command_queue_group_properties_params_t
+{
+    ze_device_handle_t* phDevice;
+    uint32_t** ppCount;
+    ze_command_queue_group_properties_t** ppCommandQueueGroupProperties;
+} ze_device_get_command_queue_group_properties_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeDeviceGetCommandQueueGroupProperties 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnDeviceGetCommandQueueGroupPropertiesCb_t)(
+    ze_device_get_command_queue_group_properties_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeDeviceGetMemoryProperties 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_device_get_memory_properties_params_t
+{
+    ze_device_handle_t* phDevice;
+    uint32_t** ppCount;
+    ze_device_memory_properties_t** ppMemProperties;
+} ze_device_get_memory_properties_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeDeviceGetMemoryProperties 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnDeviceGetMemoryPropertiesCb_t)(
+    ze_device_get_memory_properties_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeDeviceGetMemoryAccessProperties 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_device_get_memory_access_properties_params_t
+{
+    ze_device_handle_t* phDevice;
+    ze_device_memory_access_properties_t** ppMemAccessProperties;
+} ze_device_get_memory_access_properties_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeDeviceGetMemoryAccessProperties 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnDeviceGetMemoryAccessPropertiesCb_t)(
+    ze_device_get_memory_access_properties_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeDeviceGetCacheProperties 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_device_get_cache_properties_params_t
+{
+    ze_device_handle_t* phDevice;
+    uint32_t** ppCount;
+    ze_device_cache_properties_t** ppCacheProperties;
+} ze_device_get_cache_properties_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeDeviceGetCacheProperties 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnDeviceGetCachePropertiesCb_t)(
+    ze_device_get_cache_properties_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeDeviceGetImageProperties 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_device_get_image_properties_params_t
+{
+    ze_device_handle_t* phDevice;
+    ze_device_image_properties_t** ppImageProperties;
+} ze_device_get_image_properties_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeDeviceGetImageProperties 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnDeviceGetImagePropertiesCb_t)(
+    ze_device_get_image_properties_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeDeviceGetExternalMemoryProperties 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_device_get_external_memory_properties_params_t
+{
+    ze_device_handle_t* phDevice;
+    ze_device_external_memory_properties_t** ppExternalMemoryProperties;
+} ze_device_get_external_memory_properties_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeDeviceGetExternalMemoryProperties 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnDeviceGetExternalMemoryPropertiesCb_t)(
+    ze_device_get_external_memory_properties_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeDeviceGetP2PProperties 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_device_get_p2_p_properties_params_t
+{
+    ze_device_handle_t* phDevice;
+    ze_device_handle_t* phPeerDevice;
+    ze_device_p2p_properties_t** ppP2PProperties;
+} ze_device_get_p2_p_properties_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeDeviceGetP2PProperties 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnDeviceGetP2PPropertiesCb_t)(
+    ze_device_get_p2_p_properties_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeDeviceCanAccessPeer 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_device_can_access_peer_params_t
+{
+    ze_device_handle_t* phDevice;
+    ze_device_handle_t* phPeerDevice;
+    ze_bool_t** pvalue;
+} ze_device_can_access_peer_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeDeviceCanAccessPeer 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnDeviceCanAccessPeerCb_t)(
+    ze_device_can_access_peer_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeDeviceGetStatus 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_device_get_status_params_t
+{
+    ze_device_handle_t* phDevice;
+} ze_device_get_status_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeDeviceGetStatus 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnDeviceGetStatusCb_t)(
+    ze_device_get_status_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Device callback functions pointers
+typedef struct _ze_device_callbacks_t
+{
+    ze_pfnDeviceGetCb_t                                             pfnGetCb;
+    ze_pfnDeviceGetSubDevicesCb_t                                   pfnGetSubDevicesCb;
+    ze_pfnDeviceGetPropertiesCb_t                                   pfnGetPropertiesCb;
+    ze_pfnDeviceGetComputePropertiesCb_t                            pfnGetComputePropertiesCb;
+    ze_pfnDeviceGetModulePropertiesCb_t                             pfnGetModulePropertiesCb;
+    ze_pfnDeviceGetCommandQueueGroupPropertiesCb_t                  pfnGetCommandQueueGroupPropertiesCb;
+    ze_pfnDeviceGetMemoryPropertiesCb_t                             pfnGetMemoryPropertiesCb;
+    ze_pfnDeviceGetMemoryAccessPropertiesCb_t                       pfnGetMemoryAccessPropertiesCb;
+    ze_pfnDeviceGetCachePropertiesCb_t                              pfnGetCachePropertiesCb;
+    ze_pfnDeviceGetImagePropertiesCb_t                              pfnGetImagePropertiesCb;
+    ze_pfnDeviceGetExternalMemoryPropertiesCb_t                     pfnGetExternalMemoryPropertiesCb;
+    ze_pfnDeviceGetP2PPropertiesCb_t                                pfnGetP2PPropertiesCb;
+    ze_pfnDeviceCanAccessPeerCb_t                                   pfnCanAccessPeerCb;
+    ze_pfnDeviceGetStatusCb_t                                       pfnGetStatusCb;
+} ze_device_callbacks_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeContextCreate 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_context_create_params_t
+{
+    ze_driver_handle_t* phDriver;
+    const ze_context_desc_t** pdesc;
+    ze_context_handle_t** pphContext;
+} ze_context_create_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeContextCreate 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnContextCreateCb_t)(
+    ze_context_create_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeContextDestroy 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_context_destroy_params_t
+{
+    ze_context_handle_t* phContext;
+} ze_context_destroy_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeContextDestroy 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnContextDestroyCb_t)(
+    ze_context_destroy_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeContextGetStatus 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_context_get_status_params_t
+{
+    ze_context_handle_t* phContext;
+} ze_context_get_status_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeContextGetStatus 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnContextGetStatusCb_t)(
+    ze_context_get_status_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeContextSystemBarrier 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_context_system_barrier_params_t
+{
+    ze_context_handle_t* phContext;
+    ze_device_handle_t* phDevice;
+} ze_context_system_barrier_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeContextSystemBarrier 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnContextSystemBarrierCb_t)(
+    ze_context_system_barrier_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeContextMakeMemoryResident 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_context_make_memory_resident_params_t
+{
+    ze_context_handle_t* phContext;
+    ze_device_handle_t* phDevice;
+    void** pptr;
+    size_t* psize;
+} ze_context_make_memory_resident_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeContextMakeMemoryResident 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnContextMakeMemoryResidentCb_t)(
+    ze_context_make_memory_resident_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeContextEvictMemory 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_context_evict_memory_params_t
+{
+    ze_context_handle_t* phContext;
+    ze_device_handle_t* phDevice;
+    void** pptr;
+    size_t* psize;
+} ze_context_evict_memory_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeContextEvictMemory 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnContextEvictMemoryCb_t)(
+    ze_context_evict_memory_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeContextMakeImageResident 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_context_make_image_resident_params_t
+{
+    ze_context_handle_t* phContext;
+    ze_device_handle_t* phDevice;
+    ze_image_handle_t* phImage;
+} ze_context_make_image_resident_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeContextMakeImageResident 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnContextMakeImageResidentCb_t)(
+    ze_context_make_image_resident_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeContextEvictImage 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_context_evict_image_params_t
+{
+    ze_context_handle_t* phContext;
+    ze_device_handle_t* phDevice;
+    ze_image_handle_t* phImage;
+} ze_context_evict_image_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeContextEvictImage 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnContextEvictImageCb_t)(
+    ze_context_evict_image_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Context callback functions pointers
+typedef struct _ze_context_callbacks_t
+{
+    ze_pfnContextCreateCb_t                                         pfnCreateCb;
+    ze_pfnContextDestroyCb_t                                        pfnDestroyCb;
+    ze_pfnContextGetStatusCb_t                                      pfnGetStatusCb;
+    ze_pfnContextSystemBarrierCb_t                                  pfnSystemBarrierCb;
+    ze_pfnContextMakeMemoryResidentCb_t                             pfnMakeMemoryResidentCb;
+    ze_pfnContextEvictMemoryCb_t                                    pfnEvictMemoryCb;
+    ze_pfnContextMakeImageResidentCb_t                              pfnMakeImageResidentCb;
+    ze_pfnContextEvictImageCb_t                                     pfnEvictImageCb;
+} ze_context_callbacks_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandQueueCreate 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_command_queue_create_params_t
+{
+    ze_context_handle_t* phContext;
+    ze_device_handle_t* phDevice;
+    const ze_command_queue_desc_t** pdesc;
+    ze_command_queue_handle_t** pphCommandQueue;
+} ze_command_queue_create_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandQueueCreate 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnCommandQueueCreateCb_t)(
+    ze_command_queue_create_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandQueueDestroy 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_command_queue_destroy_params_t
+{
+    ze_command_queue_handle_t* phCommandQueue;
+} ze_command_queue_destroy_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandQueueDestroy 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnCommandQueueDestroyCb_t)(
+    ze_command_queue_destroy_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandQueueExecuteCommandLists 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_command_queue_execute_command_lists_params_t
+{
+    ze_command_queue_handle_t* phCommandQueue;
+    uint32_t* pnumCommandLists;
+    ze_command_list_handle_t** pphCommandLists;
+    ze_fence_handle_t* phFence;
+} ze_command_queue_execute_command_lists_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandQueueExecuteCommandLists 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnCommandQueueExecuteCommandListsCb_t)(
+    ze_command_queue_execute_command_lists_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandQueueSynchronize 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_command_queue_synchronize_params_t
+{
+    ze_command_queue_handle_t* phCommandQueue;
+    uint64_t* ptimeout;
+} ze_command_queue_synchronize_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandQueueSynchronize 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnCommandQueueSynchronizeCb_t)(
+    ze_command_queue_synchronize_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of CommandQueue callback functions pointers
+typedef struct _ze_command_queue_callbacks_t
+{
+    ze_pfnCommandQueueCreateCb_t                                    pfnCreateCb;
+    ze_pfnCommandQueueDestroyCb_t                                   pfnDestroyCb;
+    ze_pfnCommandQueueExecuteCommandListsCb_t                       pfnExecuteCommandListsCb;
+    ze_pfnCommandQueueSynchronizeCb_t                               pfnSynchronizeCb;
+} ze_command_queue_callbacks_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandListCreate 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_command_list_create_params_t
+{
+    ze_context_handle_t* phContext;
+    ze_device_handle_t* phDevice;
+    const ze_command_list_desc_t** pdesc;
+    ze_command_list_handle_t** pphCommandList;
+} ze_command_list_create_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandListCreate 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnCommandListCreateCb_t)(
+    ze_command_list_create_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandListCreateImmediate 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_command_list_create_immediate_params_t
+{
+    ze_context_handle_t* phContext;
+    ze_device_handle_t* phDevice;
+    const ze_command_queue_desc_t** paltdesc;
+    ze_command_list_handle_t** pphCommandList;
+} ze_command_list_create_immediate_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandListCreateImmediate 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnCommandListCreateImmediateCb_t)(
+    ze_command_list_create_immediate_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandListDestroy 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_command_list_destroy_params_t
+{
+    ze_command_list_handle_t* phCommandList;
+} ze_command_list_destroy_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandListDestroy 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnCommandListDestroyCb_t)(
+    ze_command_list_destroy_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandListClose 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_command_list_close_params_t
+{
+    ze_command_list_handle_t* phCommandList;
+} ze_command_list_close_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandListClose 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnCommandListCloseCb_t)(
+    ze_command_list_close_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandListReset 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_command_list_reset_params_t
+{
+    ze_command_list_handle_t* phCommandList;
+} ze_command_list_reset_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandListReset 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnCommandListResetCb_t)(
+    ze_command_list_reset_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandListAppendWriteGlobalTimestamp 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_command_list_append_write_global_timestamp_params_t
+{
+    ze_command_list_handle_t* phCommandList;
+    uint64_t** pdstptr;
+    ze_event_handle_t* phSignalEvent;
+    uint32_t* pnumWaitEvents;
+    ze_event_handle_t** pphWaitEvents;
+} ze_command_list_append_write_global_timestamp_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandListAppendWriteGlobalTimestamp 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnCommandListAppendWriteGlobalTimestampCb_t)(
+    ze_command_list_append_write_global_timestamp_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandListAppendBarrier 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_command_list_append_barrier_params_t
+{
+    ze_command_list_handle_t* phCommandList;
+    ze_event_handle_t* phSignalEvent;
+    uint32_t* pnumWaitEvents;
+    ze_event_handle_t** pphWaitEvents;
+} ze_command_list_append_barrier_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandListAppendBarrier 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnCommandListAppendBarrierCb_t)(
+    ze_command_list_append_barrier_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandListAppendMemoryRangesBarrier 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_command_list_append_memory_ranges_barrier_params_t
+{
+    ze_command_list_handle_t* phCommandList;
+    uint32_t* pnumRanges;
+    const size_t** ppRangeSizes;
+    const void*** ppRanges;
+    ze_event_handle_t* phSignalEvent;
+    uint32_t* pnumWaitEvents;
+    ze_event_handle_t** pphWaitEvents;
+} ze_command_list_append_memory_ranges_barrier_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandListAppendMemoryRangesBarrier 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnCommandListAppendMemoryRangesBarrierCb_t)(
+    ze_command_list_append_memory_ranges_barrier_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandListAppendMemoryCopy 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_command_list_append_memory_copy_params_t
+{
+    ze_command_list_handle_t* phCommandList;
+    void** pdstptr;
+    const void** psrcptr;
+    size_t* psize;
+    ze_event_handle_t* phSignalEvent;
+    uint32_t* pnumWaitEvents;
+    ze_event_handle_t** pphWaitEvents;
+} ze_command_list_append_memory_copy_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandListAppendMemoryCopy 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnCommandListAppendMemoryCopyCb_t)(
+    ze_command_list_append_memory_copy_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandListAppendMemoryFill 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_command_list_append_memory_fill_params_t
+{
+    ze_command_list_handle_t* phCommandList;
+    void** pptr;
+    const void** ppattern;
+    size_t* ppattern_size;
+    size_t* psize;
+    ze_event_handle_t* phSignalEvent;
+    uint32_t* pnumWaitEvents;
+    ze_event_handle_t** pphWaitEvents;
+} ze_command_list_append_memory_fill_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandListAppendMemoryFill 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnCommandListAppendMemoryFillCb_t)(
+    ze_command_list_append_memory_fill_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandListAppendMemoryCopyRegion 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_command_list_append_memory_copy_region_params_t
+{
+    ze_command_list_handle_t* phCommandList;
+    void** pdstptr;
+    const ze_copy_region_t** pdstRegion;
+    uint32_t* pdstPitch;
+    uint32_t* pdstSlicePitch;
+    const void** psrcptr;
+    const ze_copy_region_t** psrcRegion;
+    uint32_t* psrcPitch;
+    uint32_t* psrcSlicePitch;
+    ze_event_handle_t* phSignalEvent;
+    uint32_t* pnumWaitEvents;
+    ze_event_handle_t** pphWaitEvents;
+} ze_command_list_append_memory_copy_region_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandListAppendMemoryCopyRegion 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnCommandListAppendMemoryCopyRegionCb_t)(
+    ze_command_list_append_memory_copy_region_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandListAppendMemoryCopyFromContext 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_command_list_append_memory_copy_from_context_params_t
+{
+    ze_command_list_handle_t* phCommandList;
+    void** pdstptr;
+    ze_context_handle_t* phContextSrc;
+    const void** psrcptr;
+    size_t* psize;
+    ze_event_handle_t* phSignalEvent;
+    uint32_t* pnumWaitEvents;
+    ze_event_handle_t** pphWaitEvents;
+} ze_command_list_append_memory_copy_from_context_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandListAppendMemoryCopyFromContext 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnCommandListAppendMemoryCopyFromContextCb_t)(
+    ze_command_list_append_memory_copy_from_context_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandListAppendImageCopy 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_command_list_append_image_copy_params_t
+{
+    ze_command_list_handle_t* phCommandList;
+    ze_image_handle_t* phDstImage;
+    ze_image_handle_t* phSrcImage;
+    ze_event_handle_t* phSignalEvent;
+    uint32_t* pnumWaitEvents;
+    ze_event_handle_t** pphWaitEvents;
+} ze_command_list_append_image_copy_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandListAppendImageCopy 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnCommandListAppendImageCopyCb_t)(
+    ze_command_list_append_image_copy_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandListAppendImageCopyRegion 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_command_list_append_image_copy_region_params_t
+{
+    ze_command_list_handle_t* phCommandList;
+    ze_image_handle_t* phDstImage;
+    ze_image_handle_t* phSrcImage;
+    const ze_image_region_t** ppDstRegion;
+    const ze_image_region_t** ppSrcRegion;
+    ze_event_handle_t* phSignalEvent;
+    uint32_t* pnumWaitEvents;
+    ze_event_handle_t** pphWaitEvents;
+} ze_command_list_append_image_copy_region_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandListAppendImageCopyRegion 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnCommandListAppendImageCopyRegionCb_t)(
+    ze_command_list_append_image_copy_region_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandListAppendImageCopyToMemory 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_command_list_append_image_copy_to_memory_params_t
+{
+    ze_command_list_handle_t* phCommandList;
+    void** pdstptr;
+    ze_image_handle_t* phSrcImage;
+    const ze_image_region_t** ppSrcRegion;
+    ze_event_handle_t* phSignalEvent;
+    uint32_t* pnumWaitEvents;
+    ze_event_handle_t** pphWaitEvents;
+} ze_command_list_append_image_copy_to_memory_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandListAppendImageCopyToMemory 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnCommandListAppendImageCopyToMemoryCb_t)(
+    ze_command_list_append_image_copy_to_memory_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandListAppendImageCopyFromMemory 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_command_list_append_image_copy_from_memory_params_t
+{
+    ze_command_list_handle_t* phCommandList;
+    ze_image_handle_t* phDstImage;
+    const void** psrcptr;
+    const ze_image_region_t** ppDstRegion;
+    ze_event_handle_t* phSignalEvent;
+    uint32_t* pnumWaitEvents;
+    ze_event_handle_t** pphWaitEvents;
+} ze_command_list_append_image_copy_from_memory_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandListAppendImageCopyFromMemory 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnCommandListAppendImageCopyFromMemoryCb_t)(
+    ze_command_list_append_image_copy_from_memory_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandListAppendMemoryPrefetch 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_command_list_append_memory_prefetch_params_t
+{
+    ze_command_list_handle_t* phCommandList;
+    const void** pptr;
+    size_t* psize;
+} ze_command_list_append_memory_prefetch_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandListAppendMemoryPrefetch 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnCommandListAppendMemoryPrefetchCb_t)(
+    ze_command_list_append_memory_prefetch_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandListAppendMemAdvise 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_command_list_append_mem_advise_params_t
+{
+    ze_command_list_handle_t* phCommandList;
+    ze_device_handle_t* phDevice;
+    const void** pptr;
+    size_t* psize;
+    ze_memory_advice_t* padvice;
+} ze_command_list_append_mem_advise_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandListAppendMemAdvise 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnCommandListAppendMemAdviseCb_t)(
+    ze_command_list_append_mem_advise_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandListAppendSignalEvent 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_command_list_append_signal_event_params_t
+{
+    ze_command_list_handle_t* phCommandList;
+    ze_event_handle_t* phEvent;
+} ze_command_list_append_signal_event_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandListAppendSignalEvent 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnCommandListAppendSignalEventCb_t)(
+    ze_command_list_append_signal_event_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandListAppendWaitOnEvents 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_command_list_append_wait_on_events_params_t
+{
+    ze_command_list_handle_t* phCommandList;
+    uint32_t* pnumEvents;
+    ze_event_handle_t** pphEvents;
+} ze_command_list_append_wait_on_events_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandListAppendWaitOnEvents 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnCommandListAppendWaitOnEventsCb_t)(
+    ze_command_list_append_wait_on_events_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandListAppendEventReset 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_command_list_append_event_reset_params_t
+{
+    ze_command_list_handle_t* phCommandList;
+    ze_event_handle_t* phEvent;
+} ze_command_list_append_event_reset_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandListAppendEventReset 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnCommandListAppendEventResetCb_t)(
+    ze_command_list_append_event_reset_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandListAppendQueryKernelTimestamps 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_command_list_append_query_kernel_timestamps_params_t
+{
+    ze_command_list_handle_t* phCommandList;
+    uint32_t* pnumEvents;
+    ze_event_handle_t** pphEvents;
+    void** pdstptr;
+    const size_t** ppOffsets;
+    ze_event_handle_t* phSignalEvent;
+    uint32_t* pnumWaitEvents;
+    ze_event_handle_t** pphWaitEvents;
+} ze_command_list_append_query_kernel_timestamps_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandListAppendQueryKernelTimestamps 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnCommandListAppendQueryKernelTimestampsCb_t)(
+    ze_command_list_append_query_kernel_timestamps_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandListAppendLaunchKernel 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_command_list_append_launch_kernel_params_t
+{
+    ze_command_list_handle_t* phCommandList;
+    ze_kernel_handle_t* phKernel;
+    const ze_group_count_t** ppLaunchFuncArgs;
+    ze_event_handle_t* phSignalEvent;
+    uint32_t* pnumWaitEvents;
+    ze_event_handle_t** pphWaitEvents;
+} ze_command_list_append_launch_kernel_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandListAppendLaunchKernel 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnCommandListAppendLaunchKernelCb_t)(
+    ze_command_list_append_launch_kernel_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandListAppendLaunchCooperativeKernel 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_command_list_append_launch_cooperative_kernel_params_t
+{
+    ze_command_list_handle_t* phCommandList;
+    ze_kernel_handle_t* phKernel;
+    const ze_group_count_t** ppLaunchFuncArgs;
+    ze_event_handle_t* phSignalEvent;
+    uint32_t* pnumWaitEvents;
+    ze_event_handle_t** pphWaitEvents;
+} ze_command_list_append_launch_cooperative_kernel_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandListAppendLaunchCooperativeKernel 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnCommandListAppendLaunchCooperativeKernelCb_t)(
+    ze_command_list_append_launch_cooperative_kernel_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandListAppendLaunchKernelIndirect 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_command_list_append_launch_kernel_indirect_params_t
+{
+    ze_command_list_handle_t* phCommandList;
+    ze_kernel_handle_t* phKernel;
+    const ze_group_count_t** ppLaunchArgumentsBuffer;
+    ze_event_handle_t* phSignalEvent;
+    uint32_t* pnumWaitEvents;
+    ze_event_handle_t** pphWaitEvents;
+} ze_command_list_append_launch_kernel_indirect_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandListAppendLaunchKernelIndirect 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnCommandListAppendLaunchKernelIndirectCb_t)(
+    ze_command_list_append_launch_kernel_indirect_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeCommandListAppendLaunchMultipleKernelsIndirect 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_command_list_append_launch_multiple_kernels_indirect_params_t
+{
+    ze_command_list_handle_t* phCommandList;
+    uint32_t* pnumKernels;
+    ze_kernel_handle_t** pphKernels;
+    const uint32_t** ppCountBuffer;
+    const ze_group_count_t** ppLaunchArgumentsBuffer;
+    ze_event_handle_t* phSignalEvent;
+    uint32_t* pnumWaitEvents;
+    ze_event_handle_t** pphWaitEvents;
+} ze_command_list_append_launch_multiple_kernels_indirect_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeCommandListAppendLaunchMultipleKernelsIndirect 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnCommandListAppendLaunchMultipleKernelsIndirectCb_t)(
+    ze_command_list_append_launch_multiple_kernels_indirect_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of CommandList callback functions pointers
+typedef struct _ze_command_list_callbacks_t
+{
+    ze_pfnCommandListCreateCb_t                                     pfnCreateCb;
+    ze_pfnCommandListCreateImmediateCb_t                            pfnCreateImmediateCb;
+    ze_pfnCommandListDestroyCb_t                                    pfnDestroyCb;
+    ze_pfnCommandListCloseCb_t                                      pfnCloseCb;
+    ze_pfnCommandListResetCb_t                                      pfnResetCb;
+    ze_pfnCommandListAppendWriteGlobalTimestampCb_t                 pfnAppendWriteGlobalTimestampCb;
+    ze_pfnCommandListAppendBarrierCb_t                              pfnAppendBarrierCb;
+    ze_pfnCommandListAppendMemoryRangesBarrierCb_t                  pfnAppendMemoryRangesBarrierCb;
+    ze_pfnCommandListAppendMemoryCopyCb_t                           pfnAppendMemoryCopyCb;
+    ze_pfnCommandListAppendMemoryFillCb_t                           pfnAppendMemoryFillCb;
+    ze_pfnCommandListAppendMemoryCopyRegionCb_t                     pfnAppendMemoryCopyRegionCb;
+    ze_pfnCommandListAppendMemoryCopyFromContextCb_t                pfnAppendMemoryCopyFromContextCb;
+    ze_pfnCommandListAppendImageCopyCb_t                            pfnAppendImageCopyCb;
+    ze_pfnCommandListAppendImageCopyRegionCb_t                      pfnAppendImageCopyRegionCb;
+    ze_pfnCommandListAppendImageCopyToMemoryCb_t                    pfnAppendImageCopyToMemoryCb;
+    ze_pfnCommandListAppendImageCopyFromMemoryCb_t                  pfnAppendImageCopyFromMemoryCb;
+    ze_pfnCommandListAppendMemoryPrefetchCb_t                       pfnAppendMemoryPrefetchCb;
+    ze_pfnCommandListAppendMemAdviseCb_t                            pfnAppendMemAdviseCb;
+    ze_pfnCommandListAppendSignalEventCb_t                          pfnAppendSignalEventCb;
+    ze_pfnCommandListAppendWaitOnEventsCb_t                         pfnAppendWaitOnEventsCb;
+    ze_pfnCommandListAppendEventResetCb_t                           pfnAppendEventResetCb;
+    ze_pfnCommandListAppendQueryKernelTimestampsCb_t                pfnAppendQueryKernelTimestampsCb;
+    ze_pfnCommandListAppendLaunchKernelCb_t                         pfnAppendLaunchKernelCb;
+    ze_pfnCommandListAppendLaunchCooperativeKernelCb_t              pfnAppendLaunchCooperativeKernelCb;
+    ze_pfnCommandListAppendLaunchKernelIndirectCb_t                 pfnAppendLaunchKernelIndirectCb;
+    ze_pfnCommandListAppendLaunchMultipleKernelsIndirectCb_t        pfnAppendLaunchMultipleKernelsIndirectCb;
+} ze_command_list_callbacks_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeImageGetProperties 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_image_get_properties_params_t
+{
+    ze_device_handle_t* phDevice;
+    const ze_image_desc_t** pdesc;
+    ze_image_properties_t** ppImageProperties;
+} ze_image_get_properties_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeImageGetProperties 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnImageGetPropertiesCb_t)(
+    ze_image_get_properties_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeImageCreate 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_image_create_params_t
+{
+    ze_context_handle_t* phContext;
+    ze_device_handle_t* phDevice;
+    const ze_image_desc_t** pdesc;
+    ze_image_handle_t** pphImage;
+} ze_image_create_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeImageCreate 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnImageCreateCb_t)(
+    ze_image_create_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeImageDestroy 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_image_destroy_params_t
+{
+    ze_image_handle_t* phImage;
+} ze_image_destroy_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeImageDestroy 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnImageDestroyCb_t)(
+    ze_image_destroy_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Image callback functions pointers
+typedef struct _ze_image_callbacks_t
+{
+    ze_pfnImageGetPropertiesCb_t                                    pfnGetPropertiesCb;
+    ze_pfnImageCreateCb_t                                           pfnCreateCb;
+    ze_pfnImageDestroyCb_t                                          pfnDestroyCb;
+} ze_image_callbacks_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeMemAllocShared 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_mem_alloc_shared_params_t
+{
+    ze_context_handle_t* phContext;
+    const ze_device_mem_alloc_desc_t** pdevice_desc;
+    const ze_host_mem_alloc_desc_t** phost_desc;
+    size_t* psize;
+    size_t* palignment;
+    ze_device_handle_t* phDevice;
+    void*** ppptr;
+} ze_mem_alloc_shared_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeMemAllocShared 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnMemAllocSharedCb_t)(
+    ze_mem_alloc_shared_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeMemAllocDevice 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_mem_alloc_device_params_t
+{
+    ze_context_handle_t* phContext;
+    const ze_device_mem_alloc_desc_t** pdevice_desc;
+    size_t* psize;
+    size_t* palignment;
+    ze_device_handle_t* phDevice;
+    void*** ppptr;
+} ze_mem_alloc_device_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeMemAllocDevice 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnMemAllocDeviceCb_t)(
+    ze_mem_alloc_device_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeMemAllocHost 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_mem_alloc_host_params_t
+{
+    ze_context_handle_t* phContext;
+    const ze_host_mem_alloc_desc_t** phost_desc;
+    size_t* psize;
+    size_t* palignment;
+    void*** ppptr;
+} ze_mem_alloc_host_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeMemAllocHost 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnMemAllocHostCb_t)(
+    ze_mem_alloc_host_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeMemFree 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_mem_free_params_t
+{
+    ze_context_handle_t* phContext;
+    void** pptr;
+} ze_mem_free_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeMemFree 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnMemFreeCb_t)(
+    ze_mem_free_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeMemGetAllocProperties 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_mem_get_alloc_properties_params_t
+{
+    ze_context_handle_t* phContext;
+    const void** pptr;
+    ze_memory_allocation_properties_t** ppMemAllocProperties;
+    ze_device_handle_t** pphDevice;
+} ze_mem_get_alloc_properties_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeMemGetAllocProperties 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnMemGetAllocPropertiesCb_t)(
+    ze_mem_get_alloc_properties_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeMemGetAddressRange 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_mem_get_address_range_params_t
+{
+    ze_context_handle_t* phContext;
+    const void** pptr;
+    void*** ppBase;
+    size_t** ppSize;
+} ze_mem_get_address_range_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeMemGetAddressRange 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnMemGetAddressRangeCb_t)(
+    ze_mem_get_address_range_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeMemGetIpcHandle 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_mem_get_ipc_handle_params_t
+{
+    ze_context_handle_t* phContext;
+    const void** pptr;
+    ze_ipc_mem_handle_t** ppIpcHandle;
+} ze_mem_get_ipc_handle_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeMemGetIpcHandle 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnMemGetIpcHandleCb_t)(
+    ze_mem_get_ipc_handle_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeMemOpenIpcHandle 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_mem_open_ipc_handle_params_t
+{
+    ze_context_handle_t* phContext;
+    ze_device_handle_t* phDevice;
+    ze_ipc_mem_handle_t* phandle;
+    ze_ipc_memory_flags_t* pflags;
+    void*** ppptr;
+} ze_mem_open_ipc_handle_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeMemOpenIpcHandle 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnMemOpenIpcHandleCb_t)(
+    ze_mem_open_ipc_handle_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeMemCloseIpcHandle 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_mem_close_ipc_handle_params_t
+{
+    ze_context_handle_t* phContext;
+    const void** pptr;
+} ze_mem_close_ipc_handle_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeMemCloseIpcHandle 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnMemCloseIpcHandleCb_t)(
+    ze_mem_close_ipc_handle_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Mem callback functions pointers
+typedef struct _ze_mem_callbacks_t
+{
+    ze_pfnMemAllocSharedCb_t                                        pfnAllocSharedCb;
+    ze_pfnMemAllocDeviceCb_t                                        pfnAllocDeviceCb;
+    ze_pfnMemAllocHostCb_t                                          pfnAllocHostCb;
+    ze_pfnMemFreeCb_t                                               pfnFreeCb;
+    ze_pfnMemGetAllocPropertiesCb_t                                 pfnGetAllocPropertiesCb;
+    ze_pfnMemGetAddressRangeCb_t                                    pfnGetAddressRangeCb;
+    ze_pfnMemGetIpcHandleCb_t                                       pfnGetIpcHandleCb;
+    ze_pfnMemOpenIpcHandleCb_t                                      pfnOpenIpcHandleCb;
+    ze_pfnMemCloseIpcHandleCb_t                                     pfnCloseIpcHandleCb;
+} ze_mem_callbacks_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeFenceCreate 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_fence_create_params_t
+{
+    ze_command_queue_handle_t* phCommandQueue;
+    const ze_fence_desc_t** pdesc;
+    ze_fence_handle_t** pphFence;
+} ze_fence_create_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeFenceCreate 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnFenceCreateCb_t)(
+    ze_fence_create_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeFenceDestroy 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_fence_destroy_params_t
+{
+    ze_fence_handle_t* phFence;
+} ze_fence_destroy_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeFenceDestroy 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnFenceDestroyCb_t)(
+    ze_fence_destroy_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeFenceHostSynchronize 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_fence_host_synchronize_params_t
+{
+    ze_fence_handle_t* phFence;
+    uint64_t* ptimeout;
+} ze_fence_host_synchronize_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeFenceHostSynchronize 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnFenceHostSynchronizeCb_t)(
+    ze_fence_host_synchronize_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeFenceQueryStatus 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_fence_query_status_params_t
+{
+    ze_fence_handle_t* phFence;
+} ze_fence_query_status_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeFenceQueryStatus 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnFenceQueryStatusCb_t)(
+    ze_fence_query_status_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeFenceReset 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_fence_reset_params_t
+{
+    ze_fence_handle_t* phFence;
+} ze_fence_reset_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeFenceReset 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnFenceResetCb_t)(
+    ze_fence_reset_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Fence callback functions pointers
+typedef struct _ze_fence_callbacks_t
+{
+    ze_pfnFenceCreateCb_t                                           pfnCreateCb;
+    ze_pfnFenceDestroyCb_t                                          pfnDestroyCb;
+    ze_pfnFenceHostSynchronizeCb_t                                  pfnHostSynchronizeCb;
+    ze_pfnFenceQueryStatusCb_t                                      pfnQueryStatusCb;
+    ze_pfnFenceResetCb_t                                            pfnResetCb;
+} ze_fence_callbacks_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeEventPoolCreate 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_event_pool_create_params_t
+{
+    ze_context_handle_t* phContext;
+    const ze_event_pool_desc_t** pdesc;
+    uint32_t* pnumDevices;
+    ze_device_handle_t** pphDevices;
+    ze_event_pool_handle_t** pphEventPool;
+} ze_event_pool_create_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeEventPoolCreate 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnEventPoolCreateCb_t)(
+    ze_event_pool_create_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeEventPoolDestroy 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_event_pool_destroy_params_t
+{
+    ze_event_pool_handle_t* phEventPool;
+} ze_event_pool_destroy_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeEventPoolDestroy 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnEventPoolDestroyCb_t)(
+    ze_event_pool_destroy_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeEventPoolGetIpcHandle 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_event_pool_get_ipc_handle_params_t
+{
+    ze_event_pool_handle_t* phEventPool;
+    ze_ipc_event_pool_handle_t** pphIpc;
+} ze_event_pool_get_ipc_handle_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeEventPoolGetIpcHandle 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnEventPoolGetIpcHandleCb_t)(
+    ze_event_pool_get_ipc_handle_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeEventPoolOpenIpcHandle 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_event_pool_open_ipc_handle_params_t
+{
+    ze_context_handle_t* phContext;
+    ze_ipc_event_pool_handle_t* phIpc;
+    ze_event_pool_handle_t** pphEventPool;
+} ze_event_pool_open_ipc_handle_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeEventPoolOpenIpcHandle 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnEventPoolOpenIpcHandleCb_t)(
+    ze_event_pool_open_ipc_handle_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeEventPoolCloseIpcHandle 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_event_pool_close_ipc_handle_params_t
+{
+    ze_event_pool_handle_t* phEventPool;
+} ze_event_pool_close_ipc_handle_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeEventPoolCloseIpcHandle 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnEventPoolCloseIpcHandleCb_t)(
+    ze_event_pool_close_ipc_handle_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of EventPool callback functions pointers
+typedef struct _ze_event_pool_callbacks_t
+{
+    ze_pfnEventPoolCreateCb_t                                       pfnCreateCb;
+    ze_pfnEventPoolDestroyCb_t                                      pfnDestroyCb;
+    ze_pfnEventPoolGetIpcHandleCb_t                                 pfnGetIpcHandleCb;
+    ze_pfnEventPoolOpenIpcHandleCb_t                                pfnOpenIpcHandleCb;
+    ze_pfnEventPoolCloseIpcHandleCb_t                               pfnCloseIpcHandleCb;
+} ze_event_pool_callbacks_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeEventCreate 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_event_create_params_t
+{
+    ze_event_pool_handle_t* phEventPool;
+    const ze_event_desc_t** pdesc;
+    ze_event_handle_t** pphEvent;
+} ze_event_create_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeEventCreate 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnEventCreateCb_t)(
+    ze_event_create_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeEventDestroy 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_event_destroy_params_t
+{
+    ze_event_handle_t* phEvent;
+} ze_event_destroy_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeEventDestroy 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnEventDestroyCb_t)(
+    ze_event_destroy_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeEventHostSignal 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_event_host_signal_params_t
+{
+    ze_event_handle_t* phEvent;
+} ze_event_host_signal_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeEventHostSignal 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnEventHostSignalCb_t)(
+    ze_event_host_signal_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeEventHostSynchronize 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_event_host_synchronize_params_t
+{
+    ze_event_handle_t* phEvent;
+    uint64_t* ptimeout;
+} ze_event_host_synchronize_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeEventHostSynchronize 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnEventHostSynchronizeCb_t)(
+    ze_event_host_synchronize_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeEventQueryStatus 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_event_query_status_params_t
+{
+    ze_event_handle_t* phEvent;
+} ze_event_query_status_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeEventQueryStatus 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnEventQueryStatusCb_t)(
+    ze_event_query_status_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeEventHostReset 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_event_host_reset_params_t
+{
+    ze_event_handle_t* phEvent;
+} ze_event_host_reset_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeEventHostReset 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnEventHostResetCb_t)(
+    ze_event_host_reset_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeEventQueryKernelTimestamp 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_event_query_kernel_timestamp_params_t
+{
+    ze_event_handle_t* phEvent;
+    ze_kernel_timestamp_result_t** pdstptr;
+} ze_event_query_kernel_timestamp_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeEventQueryKernelTimestamp 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnEventQueryKernelTimestampCb_t)(
+    ze_event_query_kernel_timestamp_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Event callback functions pointers
+typedef struct _ze_event_callbacks_t
+{
+    ze_pfnEventCreateCb_t                                           pfnCreateCb;
+    ze_pfnEventDestroyCb_t                                          pfnDestroyCb;
+    ze_pfnEventHostSignalCb_t                                       pfnHostSignalCb;
+    ze_pfnEventHostSynchronizeCb_t                                  pfnHostSynchronizeCb;
+    ze_pfnEventQueryStatusCb_t                                      pfnQueryStatusCb;
+    ze_pfnEventHostResetCb_t                                        pfnHostResetCb;
+    ze_pfnEventQueryKernelTimestampCb_t                             pfnQueryKernelTimestampCb;
+} ze_event_callbacks_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeModuleCreate 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_module_create_params_t
+{
+    ze_context_handle_t* phContext;
+    ze_device_handle_t* phDevice;
+    const ze_module_desc_t** pdesc;
+    ze_module_handle_t** pphModule;
+    ze_module_build_log_handle_t** pphBuildLog;
+} ze_module_create_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeModuleCreate 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnModuleCreateCb_t)(
+    ze_module_create_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeModuleDestroy 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_module_destroy_params_t
+{
+    ze_module_handle_t* phModule;
+} ze_module_destroy_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeModuleDestroy 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnModuleDestroyCb_t)(
+    ze_module_destroy_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeModuleDynamicLink 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_module_dynamic_link_params_t
+{
+    uint32_t* pnumModules;
+    ze_module_handle_t** pphModules;
+    ze_module_build_log_handle_t** pphLinkLog;
+} ze_module_dynamic_link_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeModuleDynamicLink 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnModuleDynamicLinkCb_t)(
+    ze_module_dynamic_link_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeModuleGetNativeBinary 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_module_get_native_binary_params_t
+{
+    ze_module_handle_t* phModule;
+    size_t** ppSize;
+    uint8_t** ppModuleNativeBinary;
+} ze_module_get_native_binary_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeModuleGetNativeBinary 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnModuleGetNativeBinaryCb_t)(
+    ze_module_get_native_binary_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeModuleGetGlobalPointer 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_module_get_global_pointer_params_t
+{
+    ze_module_handle_t* phModule;
+    const char** ppGlobalName;
+    size_t** ppSize;
+    void*** ppptr;
+} ze_module_get_global_pointer_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeModuleGetGlobalPointer 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnModuleGetGlobalPointerCb_t)(
+    ze_module_get_global_pointer_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeModuleGetKernelNames 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_module_get_kernel_names_params_t
+{
+    ze_module_handle_t* phModule;
+    uint32_t** ppCount;
+    const char*** ppNames;
+} ze_module_get_kernel_names_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeModuleGetKernelNames 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnModuleGetKernelNamesCb_t)(
+    ze_module_get_kernel_names_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeModuleGetProperties 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_module_get_properties_params_t
+{
+    ze_module_handle_t* phModule;
+    ze_module_properties_t** ppModuleProperties;
+} ze_module_get_properties_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeModuleGetProperties 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnModuleGetPropertiesCb_t)(
+    ze_module_get_properties_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeModuleGetFunctionPointer 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_module_get_function_pointer_params_t
+{
+    ze_module_handle_t* phModule;
+    const char** ppFunctionName;
+    void*** ppfnFunction;
+} ze_module_get_function_pointer_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeModuleGetFunctionPointer 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnModuleGetFunctionPointerCb_t)(
+    ze_module_get_function_pointer_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Module callback functions pointers
+typedef struct _ze_module_callbacks_t
+{
+    ze_pfnModuleCreateCb_t                                          pfnCreateCb;
+    ze_pfnModuleDestroyCb_t                                         pfnDestroyCb;
+    ze_pfnModuleDynamicLinkCb_t                                     pfnDynamicLinkCb;
+    ze_pfnModuleGetNativeBinaryCb_t                                 pfnGetNativeBinaryCb;
+    ze_pfnModuleGetGlobalPointerCb_t                                pfnGetGlobalPointerCb;
+    ze_pfnModuleGetKernelNamesCb_t                                  pfnGetKernelNamesCb;
+    ze_pfnModuleGetPropertiesCb_t                                   pfnGetPropertiesCb;
+    ze_pfnModuleGetFunctionPointerCb_t                              pfnGetFunctionPointerCb;
+} ze_module_callbacks_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeModuleBuildLogDestroy 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_module_build_log_destroy_params_t
+{
+    ze_module_build_log_handle_t* phModuleBuildLog;
+} ze_module_build_log_destroy_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeModuleBuildLogDestroy 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnModuleBuildLogDestroyCb_t)(
+    ze_module_build_log_destroy_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeModuleBuildLogGetString 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_module_build_log_get_string_params_t
+{
+    ze_module_build_log_handle_t* phModuleBuildLog;
+    size_t** ppSize;
+    char** ppBuildLog;
+} ze_module_build_log_get_string_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeModuleBuildLogGetString 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnModuleBuildLogGetStringCb_t)(
+    ze_module_build_log_get_string_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of ModuleBuildLog callback functions pointers
+typedef struct _ze_module_build_log_callbacks_t
+{
+    ze_pfnModuleBuildLogDestroyCb_t                                 pfnDestroyCb;
+    ze_pfnModuleBuildLogGetStringCb_t                               pfnGetStringCb;
+} ze_module_build_log_callbacks_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeKernelCreate 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_kernel_create_params_t
+{
+    ze_module_handle_t* phModule;
+    const ze_kernel_desc_t** pdesc;
+    ze_kernel_handle_t** pphKernel;
+} ze_kernel_create_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeKernelCreate 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnKernelCreateCb_t)(
+    ze_kernel_create_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeKernelDestroy 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_kernel_destroy_params_t
+{
+    ze_kernel_handle_t* phKernel;
+} ze_kernel_destroy_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeKernelDestroy 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnKernelDestroyCb_t)(
+    ze_kernel_destroy_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeKernelSetCacheConfig 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_kernel_set_cache_config_params_t
+{
+    ze_kernel_handle_t* phKernel;
+    ze_cache_config_flags_t* pflags;
+} ze_kernel_set_cache_config_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeKernelSetCacheConfig 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnKernelSetCacheConfigCb_t)(
+    ze_kernel_set_cache_config_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeKernelSetGroupSize 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_kernel_set_group_size_params_t
+{
+    ze_kernel_handle_t* phKernel;
+    uint32_t* pgroupSizeX;
+    uint32_t* pgroupSizeY;
+    uint32_t* pgroupSizeZ;
+} ze_kernel_set_group_size_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeKernelSetGroupSize 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnKernelSetGroupSizeCb_t)(
+    ze_kernel_set_group_size_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeKernelSuggestGroupSize 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_kernel_suggest_group_size_params_t
+{
+    ze_kernel_handle_t* phKernel;
+    uint32_t* pglobalSizeX;
+    uint32_t* pglobalSizeY;
+    uint32_t* pglobalSizeZ;
+    uint32_t** pgroupSizeX;
+    uint32_t** pgroupSizeY;
+    uint32_t** pgroupSizeZ;
+} ze_kernel_suggest_group_size_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeKernelSuggestGroupSize 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnKernelSuggestGroupSizeCb_t)(
+    ze_kernel_suggest_group_size_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeKernelSuggestMaxCooperativeGroupCount 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_kernel_suggest_max_cooperative_group_count_params_t
+{
+    ze_kernel_handle_t* phKernel;
+    uint32_t** ptotalGroupCount;
+} ze_kernel_suggest_max_cooperative_group_count_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeKernelSuggestMaxCooperativeGroupCount 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnKernelSuggestMaxCooperativeGroupCountCb_t)(
+    ze_kernel_suggest_max_cooperative_group_count_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeKernelSetArgumentValue 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_kernel_set_argument_value_params_t
+{
+    ze_kernel_handle_t* phKernel;
+    uint32_t* pargIndex;
+    size_t* pargSize;
+    const void** ppArgValue;
+} ze_kernel_set_argument_value_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeKernelSetArgumentValue 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnKernelSetArgumentValueCb_t)(
+    ze_kernel_set_argument_value_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeKernelSetIndirectAccess 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_kernel_set_indirect_access_params_t
+{
+    ze_kernel_handle_t* phKernel;
+    ze_kernel_indirect_access_flags_t* pflags;
+} ze_kernel_set_indirect_access_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeKernelSetIndirectAccess 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnKernelSetIndirectAccessCb_t)(
+    ze_kernel_set_indirect_access_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeKernelGetIndirectAccess 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_kernel_get_indirect_access_params_t
+{
+    ze_kernel_handle_t* phKernel;
+    ze_kernel_indirect_access_flags_t** ppFlags;
+} ze_kernel_get_indirect_access_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeKernelGetIndirectAccess 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnKernelGetIndirectAccessCb_t)(
+    ze_kernel_get_indirect_access_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeKernelGetSourceAttributes 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_kernel_get_source_attributes_params_t
+{
+    ze_kernel_handle_t* phKernel;
+    uint32_t** ppSize;
+    char*** ppString;
+} ze_kernel_get_source_attributes_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeKernelGetSourceAttributes 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnKernelGetSourceAttributesCb_t)(
+    ze_kernel_get_source_attributes_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeKernelGetProperties 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_kernel_get_properties_params_t
+{
+    ze_kernel_handle_t* phKernel;
+    ze_kernel_properties_t** ppKernelProperties;
+} ze_kernel_get_properties_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeKernelGetProperties 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnKernelGetPropertiesCb_t)(
+    ze_kernel_get_properties_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeKernelGetName 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_kernel_get_name_params_t
+{
+    ze_kernel_handle_t* phKernel;
+    size_t** ppSize;
+    char** ppName;
+} ze_kernel_get_name_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeKernelGetName 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnKernelGetNameCb_t)(
+    ze_kernel_get_name_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Kernel callback functions pointers
+typedef struct _ze_kernel_callbacks_t
+{
+    ze_pfnKernelCreateCb_t                                          pfnCreateCb;
+    ze_pfnKernelDestroyCb_t                                         pfnDestroyCb;
+    ze_pfnKernelSetCacheConfigCb_t                                  pfnSetCacheConfigCb;
+    ze_pfnKernelSetGroupSizeCb_t                                    pfnSetGroupSizeCb;
+    ze_pfnKernelSuggestGroupSizeCb_t                                pfnSuggestGroupSizeCb;
+    ze_pfnKernelSuggestMaxCooperativeGroupCountCb_t                 pfnSuggestMaxCooperativeGroupCountCb;
+    ze_pfnKernelSetArgumentValueCb_t                                pfnSetArgumentValueCb;
+    ze_pfnKernelSetIndirectAccessCb_t                               pfnSetIndirectAccessCb;
+    ze_pfnKernelGetIndirectAccessCb_t                               pfnGetIndirectAccessCb;
+    ze_pfnKernelGetSourceAttributesCb_t                             pfnGetSourceAttributesCb;
+    ze_pfnKernelGetPropertiesCb_t                                   pfnGetPropertiesCb;
+    ze_pfnKernelGetNameCb_t                                         pfnGetNameCb;
+} ze_kernel_callbacks_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeSamplerCreate 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_sampler_create_params_t
+{
+    ze_context_handle_t* phContext;
+    ze_device_handle_t* phDevice;
+    const ze_sampler_desc_t** pdesc;
+    ze_sampler_handle_t** pphSampler;
+} ze_sampler_create_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeSamplerCreate 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnSamplerCreateCb_t)(
+    ze_sampler_create_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeSamplerDestroy 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_sampler_destroy_params_t
+{
+    ze_sampler_handle_t* phSampler;
+} ze_sampler_destroy_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeSamplerDestroy 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnSamplerDestroyCb_t)(
+    ze_sampler_destroy_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Sampler callback functions pointers
+typedef struct _ze_sampler_callbacks_t
+{
+    ze_pfnSamplerCreateCb_t                                         pfnCreateCb;
+    ze_pfnSamplerDestroyCb_t                                        pfnDestroyCb;
+} ze_sampler_callbacks_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zePhysicalMemCreate 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_physical_mem_create_params_t
+{
+    ze_context_handle_t* phContext;
+    ze_device_handle_t* phDevice;
+    ze_physical_mem_desc_t** pdesc;
+    ze_physical_mem_handle_t** pphPhysicalMemory;
+} ze_physical_mem_create_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zePhysicalMemCreate 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnPhysicalMemCreateCb_t)(
+    ze_physical_mem_create_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zePhysicalMemDestroy 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_physical_mem_destroy_params_t
+{
+    ze_context_handle_t* phContext;
+    ze_physical_mem_handle_t* phPhysicalMemory;
+} ze_physical_mem_destroy_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zePhysicalMemDestroy 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnPhysicalMemDestroyCb_t)(
+    ze_physical_mem_destroy_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of PhysicalMem callback functions pointers
+typedef struct _ze_physical_mem_callbacks_t
+{
+    ze_pfnPhysicalMemCreateCb_t                                     pfnCreateCb;
+    ze_pfnPhysicalMemDestroyCb_t                                    pfnDestroyCb;
+} ze_physical_mem_callbacks_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeVirtualMemReserve 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_virtual_mem_reserve_params_t
+{
+    ze_context_handle_t* phContext;
+    const void** ppStart;
+    size_t* psize;
+    void*** ppptr;
+} ze_virtual_mem_reserve_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeVirtualMemReserve 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnVirtualMemReserveCb_t)(
+    ze_virtual_mem_reserve_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeVirtualMemFree 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_virtual_mem_free_params_t
+{
+    ze_context_handle_t* phContext;
+    const void** pptr;
+    size_t* psize;
+} ze_virtual_mem_free_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeVirtualMemFree 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnVirtualMemFreeCb_t)(
+    ze_virtual_mem_free_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeVirtualMemQueryPageSize 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_virtual_mem_query_page_size_params_t
+{
+    ze_context_handle_t* phContext;
+    ze_device_handle_t* phDevice;
+    size_t* psize;
+    size_t** ppagesize;
+} ze_virtual_mem_query_page_size_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeVirtualMemQueryPageSize 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnVirtualMemQueryPageSizeCb_t)(
+    ze_virtual_mem_query_page_size_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeVirtualMemMap 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_virtual_mem_map_params_t
+{
+    ze_context_handle_t* phContext;
+    const void** pptr;
+    size_t* psize;
+    ze_physical_mem_handle_t* phPhysicalMemory;
+    size_t* poffset;
+    ze_memory_access_attribute_t* paccess;
+} ze_virtual_mem_map_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeVirtualMemMap 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnVirtualMemMapCb_t)(
+    ze_virtual_mem_map_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeVirtualMemUnmap 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_virtual_mem_unmap_params_t
+{
+    ze_context_handle_t* phContext;
+    const void** pptr;
+    size_t* psize;
+} ze_virtual_mem_unmap_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeVirtualMemUnmap 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnVirtualMemUnmapCb_t)(
+    ze_virtual_mem_unmap_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeVirtualMemSetAccessAttribute 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_virtual_mem_set_access_attribute_params_t
+{
+    ze_context_handle_t* phContext;
+    const void** pptr;
+    size_t* psize;
+    ze_memory_access_attribute_t* paccess;
+} ze_virtual_mem_set_access_attribute_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeVirtualMemSetAccessAttribute 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnVirtualMemSetAccessAttributeCb_t)(
+    ze_virtual_mem_set_access_attribute_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for zeVirtualMemGetAccessAttribute 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ze_virtual_mem_get_access_attribute_params_t
+{
+    ze_context_handle_t* phContext;
+    const void** pptr;
+    size_t* psize;
+    ze_memory_access_attribute_t** paccess;
+    size_t** poutSize;
+} ze_virtual_mem_get_access_attribute_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for zeVirtualMemGetAccessAttribute 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (ZE_APICALL *ze_pfnVirtualMemGetAccessAttributeCb_t)(
+    ze_virtual_mem_get_access_attribute_params_t* params,
+    ze_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of VirtualMem callback functions pointers
+typedef struct _ze_virtual_mem_callbacks_t
+{
+    ze_pfnVirtualMemReserveCb_t                                     pfnReserveCb;
+    ze_pfnVirtualMemFreeCb_t                                        pfnFreeCb;
+    ze_pfnVirtualMemQueryPageSizeCb_t                               pfnQueryPageSizeCb;
+    ze_pfnVirtualMemMapCb_t                                         pfnMapCb;
+    ze_pfnVirtualMemUnmapCb_t                                       pfnUnmapCb;
+    ze_pfnVirtualMemSetAccessAttributeCb_t                          pfnSetAccessAttributeCb;
+    ze_pfnVirtualMemGetAccessAttributeCb_t                          pfnGetAccessAttributeCb;
+} ze_virtual_mem_callbacks_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Container for all callbacks
+typedef struct _ze_callbacks_t
+{
+    ze_global_callbacks_t               Global;
+    ze_driver_callbacks_t               Driver;
+    ze_device_callbacks_t               Device;
+    ze_context_callbacks_t              Context;
+    ze_command_queue_callbacks_t        CommandQueue;
+    ze_command_list_callbacks_t         CommandList;
+    ze_fence_callbacks_t                Fence;
+    ze_event_pool_callbacks_t           EventPool;
+    ze_event_callbacks_t                Event;
+    ze_image_callbacks_t                Image;
+    ze_module_callbacks_t               Module;
+    ze_module_build_log_callbacks_t     ModuleBuildLog;
+    ze_kernel_callbacks_t               Kernel;
+    ze_sampler_callbacks_t              Sampler;
+    ze_physical_mem_callbacks_t         PhysicalMem;
+    ze_mem_callbacks_t                  Mem;
+    ze_virtual_mem_callbacks_t          VirtualMem;
+} ze_callbacks_t;
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+
+#if defined(__cplusplus)
+} // extern "C"
+#endif
+
+#endif // _ZE_API_H

--- a/include/level_zero/ze_ddi.h
+++ b/include/level_zero/ze_ddi.h
@@ -1,0 +1,2659 @@
+/*
+ *
+ * Copyright (C) 2019-2021 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file ze_ddi.h
+ * @version v1.12-r1.12.15
+ *
+ */
+#ifndef _ZE_DDI_H
+#define _ZE_DDI_H
+#if defined(__cplusplus)
+#pragma once
+#endif
+#include "ze_api.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeRTASBuilderCreateExp 
+typedef ze_result_t (ZE_APICALL *ze_pfnRTASBuilderCreateExp_t)(
+    ze_driver_handle_t,
+    const ze_rtas_builder_exp_desc_t*,
+    ze_rtas_builder_exp_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeRTASBuilderGetBuildPropertiesExp 
+typedef ze_result_t (ZE_APICALL *ze_pfnRTASBuilderGetBuildPropertiesExp_t)(
+    ze_rtas_builder_exp_handle_t,
+    const ze_rtas_builder_build_op_exp_desc_t*,
+    ze_rtas_builder_exp_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeRTASBuilderBuildExp 
+typedef ze_result_t (ZE_APICALL *ze_pfnRTASBuilderBuildExp_t)(
+    ze_rtas_builder_exp_handle_t,
+    const ze_rtas_builder_build_op_exp_desc_t*,
+    void*,
+    size_t,
+    void*,
+    size_t,
+    ze_rtas_parallel_operation_exp_handle_t,
+    void*,
+    ze_rtas_aabb_exp_t*,
+    size_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeRTASBuilderDestroyExp 
+typedef ze_result_t (ZE_APICALL *ze_pfnRTASBuilderDestroyExp_t)(
+    ze_rtas_builder_exp_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of RTASBuilderExp functions pointers
+typedef struct _ze_rtas_builder_exp_dditable_t
+{
+    ze_pfnRTASBuilderCreateExp_t                                pfnCreateExp;
+    ze_pfnRTASBuilderGetBuildPropertiesExp_t                    pfnGetBuildPropertiesExp;
+    ze_pfnRTASBuilderBuildExp_t                                 pfnBuildExp;
+    ze_pfnRTASBuilderDestroyExp_t                               pfnDestroyExp;
+} ze_rtas_builder_exp_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's RTASBuilderExp table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zeGetRTASBuilderExpProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    ze_rtas_builder_exp_dditable_t* pDdiTable                               ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeGetRTASBuilderExpProcAddrTable
+typedef ze_result_t (ZE_APICALL *ze_pfnGetRTASBuilderExpProcAddrTable_t)(
+    ze_api_version_t,
+    ze_rtas_builder_exp_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeRTASParallelOperationCreateExp 
+typedef ze_result_t (ZE_APICALL *ze_pfnRTASParallelOperationCreateExp_t)(
+    ze_driver_handle_t,
+    ze_rtas_parallel_operation_exp_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeRTASParallelOperationGetPropertiesExp 
+typedef ze_result_t (ZE_APICALL *ze_pfnRTASParallelOperationGetPropertiesExp_t)(
+    ze_rtas_parallel_operation_exp_handle_t,
+    ze_rtas_parallel_operation_exp_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeRTASParallelOperationJoinExp 
+typedef ze_result_t (ZE_APICALL *ze_pfnRTASParallelOperationJoinExp_t)(
+    ze_rtas_parallel_operation_exp_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeRTASParallelOperationDestroyExp 
+typedef ze_result_t (ZE_APICALL *ze_pfnRTASParallelOperationDestroyExp_t)(
+    ze_rtas_parallel_operation_exp_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of RTASParallelOperationExp functions pointers
+typedef struct _ze_rtas_parallel_operation_exp_dditable_t
+{
+    ze_pfnRTASParallelOperationCreateExp_t                      pfnCreateExp;
+    ze_pfnRTASParallelOperationGetPropertiesExp_t               pfnGetPropertiesExp;
+    ze_pfnRTASParallelOperationJoinExp_t                        pfnJoinExp;
+    ze_pfnRTASParallelOperationDestroyExp_t                     pfnDestroyExp;
+} ze_rtas_parallel_operation_exp_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's RTASParallelOperationExp table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zeGetRTASParallelOperationExpProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    ze_rtas_parallel_operation_exp_dditable_t* pDdiTable                    ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeGetRTASParallelOperationExpProcAddrTable
+typedef ze_result_t (ZE_APICALL *ze_pfnGetRTASParallelOperationExpProcAddrTable_t)(
+    ze_api_version_t,
+    ze_rtas_parallel_operation_exp_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeInit 
+typedef ze_result_t (ZE_APICALL *ze_pfnInit_t)(
+    ze_init_flags_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeInitDrivers 
+typedef ze_result_t (ZE_APICALL *ze_pfnInitDrivers_t)(
+    uint32_t*,
+    ze_driver_handle_t*,
+    ze_init_driver_type_desc_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Global functions pointers
+typedef struct _ze_global_dditable_t
+{
+    ze_pfnInit_t                                                pfnInit;
+    ze_pfnInitDrivers_t                                         pfnInitDrivers;
+} ze_global_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Global table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zeGetGlobalProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    ze_global_dditable_t* pDdiTable                                         ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeGetGlobalProcAddrTable
+typedef ze_result_t (ZE_APICALL *ze_pfnGetGlobalProcAddrTable_t)(
+    ze_api_version_t,
+    ze_global_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeDriverGet 
+typedef ze_result_t (ZE_APICALL *ze_pfnDriverGet_t)(
+    uint32_t*,
+    ze_driver_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeDriverGetApiVersion 
+typedef ze_result_t (ZE_APICALL *ze_pfnDriverGetApiVersion_t)(
+    ze_driver_handle_t,
+    ze_api_version_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeDriverGetProperties 
+typedef ze_result_t (ZE_APICALL *ze_pfnDriverGetProperties_t)(
+    ze_driver_handle_t,
+    ze_driver_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeDriverGetIpcProperties 
+typedef ze_result_t (ZE_APICALL *ze_pfnDriverGetIpcProperties_t)(
+    ze_driver_handle_t,
+    ze_driver_ipc_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeDriverGetExtensionProperties 
+typedef ze_result_t (ZE_APICALL *ze_pfnDriverGetExtensionProperties_t)(
+    ze_driver_handle_t,
+    uint32_t*,
+    ze_driver_extension_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeDriverGetExtensionFunctionAddress 
+typedef ze_result_t (ZE_APICALL *ze_pfnDriverGetExtensionFunctionAddress_t)(
+    ze_driver_handle_t,
+    const char*,
+    void**
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeDriverGetLastErrorDescription 
+typedef ze_result_t (ZE_APICALL *ze_pfnDriverGetLastErrorDescription_t)(
+    ze_driver_handle_t,
+    const char**
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Driver functions pointers
+typedef struct _ze_driver_dditable_t
+{
+    ze_pfnDriverGet_t                                           pfnGet;
+    ze_pfnDriverGetApiVersion_t                                 pfnGetApiVersion;
+    ze_pfnDriverGetProperties_t                                 pfnGetProperties;
+    ze_pfnDriverGetIpcProperties_t                              pfnGetIpcProperties;
+    ze_pfnDriverGetExtensionProperties_t                        pfnGetExtensionProperties;
+    ze_pfnDriverGetExtensionFunctionAddress_t                   pfnGetExtensionFunctionAddress;
+    ze_pfnDriverGetLastErrorDescription_t                       pfnGetLastErrorDescription;
+} ze_driver_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Driver table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zeGetDriverProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    ze_driver_dditable_t* pDdiTable                                         ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeGetDriverProcAddrTable
+typedef ze_result_t (ZE_APICALL *ze_pfnGetDriverProcAddrTable_t)(
+    ze_api_version_t,
+    ze_driver_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeDriverRTASFormatCompatibilityCheckExp 
+typedef ze_result_t (ZE_APICALL *ze_pfnDriverRTASFormatCompatibilityCheckExp_t)(
+    ze_driver_handle_t,
+    ze_rtas_format_exp_t,
+    ze_rtas_format_exp_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of DriverExp functions pointers
+typedef struct _ze_driver_exp_dditable_t
+{
+    ze_pfnDriverRTASFormatCompatibilityCheckExp_t               pfnRTASFormatCompatibilityCheckExp;
+} ze_driver_exp_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's DriverExp table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zeGetDriverExpProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    ze_driver_exp_dditable_t* pDdiTable                                     ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeGetDriverExpProcAddrTable
+typedef ze_result_t (ZE_APICALL *ze_pfnGetDriverExpProcAddrTable_t)(
+    ze_api_version_t,
+    ze_driver_exp_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeDeviceGet 
+typedef ze_result_t (ZE_APICALL *ze_pfnDeviceGet_t)(
+    ze_driver_handle_t,
+    uint32_t*,
+    ze_device_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeDeviceGetSubDevices 
+typedef ze_result_t (ZE_APICALL *ze_pfnDeviceGetSubDevices_t)(
+    ze_device_handle_t,
+    uint32_t*,
+    ze_device_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeDeviceGetProperties 
+typedef ze_result_t (ZE_APICALL *ze_pfnDeviceGetProperties_t)(
+    ze_device_handle_t,
+    ze_device_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeDeviceGetComputeProperties 
+typedef ze_result_t (ZE_APICALL *ze_pfnDeviceGetComputeProperties_t)(
+    ze_device_handle_t,
+    ze_device_compute_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeDeviceGetModuleProperties 
+typedef ze_result_t (ZE_APICALL *ze_pfnDeviceGetModuleProperties_t)(
+    ze_device_handle_t,
+    ze_device_module_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeDeviceGetCommandQueueGroupProperties 
+typedef ze_result_t (ZE_APICALL *ze_pfnDeviceGetCommandQueueGroupProperties_t)(
+    ze_device_handle_t,
+    uint32_t*,
+    ze_command_queue_group_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeDeviceGetMemoryProperties 
+typedef ze_result_t (ZE_APICALL *ze_pfnDeviceGetMemoryProperties_t)(
+    ze_device_handle_t,
+    uint32_t*,
+    ze_device_memory_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeDeviceGetMemoryAccessProperties 
+typedef ze_result_t (ZE_APICALL *ze_pfnDeviceGetMemoryAccessProperties_t)(
+    ze_device_handle_t,
+    ze_device_memory_access_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeDeviceGetCacheProperties 
+typedef ze_result_t (ZE_APICALL *ze_pfnDeviceGetCacheProperties_t)(
+    ze_device_handle_t,
+    uint32_t*,
+    ze_device_cache_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeDeviceGetImageProperties 
+typedef ze_result_t (ZE_APICALL *ze_pfnDeviceGetImageProperties_t)(
+    ze_device_handle_t,
+    ze_device_image_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeDeviceGetExternalMemoryProperties 
+typedef ze_result_t (ZE_APICALL *ze_pfnDeviceGetExternalMemoryProperties_t)(
+    ze_device_handle_t,
+    ze_device_external_memory_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeDeviceGetP2PProperties 
+typedef ze_result_t (ZE_APICALL *ze_pfnDeviceGetP2PProperties_t)(
+    ze_device_handle_t,
+    ze_device_handle_t,
+    ze_device_p2p_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeDeviceCanAccessPeer 
+typedef ze_result_t (ZE_APICALL *ze_pfnDeviceCanAccessPeer_t)(
+    ze_device_handle_t,
+    ze_device_handle_t,
+    ze_bool_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeDeviceGetStatus 
+typedef ze_result_t (ZE_APICALL *ze_pfnDeviceGetStatus_t)(
+    ze_device_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeDeviceGetGlobalTimestamps 
+typedef ze_result_t (ZE_APICALL *ze_pfnDeviceGetGlobalTimestamps_t)(
+    ze_device_handle_t,
+    uint64_t*,
+    uint64_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeDeviceReserveCacheExt 
+typedef ze_result_t (ZE_APICALL *ze_pfnDeviceReserveCacheExt_t)(
+    ze_device_handle_t,
+    size_t,
+    size_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeDeviceSetCacheAdviceExt 
+typedef ze_result_t (ZE_APICALL *ze_pfnDeviceSetCacheAdviceExt_t)(
+    ze_device_handle_t,
+    void*,
+    size_t,
+    ze_cache_ext_region_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeDevicePciGetPropertiesExt 
+typedef ze_result_t (ZE_APICALL *ze_pfnDevicePciGetPropertiesExt_t)(
+    ze_device_handle_t,
+    ze_pci_ext_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeDeviceGetRootDevice 
+typedef ze_result_t (ZE_APICALL *ze_pfnDeviceGetRootDevice_t)(
+    ze_device_handle_t,
+    ze_device_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeDeviceImportExternalSemaphoreExt 
+typedef ze_result_t (ZE_APICALL *ze_pfnDeviceImportExternalSemaphoreExt_t)(
+    ze_device_handle_t,
+    const ze_external_semaphore_ext_desc_t*,
+    ze_external_semaphore_ext_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeDeviceReleaseExternalSemaphoreExt 
+typedef ze_result_t (ZE_APICALL *ze_pfnDeviceReleaseExternalSemaphoreExt_t)(
+    ze_external_semaphore_ext_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Device functions pointers
+typedef struct _ze_device_dditable_t
+{
+    ze_pfnDeviceGet_t                                           pfnGet;
+    ze_pfnDeviceGetSubDevices_t                                 pfnGetSubDevices;
+    ze_pfnDeviceGetProperties_t                                 pfnGetProperties;
+    ze_pfnDeviceGetComputeProperties_t                          pfnGetComputeProperties;
+    ze_pfnDeviceGetModuleProperties_t                           pfnGetModuleProperties;
+    ze_pfnDeviceGetCommandQueueGroupProperties_t                pfnGetCommandQueueGroupProperties;
+    ze_pfnDeviceGetMemoryProperties_t                           pfnGetMemoryProperties;
+    ze_pfnDeviceGetMemoryAccessProperties_t                     pfnGetMemoryAccessProperties;
+    ze_pfnDeviceGetCacheProperties_t                            pfnGetCacheProperties;
+    ze_pfnDeviceGetImageProperties_t                            pfnGetImageProperties;
+    ze_pfnDeviceGetExternalMemoryProperties_t                   pfnGetExternalMemoryProperties;
+    ze_pfnDeviceGetP2PProperties_t                              pfnGetP2PProperties;
+    ze_pfnDeviceCanAccessPeer_t                                 pfnCanAccessPeer;
+    ze_pfnDeviceGetStatus_t                                     pfnGetStatus;
+    ze_pfnDeviceGetGlobalTimestamps_t                           pfnGetGlobalTimestamps;
+    ze_pfnDeviceReserveCacheExt_t                               pfnReserveCacheExt;
+    ze_pfnDeviceSetCacheAdviceExt_t                             pfnSetCacheAdviceExt;
+    ze_pfnDevicePciGetPropertiesExt_t                           pfnPciGetPropertiesExt;
+    ze_pfnDeviceGetRootDevice_t                                 pfnGetRootDevice;
+    ze_pfnDeviceImportExternalSemaphoreExt_t                    pfnImportExternalSemaphoreExt;
+    ze_pfnDeviceReleaseExternalSemaphoreExt_t                   pfnReleaseExternalSemaphoreExt;
+} ze_device_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Device table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zeGetDeviceProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    ze_device_dditable_t* pDdiTable                                         ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeGetDeviceProcAddrTable
+typedef ze_result_t (ZE_APICALL *ze_pfnGetDeviceProcAddrTable_t)(
+    ze_api_version_t,
+    ze_device_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeDeviceGetFabricVertexExp 
+typedef ze_result_t (ZE_APICALL *ze_pfnDeviceGetFabricVertexExp_t)(
+    ze_device_handle_t,
+    ze_fabric_vertex_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of DeviceExp functions pointers
+typedef struct _ze_device_exp_dditable_t
+{
+    ze_pfnDeviceGetFabricVertexExp_t                            pfnGetFabricVertexExp;
+} ze_device_exp_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's DeviceExp table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zeGetDeviceExpProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    ze_device_exp_dditable_t* pDdiTable                                     ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeGetDeviceExpProcAddrTable
+typedef ze_result_t (ZE_APICALL *ze_pfnGetDeviceExpProcAddrTable_t)(
+    ze_api_version_t,
+    ze_device_exp_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeContextCreate 
+typedef ze_result_t (ZE_APICALL *ze_pfnContextCreate_t)(
+    ze_driver_handle_t,
+    const ze_context_desc_t*,
+    ze_context_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeContextDestroy 
+typedef ze_result_t (ZE_APICALL *ze_pfnContextDestroy_t)(
+    ze_context_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeContextGetStatus 
+typedef ze_result_t (ZE_APICALL *ze_pfnContextGetStatus_t)(
+    ze_context_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeContextSystemBarrier 
+typedef ze_result_t (ZE_APICALL *ze_pfnContextSystemBarrier_t)(
+    ze_context_handle_t,
+    ze_device_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeContextMakeMemoryResident 
+typedef ze_result_t (ZE_APICALL *ze_pfnContextMakeMemoryResident_t)(
+    ze_context_handle_t,
+    ze_device_handle_t,
+    void*,
+    size_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeContextEvictMemory 
+typedef ze_result_t (ZE_APICALL *ze_pfnContextEvictMemory_t)(
+    ze_context_handle_t,
+    ze_device_handle_t,
+    void*,
+    size_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeContextMakeImageResident 
+typedef ze_result_t (ZE_APICALL *ze_pfnContextMakeImageResident_t)(
+    ze_context_handle_t,
+    ze_device_handle_t,
+    ze_image_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeContextEvictImage 
+typedef ze_result_t (ZE_APICALL *ze_pfnContextEvictImage_t)(
+    ze_context_handle_t,
+    ze_device_handle_t,
+    ze_image_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeContextCreateEx 
+typedef ze_result_t (ZE_APICALL *ze_pfnContextCreateEx_t)(
+    ze_driver_handle_t,
+    const ze_context_desc_t*,
+    uint32_t,
+    ze_device_handle_t*,
+    ze_context_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Context functions pointers
+typedef struct _ze_context_dditable_t
+{
+    ze_pfnContextCreate_t                                       pfnCreate;
+    ze_pfnContextDestroy_t                                      pfnDestroy;
+    ze_pfnContextGetStatus_t                                    pfnGetStatus;
+    ze_pfnContextSystemBarrier_t                                pfnSystemBarrier;
+    ze_pfnContextMakeMemoryResident_t                           pfnMakeMemoryResident;
+    ze_pfnContextEvictMemory_t                                  pfnEvictMemory;
+    ze_pfnContextMakeImageResident_t                            pfnMakeImageResident;
+    ze_pfnContextEvictImage_t                                   pfnEvictImage;
+    ze_pfnContextCreateEx_t                                     pfnCreateEx;
+} ze_context_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Context table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zeGetContextProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    ze_context_dditable_t* pDdiTable                                        ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeGetContextProcAddrTable
+typedef ze_result_t (ZE_APICALL *ze_pfnGetContextProcAddrTable_t)(
+    ze_api_version_t,
+    ze_context_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandQueueCreate 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandQueueCreate_t)(
+    ze_context_handle_t,
+    ze_device_handle_t,
+    const ze_command_queue_desc_t*,
+    ze_command_queue_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandQueueDestroy 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandQueueDestroy_t)(
+    ze_command_queue_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandQueueExecuteCommandLists 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandQueueExecuteCommandLists_t)(
+    ze_command_queue_handle_t,
+    uint32_t,
+    ze_command_list_handle_t*,
+    ze_fence_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandQueueSynchronize 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandQueueSynchronize_t)(
+    ze_command_queue_handle_t,
+    uint64_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandQueueGetOrdinal 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandQueueGetOrdinal_t)(
+    ze_command_queue_handle_t,
+    uint32_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandQueueGetIndex 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandQueueGetIndex_t)(
+    ze_command_queue_handle_t,
+    uint32_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of CommandQueue functions pointers
+typedef struct _ze_command_queue_dditable_t
+{
+    ze_pfnCommandQueueCreate_t                                  pfnCreate;
+    ze_pfnCommandQueueDestroy_t                                 pfnDestroy;
+    ze_pfnCommandQueueExecuteCommandLists_t                     pfnExecuteCommandLists;
+    ze_pfnCommandQueueSynchronize_t                             pfnSynchronize;
+    ze_pfnCommandQueueGetOrdinal_t                              pfnGetOrdinal;
+    ze_pfnCommandQueueGetIndex_t                                pfnGetIndex;
+} ze_command_queue_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's CommandQueue table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zeGetCommandQueueProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    ze_command_queue_dditable_t* pDdiTable                                  ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeGetCommandQueueProcAddrTable
+typedef ze_result_t (ZE_APICALL *ze_pfnGetCommandQueueProcAddrTable_t)(
+    ze_api_version_t,
+    ze_command_queue_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandListCreate 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandListCreate_t)(
+    ze_context_handle_t,
+    ze_device_handle_t,
+    const ze_command_list_desc_t*,
+    ze_command_list_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandListCreateImmediate 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandListCreateImmediate_t)(
+    ze_context_handle_t,
+    ze_device_handle_t,
+    const ze_command_queue_desc_t*,
+    ze_command_list_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandListDestroy 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandListDestroy_t)(
+    ze_command_list_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandListClose 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandListClose_t)(
+    ze_command_list_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandListReset 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandListReset_t)(
+    ze_command_list_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandListAppendWriteGlobalTimestamp 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandListAppendWriteGlobalTimestamp_t)(
+    ze_command_list_handle_t,
+    uint64_t*,
+    ze_event_handle_t,
+    uint32_t,
+    ze_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandListAppendBarrier 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandListAppendBarrier_t)(
+    ze_command_list_handle_t,
+    ze_event_handle_t,
+    uint32_t,
+    ze_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandListAppendMemoryRangesBarrier 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandListAppendMemoryRangesBarrier_t)(
+    ze_command_list_handle_t,
+    uint32_t,
+    const size_t*,
+    const void**,
+    ze_event_handle_t,
+    uint32_t,
+    ze_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandListAppendMemoryCopy 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandListAppendMemoryCopy_t)(
+    ze_command_list_handle_t,
+    void*,
+    const void*,
+    size_t,
+    ze_event_handle_t,
+    uint32_t,
+    ze_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandListAppendMemoryFill 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandListAppendMemoryFill_t)(
+    ze_command_list_handle_t,
+    void*,
+    const void*,
+    size_t,
+    size_t,
+    ze_event_handle_t,
+    uint32_t,
+    ze_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandListAppendMemoryCopyRegion 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandListAppendMemoryCopyRegion_t)(
+    ze_command_list_handle_t,
+    void*,
+    const ze_copy_region_t*,
+    uint32_t,
+    uint32_t,
+    const void*,
+    const ze_copy_region_t*,
+    uint32_t,
+    uint32_t,
+    ze_event_handle_t,
+    uint32_t,
+    ze_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandListAppendMemoryCopyFromContext 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandListAppendMemoryCopyFromContext_t)(
+    ze_command_list_handle_t,
+    void*,
+    ze_context_handle_t,
+    const void*,
+    size_t,
+    ze_event_handle_t,
+    uint32_t,
+    ze_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandListAppendImageCopy 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandListAppendImageCopy_t)(
+    ze_command_list_handle_t,
+    ze_image_handle_t,
+    ze_image_handle_t,
+    ze_event_handle_t,
+    uint32_t,
+    ze_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandListAppendImageCopyRegion 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandListAppendImageCopyRegion_t)(
+    ze_command_list_handle_t,
+    ze_image_handle_t,
+    ze_image_handle_t,
+    const ze_image_region_t*,
+    const ze_image_region_t*,
+    ze_event_handle_t,
+    uint32_t,
+    ze_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandListAppendImageCopyToMemory 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandListAppendImageCopyToMemory_t)(
+    ze_command_list_handle_t,
+    void*,
+    ze_image_handle_t,
+    const ze_image_region_t*,
+    ze_event_handle_t,
+    uint32_t,
+    ze_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandListAppendImageCopyFromMemory 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandListAppendImageCopyFromMemory_t)(
+    ze_command_list_handle_t,
+    ze_image_handle_t,
+    const void*,
+    const ze_image_region_t*,
+    ze_event_handle_t,
+    uint32_t,
+    ze_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandListAppendMemoryPrefetch 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandListAppendMemoryPrefetch_t)(
+    ze_command_list_handle_t,
+    const void*,
+    size_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandListAppendMemAdvise 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandListAppendMemAdvise_t)(
+    ze_command_list_handle_t,
+    ze_device_handle_t,
+    const void*,
+    size_t,
+    ze_memory_advice_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandListAppendSignalEvent 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandListAppendSignalEvent_t)(
+    ze_command_list_handle_t,
+    ze_event_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandListAppendWaitOnEvents 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandListAppendWaitOnEvents_t)(
+    ze_command_list_handle_t,
+    uint32_t,
+    ze_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandListAppendEventReset 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandListAppendEventReset_t)(
+    ze_command_list_handle_t,
+    ze_event_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandListAppendQueryKernelTimestamps 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandListAppendQueryKernelTimestamps_t)(
+    ze_command_list_handle_t,
+    uint32_t,
+    ze_event_handle_t*,
+    void*,
+    const size_t*,
+    ze_event_handle_t,
+    uint32_t,
+    ze_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandListAppendLaunchKernel 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandListAppendLaunchKernel_t)(
+    ze_command_list_handle_t,
+    ze_kernel_handle_t,
+    const ze_group_count_t*,
+    ze_event_handle_t,
+    uint32_t,
+    ze_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandListAppendLaunchCooperativeKernel 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandListAppendLaunchCooperativeKernel_t)(
+    ze_command_list_handle_t,
+    ze_kernel_handle_t,
+    const ze_group_count_t*,
+    ze_event_handle_t,
+    uint32_t,
+    ze_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandListAppendLaunchKernelIndirect 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandListAppendLaunchKernelIndirect_t)(
+    ze_command_list_handle_t,
+    ze_kernel_handle_t,
+    const ze_group_count_t*,
+    ze_event_handle_t,
+    uint32_t,
+    ze_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandListAppendLaunchMultipleKernelsIndirect 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandListAppendLaunchMultipleKernelsIndirect_t)(
+    ze_command_list_handle_t,
+    uint32_t,
+    ze_kernel_handle_t*,
+    const uint32_t*,
+    const ze_group_count_t*,
+    ze_event_handle_t,
+    uint32_t,
+    ze_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandListAppendImageCopyToMemoryExt 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandListAppendImageCopyToMemoryExt_t)(
+    ze_command_list_handle_t,
+    void*,
+    ze_image_handle_t,
+    const ze_image_region_t*,
+    uint32_t,
+    uint32_t,
+    ze_event_handle_t,
+    uint32_t,
+    ze_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandListAppendImageCopyFromMemoryExt 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandListAppendImageCopyFromMemoryExt_t)(
+    ze_command_list_handle_t,
+    ze_image_handle_t,
+    const void*,
+    const ze_image_region_t*,
+    uint32_t,
+    uint32_t,
+    ze_event_handle_t,
+    uint32_t,
+    ze_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandListHostSynchronize 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandListHostSynchronize_t)(
+    ze_command_list_handle_t,
+    uint64_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandListGetDeviceHandle 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandListGetDeviceHandle_t)(
+    ze_command_list_handle_t,
+    ze_device_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandListGetContextHandle 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandListGetContextHandle_t)(
+    ze_command_list_handle_t,
+    ze_context_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandListGetOrdinal 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandListGetOrdinal_t)(
+    ze_command_list_handle_t,
+    uint32_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandListImmediateGetIndex 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandListImmediateGetIndex_t)(
+    ze_command_list_handle_t,
+    uint32_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandListIsImmediate 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandListIsImmediate_t)(
+    ze_command_list_handle_t,
+    ze_bool_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandListAppendSignalExternalSemaphoreExt 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandListAppendSignalExternalSemaphoreExt_t)(
+    ze_command_list_handle_t,
+    uint32_t,
+    ze_external_semaphore_ext_handle_t*,
+    ze_external_semaphore_signal_params_ext_t*,
+    ze_event_handle_t,
+    uint32_t,
+    ze_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandListAppendWaitExternalSemaphoreExt 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandListAppendWaitExternalSemaphoreExt_t)(
+    ze_command_list_handle_t,
+    uint32_t,
+    ze_external_semaphore_ext_handle_t*,
+    ze_external_semaphore_wait_params_ext_t*,
+    ze_event_handle_t,
+    uint32_t,
+    ze_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of CommandList functions pointers
+typedef struct _ze_command_list_dditable_t
+{
+    ze_pfnCommandListCreate_t                                   pfnCreate;
+    ze_pfnCommandListCreateImmediate_t                          pfnCreateImmediate;
+    ze_pfnCommandListDestroy_t                                  pfnDestroy;
+    ze_pfnCommandListClose_t                                    pfnClose;
+    ze_pfnCommandListReset_t                                    pfnReset;
+    ze_pfnCommandListAppendWriteGlobalTimestamp_t               pfnAppendWriteGlobalTimestamp;
+    ze_pfnCommandListAppendBarrier_t                            pfnAppendBarrier;
+    ze_pfnCommandListAppendMemoryRangesBarrier_t                pfnAppendMemoryRangesBarrier;
+    ze_pfnCommandListAppendMemoryCopy_t                         pfnAppendMemoryCopy;
+    ze_pfnCommandListAppendMemoryFill_t                         pfnAppendMemoryFill;
+    ze_pfnCommandListAppendMemoryCopyRegion_t                   pfnAppendMemoryCopyRegion;
+    ze_pfnCommandListAppendMemoryCopyFromContext_t              pfnAppendMemoryCopyFromContext;
+    ze_pfnCommandListAppendImageCopy_t                          pfnAppendImageCopy;
+    ze_pfnCommandListAppendImageCopyRegion_t                    pfnAppendImageCopyRegion;
+    ze_pfnCommandListAppendImageCopyToMemory_t                  pfnAppendImageCopyToMemory;
+    ze_pfnCommandListAppendImageCopyFromMemory_t                pfnAppendImageCopyFromMemory;
+    ze_pfnCommandListAppendMemoryPrefetch_t                     pfnAppendMemoryPrefetch;
+    ze_pfnCommandListAppendMemAdvise_t                          pfnAppendMemAdvise;
+    ze_pfnCommandListAppendSignalEvent_t                        pfnAppendSignalEvent;
+    ze_pfnCommandListAppendWaitOnEvents_t                       pfnAppendWaitOnEvents;
+    ze_pfnCommandListAppendEventReset_t                         pfnAppendEventReset;
+    ze_pfnCommandListAppendQueryKernelTimestamps_t              pfnAppendQueryKernelTimestamps;
+    ze_pfnCommandListAppendLaunchKernel_t                       pfnAppendLaunchKernel;
+    ze_pfnCommandListAppendLaunchCooperativeKernel_t            pfnAppendLaunchCooperativeKernel;
+    ze_pfnCommandListAppendLaunchKernelIndirect_t               pfnAppendLaunchKernelIndirect;
+    ze_pfnCommandListAppendLaunchMultipleKernelsIndirect_t      pfnAppendLaunchMultipleKernelsIndirect;
+    ze_pfnCommandListAppendImageCopyToMemoryExt_t               pfnAppendImageCopyToMemoryExt;
+    ze_pfnCommandListAppendImageCopyFromMemoryExt_t             pfnAppendImageCopyFromMemoryExt;
+    ze_pfnCommandListHostSynchronize_t                          pfnHostSynchronize;
+    ze_pfnCommandListGetDeviceHandle_t                          pfnGetDeviceHandle;
+    ze_pfnCommandListGetContextHandle_t                         pfnGetContextHandle;
+    ze_pfnCommandListGetOrdinal_t                               pfnGetOrdinal;
+    ze_pfnCommandListImmediateGetIndex_t                        pfnImmediateGetIndex;
+    ze_pfnCommandListIsImmediate_t                              pfnIsImmediate;
+    ze_pfnCommandListAppendSignalExternalSemaphoreExt_t         pfnAppendSignalExternalSemaphoreExt;
+    ze_pfnCommandListAppendWaitExternalSemaphoreExt_t           pfnAppendWaitExternalSemaphoreExt;
+} ze_command_list_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's CommandList table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zeGetCommandListProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    ze_command_list_dditable_t* pDdiTable                                   ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeGetCommandListProcAddrTable
+typedef ze_result_t (ZE_APICALL *ze_pfnGetCommandListProcAddrTable_t)(
+    ze_api_version_t,
+    ze_command_list_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandListCreateCloneExp 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandListCreateCloneExp_t)(
+    ze_command_list_handle_t,
+    ze_command_list_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandListImmediateAppendCommandListsExp 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandListImmediateAppendCommandListsExp_t)(
+    ze_command_list_handle_t,
+    uint32_t,
+    ze_command_list_handle_t*,
+    ze_event_handle_t,
+    uint32_t,
+    ze_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandListGetNextCommandIdExp 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandListGetNextCommandIdExp_t)(
+    ze_command_list_handle_t,
+    const ze_mutable_command_id_exp_desc_t*,
+    uint64_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandListUpdateMutableCommandsExp 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandListUpdateMutableCommandsExp_t)(
+    ze_command_list_handle_t,
+    const ze_mutable_commands_exp_desc_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandListUpdateMutableCommandSignalEventExp 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandListUpdateMutableCommandSignalEventExp_t)(
+    ze_command_list_handle_t,
+    uint64_t,
+    ze_event_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandListUpdateMutableCommandWaitEventsExp 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandListUpdateMutableCommandWaitEventsExp_t)(
+    ze_command_list_handle_t,
+    uint64_t,
+    uint32_t,
+    ze_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandListGetNextCommandIdWithKernelsExp 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandListGetNextCommandIdWithKernelsExp_t)(
+    ze_command_list_handle_t,
+    const ze_mutable_command_id_exp_desc_t*,
+    uint32_t,
+    ze_kernel_handle_t*,
+    uint64_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeCommandListUpdateMutableCommandKernelsExp 
+typedef ze_result_t (ZE_APICALL *ze_pfnCommandListUpdateMutableCommandKernelsExp_t)(
+    ze_command_list_handle_t,
+    uint32_t,
+    uint64_t*,
+    ze_kernel_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of CommandListExp functions pointers
+typedef struct _ze_command_list_exp_dditable_t
+{
+    ze_pfnCommandListCreateCloneExp_t                           pfnCreateCloneExp;
+    ze_pfnCommandListImmediateAppendCommandListsExp_t           pfnImmediateAppendCommandListsExp;
+    ze_pfnCommandListGetNextCommandIdExp_t                      pfnGetNextCommandIdExp;
+    ze_pfnCommandListUpdateMutableCommandsExp_t                 pfnUpdateMutableCommandsExp;
+    ze_pfnCommandListUpdateMutableCommandSignalEventExp_t       pfnUpdateMutableCommandSignalEventExp;
+    ze_pfnCommandListUpdateMutableCommandWaitEventsExp_t        pfnUpdateMutableCommandWaitEventsExp;
+    ze_pfnCommandListGetNextCommandIdWithKernelsExp_t           pfnGetNextCommandIdWithKernelsExp;
+    ze_pfnCommandListUpdateMutableCommandKernelsExp_t           pfnUpdateMutableCommandKernelsExp;
+} ze_command_list_exp_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's CommandListExp table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zeGetCommandListExpProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    ze_command_list_exp_dditable_t* pDdiTable                               ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeGetCommandListExpProcAddrTable
+typedef ze_result_t (ZE_APICALL *ze_pfnGetCommandListExpProcAddrTable_t)(
+    ze_api_version_t,
+    ze_command_list_exp_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeImageGetProperties 
+typedef ze_result_t (ZE_APICALL *ze_pfnImageGetProperties_t)(
+    ze_device_handle_t,
+    const ze_image_desc_t*,
+    ze_image_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeImageCreate 
+typedef ze_result_t (ZE_APICALL *ze_pfnImageCreate_t)(
+    ze_context_handle_t,
+    ze_device_handle_t,
+    const ze_image_desc_t*,
+    ze_image_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeImageDestroy 
+typedef ze_result_t (ZE_APICALL *ze_pfnImageDestroy_t)(
+    ze_image_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeImageGetAllocPropertiesExt 
+typedef ze_result_t (ZE_APICALL *ze_pfnImageGetAllocPropertiesExt_t)(
+    ze_context_handle_t,
+    ze_image_handle_t,
+    ze_image_allocation_ext_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeImageViewCreateExt 
+typedef ze_result_t (ZE_APICALL *ze_pfnImageViewCreateExt_t)(
+    ze_context_handle_t,
+    ze_device_handle_t,
+    const ze_image_desc_t*,
+    ze_image_handle_t,
+    ze_image_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Image functions pointers
+typedef struct _ze_image_dditable_t
+{
+    ze_pfnImageGetProperties_t                                  pfnGetProperties;
+    ze_pfnImageCreate_t                                         pfnCreate;
+    ze_pfnImageDestroy_t                                        pfnDestroy;
+    ze_pfnImageGetAllocPropertiesExt_t                          pfnGetAllocPropertiesExt;
+    ze_pfnImageViewCreateExt_t                                  pfnViewCreateExt;
+} ze_image_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Image table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zeGetImageProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    ze_image_dditable_t* pDdiTable                                          ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeGetImageProcAddrTable
+typedef ze_result_t (ZE_APICALL *ze_pfnGetImageProcAddrTable_t)(
+    ze_api_version_t,
+    ze_image_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeImageGetMemoryPropertiesExp 
+typedef ze_result_t (ZE_APICALL *ze_pfnImageGetMemoryPropertiesExp_t)(
+    ze_image_handle_t,
+    ze_image_memory_properties_exp_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeImageViewCreateExp 
+typedef ze_result_t (ZE_APICALL *ze_pfnImageViewCreateExp_t)(
+    ze_context_handle_t,
+    ze_device_handle_t,
+    const ze_image_desc_t*,
+    ze_image_handle_t,
+    ze_image_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeImageGetDeviceOffsetExp 
+typedef ze_result_t (ZE_APICALL *ze_pfnImageGetDeviceOffsetExp_t)(
+    ze_image_handle_t,
+    uint64_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of ImageExp functions pointers
+typedef struct _ze_image_exp_dditable_t
+{
+    ze_pfnImageGetMemoryPropertiesExp_t                         pfnGetMemoryPropertiesExp;
+    ze_pfnImageViewCreateExp_t                                  pfnViewCreateExp;
+    ze_pfnImageGetDeviceOffsetExp_t                             pfnGetDeviceOffsetExp;
+} ze_image_exp_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's ImageExp table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zeGetImageExpProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    ze_image_exp_dditable_t* pDdiTable                                      ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeGetImageExpProcAddrTable
+typedef ze_result_t (ZE_APICALL *ze_pfnGetImageExpProcAddrTable_t)(
+    ze_api_version_t,
+    ze_image_exp_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeMemAllocShared 
+typedef ze_result_t (ZE_APICALL *ze_pfnMemAllocShared_t)(
+    ze_context_handle_t,
+    const ze_device_mem_alloc_desc_t*,
+    const ze_host_mem_alloc_desc_t*,
+    size_t,
+    size_t,
+    ze_device_handle_t,
+    void**
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeMemAllocDevice 
+typedef ze_result_t (ZE_APICALL *ze_pfnMemAllocDevice_t)(
+    ze_context_handle_t,
+    const ze_device_mem_alloc_desc_t*,
+    size_t,
+    size_t,
+    ze_device_handle_t,
+    void**
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeMemAllocHost 
+typedef ze_result_t (ZE_APICALL *ze_pfnMemAllocHost_t)(
+    ze_context_handle_t,
+    const ze_host_mem_alloc_desc_t*,
+    size_t,
+    size_t,
+    void**
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeMemFree 
+typedef ze_result_t (ZE_APICALL *ze_pfnMemFree_t)(
+    ze_context_handle_t,
+    void*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeMemGetAllocProperties 
+typedef ze_result_t (ZE_APICALL *ze_pfnMemGetAllocProperties_t)(
+    ze_context_handle_t,
+    const void*,
+    ze_memory_allocation_properties_t*,
+    ze_device_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeMemGetAddressRange 
+typedef ze_result_t (ZE_APICALL *ze_pfnMemGetAddressRange_t)(
+    ze_context_handle_t,
+    const void*,
+    void**,
+    size_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeMemGetIpcHandle 
+typedef ze_result_t (ZE_APICALL *ze_pfnMemGetIpcHandle_t)(
+    ze_context_handle_t,
+    const void*,
+    ze_ipc_mem_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeMemOpenIpcHandle 
+typedef ze_result_t (ZE_APICALL *ze_pfnMemOpenIpcHandle_t)(
+    ze_context_handle_t,
+    ze_device_handle_t,
+    ze_ipc_mem_handle_t,
+    ze_ipc_memory_flags_t,
+    void**
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeMemCloseIpcHandle 
+typedef ze_result_t (ZE_APICALL *ze_pfnMemCloseIpcHandle_t)(
+    ze_context_handle_t,
+    const void*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeMemFreeExt 
+typedef ze_result_t (ZE_APICALL *ze_pfnMemFreeExt_t)(
+    ze_context_handle_t,
+    const ze_memory_free_ext_desc_t*,
+    void*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeMemPutIpcHandle 
+typedef ze_result_t (ZE_APICALL *ze_pfnMemPutIpcHandle_t)(
+    ze_context_handle_t,
+    ze_ipc_mem_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeMemGetPitchFor2dImage 
+typedef ze_result_t (ZE_APICALL *ze_pfnMemGetPitchFor2dImage_t)(
+    ze_context_handle_t,
+    ze_device_handle_t,
+    size_t,
+    size_t,
+    unsigned int,
+    size_t *
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Mem functions pointers
+typedef struct _ze_mem_dditable_t
+{
+    ze_pfnMemAllocShared_t                                      pfnAllocShared;
+    ze_pfnMemAllocDevice_t                                      pfnAllocDevice;
+    ze_pfnMemAllocHost_t                                        pfnAllocHost;
+    ze_pfnMemFree_t                                             pfnFree;
+    ze_pfnMemGetAllocProperties_t                               pfnGetAllocProperties;
+    ze_pfnMemGetAddressRange_t                                  pfnGetAddressRange;
+    ze_pfnMemGetIpcHandle_t                                     pfnGetIpcHandle;
+    ze_pfnMemOpenIpcHandle_t                                    pfnOpenIpcHandle;
+    ze_pfnMemCloseIpcHandle_t                                   pfnCloseIpcHandle;
+    ze_pfnMemFreeExt_t                                          pfnFreeExt;
+    ze_pfnMemPutIpcHandle_t                                     pfnPutIpcHandle;
+    ze_pfnMemGetPitchFor2dImage_t                               pfnGetPitchFor2dImage;
+} ze_mem_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Mem table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zeGetMemProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    ze_mem_dditable_t* pDdiTable                                            ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeGetMemProcAddrTable
+typedef ze_result_t (ZE_APICALL *ze_pfnGetMemProcAddrTable_t)(
+    ze_api_version_t,
+    ze_mem_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeMemGetIpcHandleFromFileDescriptorExp 
+typedef ze_result_t (ZE_APICALL *ze_pfnMemGetIpcHandleFromFileDescriptorExp_t)(
+    ze_context_handle_t,
+    uint64_t,
+    ze_ipc_mem_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeMemGetFileDescriptorFromIpcHandleExp 
+typedef ze_result_t (ZE_APICALL *ze_pfnMemGetFileDescriptorFromIpcHandleExp_t)(
+    ze_context_handle_t,
+    ze_ipc_mem_handle_t,
+    uint64_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeMemSetAtomicAccessAttributeExp 
+typedef ze_result_t (ZE_APICALL *ze_pfnMemSetAtomicAccessAttributeExp_t)(
+    ze_context_handle_t,
+    ze_device_handle_t,
+    const void*,
+    size_t,
+    ze_memory_atomic_attr_exp_flags_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeMemGetAtomicAccessAttributeExp 
+typedef ze_result_t (ZE_APICALL *ze_pfnMemGetAtomicAccessAttributeExp_t)(
+    ze_context_handle_t,
+    ze_device_handle_t,
+    const void*,
+    size_t,
+    ze_memory_atomic_attr_exp_flags_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of MemExp functions pointers
+typedef struct _ze_mem_exp_dditable_t
+{
+    ze_pfnMemGetIpcHandleFromFileDescriptorExp_t                pfnGetIpcHandleFromFileDescriptorExp;
+    ze_pfnMemGetFileDescriptorFromIpcHandleExp_t                pfnGetFileDescriptorFromIpcHandleExp;
+    ze_pfnMemSetAtomicAccessAttributeExp_t                      pfnSetAtomicAccessAttributeExp;
+    ze_pfnMemGetAtomicAccessAttributeExp_t                      pfnGetAtomicAccessAttributeExp;
+} ze_mem_exp_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's MemExp table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zeGetMemExpProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    ze_mem_exp_dditable_t* pDdiTable                                        ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeGetMemExpProcAddrTable
+typedef ze_result_t (ZE_APICALL *ze_pfnGetMemExpProcAddrTable_t)(
+    ze_api_version_t,
+    ze_mem_exp_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeFenceCreate 
+typedef ze_result_t (ZE_APICALL *ze_pfnFenceCreate_t)(
+    ze_command_queue_handle_t,
+    const ze_fence_desc_t*,
+    ze_fence_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeFenceDestroy 
+typedef ze_result_t (ZE_APICALL *ze_pfnFenceDestroy_t)(
+    ze_fence_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeFenceHostSynchronize 
+typedef ze_result_t (ZE_APICALL *ze_pfnFenceHostSynchronize_t)(
+    ze_fence_handle_t,
+    uint64_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeFenceQueryStatus 
+typedef ze_result_t (ZE_APICALL *ze_pfnFenceQueryStatus_t)(
+    ze_fence_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeFenceReset 
+typedef ze_result_t (ZE_APICALL *ze_pfnFenceReset_t)(
+    ze_fence_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Fence functions pointers
+typedef struct _ze_fence_dditable_t
+{
+    ze_pfnFenceCreate_t                                         pfnCreate;
+    ze_pfnFenceDestroy_t                                        pfnDestroy;
+    ze_pfnFenceHostSynchronize_t                                pfnHostSynchronize;
+    ze_pfnFenceQueryStatus_t                                    pfnQueryStatus;
+    ze_pfnFenceReset_t                                          pfnReset;
+} ze_fence_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Fence table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zeGetFenceProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    ze_fence_dditable_t* pDdiTable                                          ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeGetFenceProcAddrTable
+typedef ze_result_t (ZE_APICALL *ze_pfnGetFenceProcAddrTable_t)(
+    ze_api_version_t,
+    ze_fence_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeEventPoolCreate 
+typedef ze_result_t (ZE_APICALL *ze_pfnEventPoolCreate_t)(
+    ze_context_handle_t,
+    const ze_event_pool_desc_t*,
+    uint32_t,
+    ze_device_handle_t*,
+    ze_event_pool_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeEventPoolDestroy 
+typedef ze_result_t (ZE_APICALL *ze_pfnEventPoolDestroy_t)(
+    ze_event_pool_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeEventPoolGetIpcHandle 
+typedef ze_result_t (ZE_APICALL *ze_pfnEventPoolGetIpcHandle_t)(
+    ze_event_pool_handle_t,
+    ze_ipc_event_pool_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeEventPoolOpenIpcHandle 
+typedef ze_result_t (ZE_APICALL *ze_pfnEventPoolOpenIpcHandle_t)(
+    ze_context_handle_t,
+    ze_ipc_event_pool_handle_t,
+    ze_event_pool_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeEventPoolCloseIpcHandle 
+typedef ze_result_t (ZE_APICALL *ze_pfnEventPoolCloseIpcHandle_t)(
+    ze_event_pool_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeEventPoolPutIpcHandle 
+typedef ze_result_t (ZE_APICALL *ze_pfnEventPoolPutIpcHandle_t)(
+    ze_context_handle_t,
+    ze_ipc_event_pool_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeEventPoolGetContextHandle 
+typedef ze_result_t (ZE_APICALL *ze_pfnEventPoolGetContextHandle_t)(
+    ze_event_pool_handle_t,
+    ze_context_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeEventPoolGetFlags 
+typedef ze_result_t (ZE_APICALL *ze_pfnEventPoolGetFlags_t)(
+    ze_event_pool_handle_t,
+    ze_event_pool_flags_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of EventPool functions pointers
+typedef struct _ze_event_pool_dditable_t
+{
+    ze_pfnEventPoolCreate_t                                     pfnCreate;
+    ze_pfnEventPoolDestroy_t                                    pfnDestroy;
+    ze_pfnEventPoolGetIpcHandle_t                               pfnGetIpcHandle;
+    ze_pfnEventPoolOpenIpcHandle_t                              pfnOpenIpcHandle;
+    ze_pfnEventPoolCloseIpcHandle_t                             pfnCloseIpcHandle;
+    ze_pfnEventPoolPutIpcHandle_t                               pfnPutIpcHandle;
+    ze_pfnEventPoolGetContextHandle_t                           pfnGetContextHandle;
+    ze_pfnEventPoolGetFlags_t                                   pfnGetFlags;
+} ze_event_pool_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's EventPool table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zeGetEventPoolProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    ze_event_pool_dditable_t* pDdiTable                                     ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeGetEventPoolProcAddrTable
+typedef ze_result_t (ZE_APICALL *ze_pfnGetEventPoolProcAddrTable_t)(
+    ze_api_version_t,
+    ze_event_pool_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeEventCreate 
+typedef ze_result_t (ZE_APICALL *ze_pfnEventCreate_t)(
+    ze_event_pool_handle_t,
+    const ze_event_desc_t*,
+    ze_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeEventDestroy 
+typedef ze_result_t (ZE_APICALL *ze_pfnEventDestroy_t)(
+    ze_event_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeEventHostSignal 
+typedef ze_result_t (ZE_APICALL *ze_pfnEventHostSignal_t)(
+    ze_event_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeEventHostSynchronize 
+typedef ze_result_t (ZE_APICALL *ze_pfnEventHostSynchronize_t)(
+    ze_event_handle_t,
+    uint64_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeEventQueryStatus 
+typedef ze_result_t (ZE_APICALL *ze_pfnEventQueryStatus_t)(
+    ze_event_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeEventHostReset 
+typedef ze_result_t (ZE_APICALL *ze_pfnEventHostReset_t)(
+    ze_event_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeEventQueryKernelTimestamp 
+typedef ze_result_t (ZE_APICALL *ze_pfnEventQueryKernelTimestamp_t)(
+    ze_event_handle_t,
+    ze_kernel_timestamp_result_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeEventQueryKernelTimestampsExt 
+typedef ze_result_t (ZE_APICALL *ze_pfnEventQueryKernelTimestampsExt_t)(
+    ze_event_handle_t,
+    ze_device_handle_t,
+    uint32_t*,
+    ze_event_query_kernel_timestamps_results_ext_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeEventGetEventPool 
+typedef ze_result_t (ZE_APICALL *ze_pfnEventGetEventPool_t)(
+    ze_event_handle_t,
+    ze_event_pool_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeEventGetSignalScope 
+typedef ze_result_t (ZE_APICALL *ze_pfnEventGetSignalScope_t)(
+    ze_event_handle_t,
+    ze_event_scope_flags_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeEventGetWaitScope 
+typedef ze_result_t (ZE_APICALL *ze_pfnEventGetWaitScope_t)(
+    ze_event_handle_t,
+    ze_event_scope_flags_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Event functions pointers
+typedef struct _ze_event_dditable_t
+{
+    ze_pfnEventCreate_t                                         pfnCreate;
+    ze_pfnEventDestroy_t                                        pfnDestroy;
+    ze_pfnEventHostSignal_t                                     pfnHostSignal;
+    ze_pfnEventHostSynchronize_t                                pfnHostSynchronize;
+    ze_pfnEventQueryStatus_t                                    pfnQueryStatus;
+    ze_pfnEventHostReset_t                                      pfnHostReset;
+    ze_pfnEventQueryKernelTimestamp_t                           pfnQueryKernelTimestamp;
+    ze_pfnEventQueryKernelTimestampsExt_t                       pfnQueryKernelTimestampsExt;
+    ze_pfnEventGetEventPool_t                                   pfnGetEventPool;
+    ze_pfnEventGetSignalScope_t                                 pfnGetSignalScope;
+    ze_pfnEventGetWaitScope_t                                   pfnGetWaitScope;
+} ze_event_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Event table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zeGetEventProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    ze_event_dditable_t* pDdiTable                                          ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeGetEventProcAddrTable
+typedef ze_result_t (ZE_APICALL *ze_pfnGetEventProcAddrTable_t)(
+    ze_api_version_t,
+    ze_event_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeEventQueryTimestampsExp 
+typedef ze_result_t (ZE_APICALL *ze_pfnEventQueryTimestampsExp_t)(
+    ze_event_handle_t,
+    ze_device_handle_t,
+    uint32_t*,
+    ze_kernel_timestamp_result_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of EventExp functions pointers
+typedef struct _ze_event_exp_dditable_t
+{
+    ze_pfnEventQueryTimestampsExp_t                             pfnQueryTimestampsExp;
+} ze_event_exp_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's EventExp table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zeGetEventExpProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    ze_event_exp_dditable_t* pDdiTable                                      ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeGetEventExpProcAddrTable
+typedef ze_result_t (ZE_APICALL *ze_pfnGetEventExpProcAddrTable_t)(
+    ze_api_version_t,
+    ze_event_exp_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeModuleCreate 
+typedef ze_result_t (ZE_APICALL *ze_pfnModuleCreate_t)(
+    ze_context_handle_t,
+    ze_device_handle_t,
+    const ze_module_desc_t*,
+    ze_module_handle_t*,
+    ze_module_build_log_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeModuleDestroy 
+typedef ze_result_t (ZE_APICALL *ze_pfnModuleDestroy_t)(
+    ze_module_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeModuleDynamicLink 
+typedef ze_result_t (ZE_APICALL *ze_pfnModuleDynamicLink_t)(
+    uint32_t,
+    ze_module_handle_t*,
+    ze_module_build_log_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeModuleGetNativeBinary 
+typedef ze_result_t (ZE_APICALL *ze_pfnModuleGetNativeBinary_t)(
+    ze_module_handle_t,
+    size_t*,
+    uint8_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeModuleGetGlobalPointer 
+typedef ze_result_t (ZE_APICALL *ze_pfnModuleGetGlobalPointer_t)(
+    ze_module_handle_t,
+    const char*,
+    size_t*,
+    void**
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeModuleGetKernelNames 
+typedef ze_result_t (ZE_APICALL *ze_pfnModuleGetKernelNames_t)(
+    ze_module_handle_t,
+    uint32_t*,
+    const char**
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeModuleGetProperties 
+typedef ze_result_t (ZE_APICALL *ze_pfnModuleGetProperties_t)(
+    ze_module_handle_t,
+    ze_module_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeModuleGetFunctionPointer 
+typedef ze_result_t (ZE_APICALL *ze_pfnModuleGetFunctionPointer_t)(
+    ze_module_handle_t,
+    const char*,
+    void**
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeModuleInspectLinkageExt 
+typedef ze_result_t (ZE_APICALL *ze_pfnModuleInspectLinkageExt_t)(
+    ze_linkage_inspection_ext_desc_t*,
+    uint32_t,
+    ze_module_handle_t*,
+    ze_module_build_log_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Module functions pointers
+typedef struct _ze_module_dditable_t
+{
+    ze_pfnModuleCreate_t                                        pfnCreate;
+    ze_pfnModuleDestroy_t                                       pfnDestroy;
+    ze_pfnModuleDynamicLink_t                                   pfnDynamicLink;
+    ze_pfnModuleGetNativeBinary_t                               pfnGetNativeBinary;
+    ze_pfnModuleGetGlobalPointer_t                              pfnGetGlobalPointer;
+    ze_pfnModuleGetKernelNames_t                                pfnGetKernelNames;
+    ze_pfnModuleGetProperties_t                                 pfnGetProperties;
+    ze_pfnModuleGetFunctionPointer_t                            pfnGetFunctionPointer;
+    ze_pfnModuleInspectLinkageExt_t                             pfnInspectLinkageExt;
+} ze_module_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Module table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zeGetModuleProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    ze_module_dditable_t* pDdiTable                                         ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeGetModuleProcAddrTable
+typedef ze_result_t (ZE_APICALL *ze_pfnGetModuleProcAddrTable_t)(
+    ze_api_version_t,
+    ze_module_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeModuleBuildLogDestroy 
+typedef ze_result_t (ZE_APICALL *ze_pfnModuleBuildLogDestroy_t)(
+    ze_module_build_log_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeModuleBuildLogGetString 
+typedef ze_result_t (ZE_APICALL *ze_pfnModuleBuildLogGetString_t)(
+    ze_module_build_log_handle_t,
+    size_t*,
+    char*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of ModuleBuildLog functions pointers
+typedef struct _ze_module_build_log_dditable_t
+{
+    ze_pfnModuleBuildLogDestroy_t                               pfnDestroy;
+    ze_pfnModuleBuildLogGetString_t                             pfnGetString;
+} ze_module_build_log_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's ModuleBuildLog table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zeGetModuleBuildLogProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    ze_module_build_log_dditable_t* pDdiTable                               ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeGetModuleBuildLogProcAddrTable
+typedef ze_result_t (ZE_APICALL *ze_pfnGetModuleBuildLogProcAddrTable_t)(
+    ze_api_version_t,
+    ze_module_build_log_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeKernelCreate 
+typedef ze_result_t (ZE_APICALL *ze_pfnKernelCreate_t)(
+    ze_module_handle_t,
+    const ze_kernel_desc_t*,
+    ze_kernel_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeKernelDestroy 
+typedef ze_result_t (ZE_APICALL *ze_pfnKernelDestroy_t)(
+    ze_kernel_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeKernelSetCacheConfig 
+typedef ze_result_t (ZE_APICALL *ze_pfnKernelSetCacheConfig_t)(
+    ze_kernel_handle_t,
+    ze_cache_config_flags_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeKernelSetGroupSize 
+typedef ze_result_t (ZE_APICALL *ze_pfnKernelSetGroupSize_t)(
+    ze_kernel_handle_t,
+    uint32_t,
+    uint32_t,
+    uint32_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeKernelSuggestGroupSize 
+typedef ze_result_t (ZE_APICALL *ze_pfnKernelSuggestGroupSize_t)(
+    ze_kernel_handle_t,
+    uint32_t,
+    uint32_t,
+    uint32_t,
+    uint32_t*,
+    uint32_t*,
+    uint32_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeKernelSuggestMaxCooperativeGroupCount 
+typedef ze_result_t (ZE_APICALL *ze_pfnKernelSuggestMaxCooperativeGroupCount_t)(
+    ze_kernel_handle_t,
+    uint32_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeKernelSetArgumentValue 
+typedef ze_result_t (ZE_APICALL *ze_pfnKernelSetArgumentValue_t)(
+    ze_kernel_handle_t,
+    uint32_t,
+    size_t,
+    const void*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeKernelSetIndirectAccess 
+typedef ze_result_t (ZE_APICALL *ze_pfnKernelSetIndirectAccess_t)(
+    ze_kernel_handle_t,
+    ze_kernel_indirect_access_flags_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeKernelGetIndirectAccess 
+typedef ze_result_t (ZE_APICALL *ze_pfnKernelGetIndirectAccess_t)(
+    ze_kernel_handle_t,
+    ze_kernel_indirect_access_flags_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeKernelGetSourceAttributes 
+typedef ze_result_t (ZE_APICALL *ze_pfnKernelGetSourceAttributes_t)(
+    ze_kernel_handle_t,
+    uint32_t*,
+    char**
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeKernelGetProperties 
+typedef ze_result_t (ZE_APICALL *ze_pfnKernelGetProperties_t)(
+    ze_kernel_handle_t,
+    ze_kernel_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeKernelGetName 
+typedef ze_result_t (ZE_APICALL *ze_pfnKernelGetName_t)(
+    ze_kernel_handle_t,
+    size_t*,
+    char*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Kernel functions pointers
+typedef struct _ze_kernel_dditable_t
+{
+    ze_pfnKernelCreate_t                                        pfnCreate;
+    ze_pfnKernelDestroy_t                                       pfnDestroy;
+    ze_pfnKernelSetCacheConfig_t                                pfnSetCacheConfig;
+    ze_pfnKernelSetGroupSize_t                                  pfnSetGroupSize;
+    ze_pfnKernelSuggestGroupSize_t                              pfnSuggestGroupSize;
+    ze_pfnKernelSuggestMaxCooperativeGroupCount_t               pfnSuggestMaxCooperativeGroupCount;
+    ze_pfnKernelSetArgumentValue_t                              pfnSetArgumentValue;
+    ze_pfnKernelSetIndirectAccess_t                             pfnSetIndirectAccess;
+    ze_pfnKernelGetIndirectAccess_t                             pfnGetIndirectAccess;
+    ze_pfnKernelGetSourceAttributes_t                           pfnGetSourceAttributes;
+    ze_pfnKernelGetProperties_t                                 pfnGetProperties;
+    ze_pfnKernelGetName_t                                       pfnGetName;
+} ze_kernel_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Kernel table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zeGetKernelProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    ze_kernel_dditable_t* pDdiTable                                         ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeGetKernelProcAddrTable
+typedef ze_result_t (ZE_APICALL *ze_pfnGetKernelProcAddrTable_t)(
+    ze_api_version_t,
+    ze_kernel_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeKernelSetGlobalOffsetExp 
+typedef ze_result_t (ZE_APICALL *ze_pfnKernelSetGlobalOffsetExp_t)(
+    ze_kernel_handle_t,
+    uint32_t,
+    uint32_t,
+    uint32_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeKernelSchedulingHintExp 
+typedef ze_result_t (ZE_APICALL *ze_pfnKernelSchedulingHintExp_t)(
+    ze_kernel_handle_t,
+    ze_scheduling_hint_exp_desc_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeKernelGetBinaryExp 
+typedef ze_result_t (ZE_APICALL *ze_pfnKernelGetBinaryExp_t)(
+    ze_kernel_handle_t,
+    size_t*,
+    uint8_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of KernelExp functions pointers
+typedef struct _ze_kernel_exp_dditable_t
+{
+    ze_pfnKernelSetGlobalOffsetExp_t                            pfnSetGlobalOffsetExp;
+    ze_pfnKernelSchedulingHintExp_t                             pfnSchedulingHintExp;
+    ze_pfnKernelGetBinaryExp_t                                  pfnGetBinaryExp;
+} ze_kernel_exp_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's KernelExp table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zeGetKernelExpProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    ze_kernel_exp_dditable_t* pDdiTable                                     ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeGetKernelExpProcAddrTable
+typedef ze_result_t (ZE_APICALL *ze_pfnGetKernelExpProcAddrTable_t)(
+    ze_api_version_t,
+    ze_kernel_exp_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeSamplerCreate 
+typedef ze_result_t (ZE_APICALL *ze_pfnSamplerCreate_t)(
+    ze_context_handle_t,
+    ze_device_handle_t,
+    const ze_sampler_desc_t*,
+    ze_sampler_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeSamplerDestroy 
+typedef ze_result_t (ZE_APICALL *ze_pfnSamplerDestroy_t)(
+    ze_sampler_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Sampler functions pointers
+typedef struct _ze_sampler_dditable_t
+{
+    ze_pfnSamplerCreate_t                                       pfnCreate;
+    ze_pfnSamplerDestroy_t                                      pfnDestroy;
+} ze_sampler_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Sampler table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zeGetSamplerProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    ze_sampler_dditable_t* pDdiTable                                        ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeGetSamplerProcAddrTable
+typedef ze_result_t (ZE_APICALL *ze_pfnGetSamplerProcAddrTable_t)(
+    ze_api_version_t,
+    ze_sampler_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zePhysicalMemCreate 
+typedef ze_result_t (ZE_APICALL *ze_pfnPhysicalMemCreate_t)(
+    ze_context_handle_t,
+    ze_device_handle_t,
+    ze_physical_mem_desc_t*,
+    ze_physical_mem_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zePhysicalMemDestroy 
+typedef ze_result_t (ZE_APICALL *ze_pfnPhysicalMemDestroy_t)(
+    ze_context_handle_t,
+    ze_physical_mem_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of PhysicalMem functions pointers
+typedef struct _ze_physical_mem_dditable_t
+{
+    ze_pfnPhysicalMemCreate_t                                   pfnCreate;
+    ze_pfnPhysicalMemDestroy_t                                  pfnDestroy;
+} ze_physical_mem_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's PhysicalMem table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zeGetPhysicalMemProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    ze_physical_mem_dditable_t* pDdiTable                                   ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeGetPhysicalMemProcAddrTable
+typedef ze_result_t (ZE_APICALL *ze_pfnGetPhysicalMemProcAddrTable_t)(
+    ze_api_version_t,
+    ze_physical_mem_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeVirtualMemReserve 
+typedef ze_result_t (ZE_APICALL *ze_pfnVirtualMemReserve_t)(
+    ze_context_handle_t,
+    const void*,
+    size_t,
+    void**
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeVirtualMemFree 
+typedef ze_result_t (ZE_APICALL *ze_pfnVirtualMemFree_t)(
+    ze_context_handle_t,
+    const void*,
+    size_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeVirtualMemQueryPageSize 
+typedef ze_result_t (ZE_APICALL *ze_pfnVirtualMemQueryPageSize_t)(
+    ze_context_handle_t,
+    ze_device_handle_t,
+    size_t,
+    size_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeVirtualMemMap 
+typedef ze_result_t (ZE_APICALL *ze_pfnVirtualMemMap_t)(
+    ze_context_handle_t,
+    const void*,
+    size_t,
+    ze_physical_mem_handle_t,
+    size_t,
+    ze_memory_access_attribute_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeVirtualMemUnmap 
+typedef ze_result_t (ZE_APICALL *ze_pfnVirtualMemUnmap_t)(
+    ze_context_handle_t,
+    const void*,
+    size_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeVirtualMemSetAccessAttribute 
+typedef ze_result_t (ZE_APICALL *ze_pfnVirtualMemSetAccessAttribute_t)(
+    ze_context_handle_t,
+    const void*,
+    size_t,
+    ze_memory_access_attribute_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeVirtualMemGetAccessAttribute 
+typedef ze_result_t (ZE_APICALL *ze_pfnVirtualMemGetAccessAttribute_t)(
+    ze_context_handle_t,
+    const void*,
+    size_t,
+    ze_memory_access_attribute_t*,
+    size_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of VirtualMem functions pointers
+typedef struct _ze_virtual_mem_dditable_t
+{
+    ze_pfnVirtualMemReserve_t                                   pfnReserve;
+    ze_pfnVirtualMemFree_t                                      pfnFree;
+    ze_pfnVirtualMemQueryPageSize_t                             pfnQueryPageSize;
+    ze_pfnVirtualMemMap_t                                       pfnMap;
+    ze_pfnVirtualMemUnmap_t                                     pfnUnmap;
+    ze_pfnVirtualMemSetAccessAttribute_t                        pfnSetAccessAttribute;
+    ze_pfnVirtualMemGetAccessAttribute_t                        pfnGetAccessAttribute;
+} ze_virtual_mem_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's VirtualMem table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zeGetVirtualMemProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    ze_virtual_mem_dditable_t* pDdiTable                                    ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeGetVirtualMemProcAddrTable
+typedef ze_result_t (ZE_APICALL *ze_pfnGetVirtualMemProcAddrTable_t)(
+    ze_api_version_t,
+    ze_virtual_mem_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeFabricVertexGetExp 
+typedef ze_result_t (ZE_APICALL *ze_pfnFabricVertexGetExp_t)(
+    ze_driver_handle_t,
+    uint32_t*,
+    ze_fabric_vertex_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeFabricVertexGetSubVerticesExp 
+typedef ze_result_t (ZE_APICALL *ze_pfnFabricVertexGetSubVerticesExp_t)(
+    ze_fabric_vertex_handle_t,
+    uint32_t*,
+    ze_fabric_vertex_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeFabricVertexGetPropertiesExp 
+typedef ze_result_t (ZE_APICALL *ze_pfnFabricVertexGetPropertiesExp_t)(
+    ze_fabric_vertex_handle_t,
+    ze_fabric_vertex_exp_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeFabricVertexGetDeviceExp 
+typedef ze_result_t (ZE_APICALL *ze_pfnFabricVertexGetDeviceExp_t)(
+    ze_fabric_vertex_handle_t,
+    ze_device_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of FabricVertexExp functions pointers
+typedef struct _ze_fabric_vertex_exp_dditable_t
+{
+    ze_pfnFabricVertexGetExp_t                                  pfnGetExp;
+    ze_pfnFabricVertexGetSubVerticesExp_t                       pfnGetSubVerticesExp;
+    ze_pfnFabricVertexGetPropertiesExp_t                        pfnGetPropertiesExp;
+    ze_pfnFabricVertexGetDeviceExp_t                            pfnGetDeviceExp;
+} ze_fabric_vertex_exp_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's FabricVertexExp table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zeGetFabricVertexExpProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    ze_fabric_vertex_exp_dditable_t* pDdiTable                              ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeGetFabricVertexExpProcAddrTable
+typedef ze_result_t (ZE_APICALL *ze_pfnGetFabricVertexExpProcAddrTable_t)(
+    ze_api_version_t,
+    ze_fabric_vertex_exp_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeFabricEdgeGetExp 
+typedef ze_result_t (ZE_APICALL *ze_pfnFabricEdgeGetExp_t)(
+    ze_fabric_vertex_handle_t,
+    ze_fabric_vertex_handle_t,
+    uint32_t*,
+    ze_fabric_edge_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeFabricEdgeGetVerticesExp 
+typedef ze_result_t (ZE_APICALL *ze_pfnFabricEdgeGetVerticesExp_t)(
+    ze_fabric_edge_handle_t,
+    ze_fabric_vertex_handle_t*,
+    ze_fabric_vertex_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeFabricEdgeGetPropertiesExp 
+typedef ze_result_t (ZE_APICALL *ze_pfnFabricEdgeGetPropertiesExp_t)(
+    ze_fabric_edge_handle_t,
+    ze_fabric_edge_exp_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of FabricEdgeExp functions pointers
+typedef struct _ze_fabric_edge_exp_dditable_t
+{
+    ze_pfnFabricEdgeGetExp_t                                    pfnGetExp;
+    ze_pfnFabricEdgeGetVerticesExp_t                            pfnGetVerticesExp;
+    ze_pfnFabricEdgeGetPropertiesExp_t                          pfnGetPropertiesExp;
+} ze_fabric_edge_exp_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's FabricEdgeExp table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zeGetFabricEdgeExpProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    ze_fabric_edge_exp_dditable_t* pDdiTable                                ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zeGetFabricEdgeExpProcAddrTable
+typedef ze_result_t (ZE_APICALL *ze_pfnGetFabricEdgeExpProcAddrTable_t)(
+    ze_api_version_t,
+    ze_fabric_edge_exp_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Container for all DDI tables
+typedef struct _ze_dditable_t
+{
+    ze_rtas_builder_exp_dditable_t      RTASBuilderExp;
+    ze_rtas_parallel_operation_exp_dditable_t   RTASParallelOperationExp;
+    ze_global_dditable_t                Global;
+    ze_driver_dditable_t                Driver;
+    ze_driver_exp_dditable_t            DriverExp;
+    ze_device_dditable_t                Device;
+    ze_device_exp_dditable_t            DeviceExp;
+    ze_context_dditable_t               Context;
+    ze_command_queue_dditable_t         CommandQueue;
+    ze_command_list_dditable_t          CommandList;
+    ze_command_list_exp_dditable_t      CommandListExp;
+    ze_image_dditable_t                 Image;
+    ze_image_exp_dditable_t             ImageExp;
+    ze_mem_dditable_t                   Mem;
+    ze_mem_exp_dditable_t               MemExp;
+    ze_fence_dditable_t                 Fence;
+    ze_event_pool_dditable_t            EventPool;
+    ze_event_dditable_t                 Event;
+    ze_event_exp_dditable_t             EventExp;
+    ze_module_dditable_t                Module;
+    ze_module_build_log_dditable_t      ModuleBuildLog;
+    ze_kernel_dditable_t                Kernel;
+    ze_kernel_exp_dditable_t            KernelExp;
+    ze_sampler_dditable_t               Sampler;
+    ze_physical_mem_dditable_t          PhysicalMem;
+    ze_virtual_mem_dditable_t           VirtualMem;
+    ze_fabric_vertex_exp_dditable_t     FabricVertexExp;
+    ze_fabric_edge_exp_dditable_t       FabricEdgeExp;
+} ze_dditable_t;
+/// @brief Container for all DDI tables with version and tables set by the Driver
+typedef struct _ze_dditable_driver_t
+{
+    ze_api_version_t    version;
+    uint8_t             isValidFlag;
+    ze_rtas_builder_exp_dditable_t *    RTASBuilderExp;
+    ze_rtas_parallel_operation_exp_dditable_t * RTASParallelOperationExp;
+    ze_global_dditable_t *              Global;
+    ze_driver_dditable_t *              Driver;
+    ze_driver_exp_dditable_t *          DriverExp;
+    ze_device_dditable_t *              Device;
+    ze_device_exp_dditable_t *          DeviceExp;
+    ze_context_dditable_t *             Context;
+    ze_command_queue_dditable_t *       CommandQueue;
+    ze_command_list_dditable_t *        CommandList;
+    ze_command_list_exp_dditable_t *    CommandListExp;
+    ze_image_dditable_t *               Image;
+    ze_image_exp_dditable_t *           ImageExp;
+    ze_mem_dditable_t *                 Mem;
+    ze_mem_exp_dditable_t *             MemExp;
+    ze_fence_dditable_t *               Fence;
+    ze_event_pool_dditable_t *          EventPool;
+    ze_event_dditable_t *               Event;
+    ze_event_exp_dditable_t *           EventExp;
+    ze_module_dditable_t *              Module;
+    ze_module_build_log_dditable_t *    ModuleBuildLog;
+    ze_kernel_dditable_t *              Kernel;
+    ze_kernel_exp_dditable_t *          KernelExp;
+    ze_sampler_dditable_t *             Sampler;
+    ze_physical_mem_dditable_t *        PhysicalMem;
+    ze_virtual_mem_dditable_t *         VirtualMem;
+    ze_fabric_vertex_exp_dditable_t *   FabricVertexExp;
+    ze_fabric_edge_exp_dditable_t *     FabricEdgeExp;
+} ze_dditable_driver_t;
+
+#if defined(__cplusplus)
+} // extern "C"
+#endif
+
+#endif // _ZE_DDI_H

--- a/include/level_zero/zes.py
+++ b/include/level_zero/zes.py
@@ -1,0 +1,4335 @@
+"""
+ Copyright (C) 2019-2021 Intel Corporation
+
+ SPDX-License-Identifier: MIT
+
+ @file zes.py
+ @version v1.12-r1.12.15
+
+ """
+import platform
+from ctypes import *
+from enum import *
+
+###############################################################################
+__version__ = "1.0"
+
+###############################################################################
+## @brief Handle to a driver instance
+class zes_driver_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle of device object
+class zes_device_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle for a Sysman device scheduler queue
+class zes_sched_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle for a Sysman device performance factors
+class zes_perf_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle for a Sysman device power domain
+class zes_pwr_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle for a Sysman device frequency domain
+class zes_freq_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle for a Sysman device engine group
+class zes_engine_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle for a Sysman device standby control
+class zes_standby_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle for a Sysman device firmware
+class zes_firmware_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle for a Sysman device memory module
+class zes_mem_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle for a Sysman fabric port
+class zes_fabric_port_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle for a Sysman device temperature sensor
+class zes_temp_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle for a Sysman device power supply
+class zes_psu_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle for a Sysman device fan
+class zes_fan_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle for a Sysman device LED
+class zes_led_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle for a Sysman device RAS error set
+class zes_ras_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle for a Sysman device diagnostics test suite
+class zes_diag_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle for a Sysman device overclock domain
+class zes_overclock_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle for a Sysman virtual function management domain
+class zes_vf_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Defines structure types
+class zes_structure_type_v(IntEnum):
+    DEVICE_PROPERTIES = 0x1                                                 ## ::zes_device_properties_t
+    PCI_PROPERTIES = 0x2                                                    ## ::zes_pci_properties_t
+    PCI_BAR_PROPERTIES = 0x3                                                ## ::zes_pci_bar_properties_t
+    DIAG_PROPERTIES = 0x4                                                   ## ::zes_diag_properties_t
+    ENGINE_PROPERTIES = 0x5                                                 ## ::zes_engine_properties_t
+    FABRIC_PORT_PROPERTIES = 0x6                                            ## ::zes_fabric_port_properties_t
+    FAN_PROPERTIES = 0x7                                                    ## ::zes_fan_properties_t
+    FIRMWARE_PROPERTIES = 0x8                                               ## ::zes_firmware_properties_t
+    FREQ_PROPERTIES = 0x9                                                   ## ::zes_freq_properties_t
+    LED_PROPERTIES = 0xa                                                    ## ::zes_led_properties_t
+    MEM_PROPERTIES = 0xb                                                    ## ::zes_mem_properties_t
+    PERF_PROPERTIES = 0xc                                                   ## ::zes_perf_properties_t
+    POWER_PROPERTIES = 0xd                                                  ## ::zes_power_properties_t
+    PSU_PROPERTIES = 0xe                                                    ## ::zes_psu_properties_t
+    RAS_PROPERTIES = 0xf                                                    ## ::zes_ras_properties_t
+    SCHED_PROPERTIES = 0x10                                                 ## ::zes_sched_properties_t
+    SCHED_TIMEOUT_PROPERTIES = 0x11                                         ## ::zes_sched_timeout_properties_t
+    SCHED_TIMESLICE_PROPERTIES = 0x12                                       ## ::zes_sched_timeslice_properties_t
+    STANDBY_PROPERTIES = 0x13                                               ## ::zes_standby_properties_t
+    TEMP_PROPERTIES = 0x14                                                  ## ::zes_temp_properties_t
+    DEVICE_STATE = 0x15                                                     ## ::zes_device_state_t
+    PROCESS_STATE = 0x16                                                    ## ::zes_process_state_t
+    PCI_STATE = 0x17                                                        ## ::zes_pci_state_t
+    FABRIC_PORT_CONFIG = 0x18                                               ## ::zes_fabric_port_config_t
+    FABRIC_PORT_STATE = 0x19                                                ## ::zes_fabric_port_state_t
+    FAN_CONFIG = 0x1a                                                       ## ::zes_fan_config_t
+    FREQ_STATE = 0x1b                                                       ## ::zes_freq_state_t
+    OC_CAPABILITIES = 0x1c                                                  ## ::zes_oc_capabilities_t
+    LED_STATE = 0x1d                                                        ## ::zes_led_state_t
+    MEM_STATE = 0x1e                                                        ## ::zes_mem_state_t
+    PSU_STATE = 0x1f                                                        ## ::zes_psu_state_t
+    BASE_STATE = 0x20                                                       ## ::zes_base_state_t
+    RAS_CONFIG = 0x21                                                       ## ::zes_ras_config_t
+    RAS_STATE = 0x22                                                        ## ::zes_ras_state_t
+    TEMP_CONFIG = 0x23                                                      ## ::zes_temp_config_t
+    PCI_BAR_PROPERTIES_1_2 = 0x24                                           ## ::zes_pci_bar_properties_1_2_t
+    DEVICE_ECC_DESC = 0x25                                                  ## ::zes_device_ecc_desc_t
+    DEVICE_ECC_PROPERTIES = 0x26                                            ## ::zes_device_ecc_properties_t
+    POWER_LIMIT_EXT_DESC = 0x27                                             ## ::zes_power_limit_ext_desc_t
+    POWER_EXT_PROPERTIES = 0x28                                             ## ::zes_power_ext_properties_t
+    OVERCLOCK_PROPERTIES = 0x29                                             ## ::zes_overclock_properties_t
+    FABRIC_PORT_ERROR_COUNTERS = 0x2a                                       ## ::zes_fabric_port_error_counters_t
+    ENGINE_EXT_PROPERTIES = 0x2b                                            ## ::zes_engine_ext_properties_t
+    RESET_PROPERTIES = 0x2c                                                 ## ::zes_reset_properties_t
+    DEVICE_EXT_PROPERTIES = 0x2d                                            ## ::zes_device_ext_properties_t
+    DEVICE_UUID = 0x2e                                                      ## ::zes_uuid_t
+    POWER_DOMAIN_EXP_PROPERTIES = 0x00020001                                ## ::zes_power_domain_exp_properties_t
+    MEM_BANDWIDTH_COUNTER_BITS_EXP_PROPERTIES = 0x00020002                  ## ::zes_mem_bandwidth_counter_bits_exp_properties_t
+    MEMORY_PAGE_OFFLINE_STATE_EXP = 0x00020003                              ## ::zes_mem_page_offline_state_exp_t
+    SUBDEVICE_EXP_PROPERTIES = 0x00020004                                   ## ::zes_subdevice_exp_properties_t
+    VF_EXP_PROPERTIES = 0x00020005                                          ## ::zes_vf_exp_properties_t
+    VF_UTIL_MEM_EXP = 0x00020006                                            ## ::zes_vf_util_mem_exp_t
+    VF_UTIL_ENGINE_EXP = 0x00020007                                         ## ::zes_vf_util_engine_exp_t
+    VF_EXP_CAPABILITIES = 0x00020008                                        ## ::zes_vf_exp_capabilities_t
+    VF_UTIL_MEM_EXP2 = 0x00020009                                           ## ::zes_vf_util_mem_exp2_t
+    VF_UTIL_ENGINE_EXP2 = 0x00020010                                        ## ::zes_vf_util_engine_exp2_t
+    VF_EXP2_CAPABILITIES = 0x00020011                                       ## ::zes_vf_exp2_capabilities_t
+
+class zes_structure_type_t(c_int):
+    def __str__(self):
+        return str(zes_structure_type_v(self.value))
+
+
+###############################################################################
+## @brief Base for all properties types
+class zes_base_properties_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p)                                             ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+    ]
+
+###############################################################################
+## @brief Base for all descriptor types
+class zes_base_desc_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p)                                             ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+    ]
+
+###############################################################################
+## @brief Base for all state types
+class zes_base_state_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p)                                             ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+    ]
+
+###############################################################################
+## @brief Base for all config types
+class zes_base_config_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p)                                             ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+    ]
+
+###############################################################################
+## @brief Base for all capability types
+class zes_base_capability_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p)                                             ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+    ]
+
+###############################################################################
+## @brief Supported sysman initialization flags
+class zes_init_flags_v(IntEnum):
+    PLACEHOLDER = ZE_BIT(0)                                                 ## placeholder for future use
+
+class zes_init_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Maximum extension name string size
+ZES_MAX_EXTENSION_NAME = 256
+
+###############################################################################
+## @brief Extension properties queried using ::zesDriverGetExtensionProperties
+class zes_driver_extension_properties_t(Structure):
+    _fields_ = [
+        ("name", c_char * ZES_MAX_EXTENSION_NAME),                      ## [out] extension name
+        ("version", c_ulong)                                            ## [out] extension version using ::ZE_MAKE_VERSION
+    ]
+
+###############################################################################
+## @brief Maximum number of characters in string properties.
+ZES_STRING_PROPERTY_SIZE = 64
+
+###############################################################################
+## @brief Maximum device universal unique id (UUID) size in bytes.
+ZES_MAX_UUID_SIZE = 16
+
+###############################################################################
+## @brief Types of accelerator engines
+class zes_engine_type_flags_v(IntEnum):
+    OTHER = ZE_BIT(0)                                                       ## Undefined types of accelerators.
+    COMPUTE = ZE_BIT(1)                                                     ## Engines that process compute kernels only (no 3D content).
+    _3D = ZE_BIT(2)                                                         ## Engines that process 3D content only (no compute kernels).
+    MEDIA = ZE_BIT(3)                                                       ## Engines that process media workloads.
+    DMA = ZE_BIT(4)                                                         ## Engines that copy blocks of data.
+    RENDER = ZE_BIT(5)                                                      ## Engines that can process both 3D content and compute kernels.
+
+class zes_engine_type_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Device repair status
+class zes_repair_status_v(IntEnum):
+    UNSUPPORTED = 0                                                         ## The device does not support in-field repairs.
+    NOT_PERFORMED = 1                                                       ## The device has never been repaired.
+    PERFORMED = 2                                                           ## The device has been repaired.
+
+class zes_repair_status_t(c_int):
+    def __str__(self):
+        return str(zes_repair_status_v(self.value))
+
+
+###############################################################################
+## @brief Device reset reasons
+class zes_reset_reason_flags_v(IntEnum):
+    WEDGED = ZE_BIT(0)                                                      ## The device needs to be reset because one or more parts of the hardware
+                                                                            ## is wedged
+    REPAIR = ZE_BIT(1)                                                      ## The device needs to be reset in order to complete in-field repairs
+
+class zes_reset_reason_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Device reset type
+class zes_reset_type_v(IntEnum):
+    WARM = 0                                                                ## Apply warm reset
+    COLD = 1                                                                ## Apply cold reset
+    FLR = 2                                                                 ## Apply FLR reset
+
+class zes_reset_type_t(c_int):
+    def __str__(self):
+        return str(zes_reset_type_v(self.value))
+
+
+###############################################################################
+## @brief Device state
+class zes_device_state_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("reset", zes_reset_reason_flags_t),                            ## [out] Indicates if the device needs to be reset and for what reasons.
+                                                                        ## returns 0 (none) or combination of ::zes_reset_reason_flag_t
+        ("repaired", zes_repair_status_t)                               ## [out] Indicates if the device has been repaired
+    ]
+
+###############################################################################
+## @brief Device reset properties
+class zes_reset_properties_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("force", ze_bool_t),                                           ## [in] If set to true, all applications that are currently using the
+                                                                        ## device will be forcibly killed.
+        ("resetType", zes_reset_type_t)                                 ## [in] Type of reset needs to be performed
+    ]
+
+###############################################################################
+## @brief Device universal unique id (UUID)
+class zes_uuid_t(Structure):
+    _fields_ = [
+        ("id", c_ubyte * ZES_MAX_UUID_SIZE)                             ## [out] opaque data representing a device UUID
+    ]
+
+###############################################################################
+## @brief Supported device types
+class zes_device_type_v(IntEnum):
+    GPU = 1                                                                 ## Graphics Processing Unit
+    CPU = 2                                                                 ## Central Processing Unit
+    FPGA = 3                                                                ## Field Programmable Gate Array
+    MCA = 4                                                                 ## Memory Copy Accelerator
+    VPU = 5                                                                 ## Vision Processing Unit
+
+class zes_device_type_t(c_int):
+    def __str__(self):
+        return str(zes_device_type_v(self.value))
+
+
+###############################################################################
+## @brief Supported device property flags
+class zes_device_property_flags_v(IntEnum):
+    INTEGRATED = ZE_BIT(0)                                                  ## Device is integrated with the Host.
+    SUBDEVICE = ZE_BIT(1)                                                   ## Device handle used for query represents a sub-device.
+    ECC = ZE_BIT(2)                                                         ## Device supports error correction memory access.
+    ONDEMANDPAGING = ZE_BIT(3)                                              ## Device supports on-demand page-faulting.
+
+class zes_device_property_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Device properties
+class zes_device_properties_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("core", ze_device_properties_t),                               ## [out] (Deprecated, use ::zes_uuid_t in the extended structure) Core
+                                                                        ## device properties
+        ("numSubdevices", c_ulong),                                     ## [out] Number of sub-devices. A value of 0 indicates that this device
+                                                                        ## doesn't have sub-devices.
+        ("serialNumber", c_char * ZES_STRING_PROPERTY_SIZE),            ## [out] Manufacturing serial number (NULL terminated string value). This
+                                                                        ## value is intended to reflect the Part ID/SoC ID assigned by
+                                                                        ## manufacturer that is unique for a SoC. Will be set to the string
+                                                                        ## "unknown" if this cannot be determined for the device.
+        ("boardNumber", c_char * ZES_STRING_PROPERTY_SIZE),             ## [out] Manufacturing board number (NULL terminated string value).
+                                                                        ## Alternatively "boardSerialNumber", this value is intended to reflect
+                                                                        ## the string printed on board label by manufacturer. Will be set to the
+                                                                        ## string "unknown" if this cannot be determined for the device.
+        ("brandName", c_char * ZES_STRING_PROPERTY_SIZE),               ## [out] Brand name of the device (NULL terminated string value). Will be
+                                                                        ## set to the string "unknown" if this cannot be determined for the
+                                                                        ## device.
+        ("modelName", c_char * ZES_STRING_PROPERTY_SIZE),               ## [out] Model name of the device (NULL terminated string value). Will be
+                                                                        ## set to the string "unknown" if this cannot be determined for the
+                                                                        ## device.
+        ("vendorName", c_char * ZES_STRING_PROPERTY_SIZE),              ## [out] Vendor name of the device (NULL terminated string value). Will
+                                                                        ## be set to the string "unknown" if this cannot be determined for the
+                                                                        ## device.
+        ("driverVersion", c_char * ZES_STRING_PROPERTY_SIZE)            ## [out] Installed driver version (NULL terminated string value). Will be
+                                                                        ## set to the string "unknown" if this cannot be determined for the
+                                                                        ## device.
+    ]
+
+###############################################################################
+## @brief Device properties
+class zes_device_ext_properties_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("uuid", zes_uuid_t),                                           ## [out] universal unique identifier. Note: uuid obtained from Sysman API
+                                                                        ## is the same as from core API. Subdevices will have their own uuid.
+        ("type", zes_device_type_t),                                    ## [out] generic device type
+        ("flags", zes_device_property_flags_t)                          ## [out] 0 (none) or a valid combination of ::zes_device_property_flag_t
+    ]
+
+###############################################################################
+## @brief Contains information about a process that has an open connection with
+##        this device
+## 
+## @details
+##     - The application can use the process ID to query the OS for the owner
+##       and the path to the executable.
+class zes_process_state_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("processId", c_ulong),                                         ## [out] Host OS process ID.
+        ("memSize", c_ulonglong),                                       ## [out] Device memory size in bytes allocated by this process (may not
+                                                                        ## necessarily be resident on the device at the time of reading).
+        ("sharedSize", c_ulonglong),                                    ## [out] The size of shared device memory mapped into this process (may
+                                                                        ## not necessarily be resident on the device at the time of reading).
+        ("engines", zes_engine_type_flags_t)                            ## [out] Bitfield of accelerator engine types being used by this process.
+    ]
+
+###############################################################################
+## @brief PCI address
+class zes_pci_address_t(Structure):
+    _fields_ = [
+        ("domain", c_ulong),                                            ## [out] BDF domain
+        ("bus", c_ulong),                                               ## [out] BDF bus
+        ("device", c_ulong),                                            ## [out] BDF device
+        ("function", c_ulong)                                           ## [out] BDF function
+    ]
+
+###############################################################################
+## @brief PCI speed
+class zes_pci_speed_t(Structure):
+    _fields_ = [
+        ("gen", c_int32_t),                                             ## [out] The link generation. A value of -1 means that this property is
+                                                                        ## unknown.
+        ("width", c_int32_t),                                           ## [out] The number of lanes. A value of -1 means that this property is
+                                                                        ## unknown.
+        ("maxBandwidth", c_int64_t)                                     ## [out] The maximum bandwidth in bytes/sec (sum of all lanes). A value
+                                                                        ## of -1 means that this property is unknown.
+    ]
+
+###############################################################################
+## @brief Static PCI properties
+class zes_pci_properties_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("address", zes_pci_address_t),                                 ## [out] The BDF address
+        ("maxSpeed", zes_pci_speed_t),                                  ## [out] Fastest port configuration supported by the device (sum of all
+                                                                        ## lanes)
+        ("haveBandwidthCounters", ze_bool_t),                           ## [out] Indicates whether the `rxCounter` and `txCounter` members of
+                                                                        ## ::zes_pci_stats_t will have valid values
+        ("havePacketCounters", ze_bool_t),                              ## [out] Indicates whether the `packetCounter` member of
+                                                                        ## ::zes_pci_stats_t will have a valid value
+        ("haveReplayCounters", ze_bool_t)                               ## [out] Indicates whether the `replayCounter` member of
+                                                                        ## ::zes_pci_stats_t will have a valid value
+    ]
+
+###############################################################################
+## @brief PCI link status
+class zes_pci_link_status_v(IntEnum):
+    UNKNOWN = 0                                                             ## The link status could not be determined
+    GOOD = 1                                                                ## The link is up and operating as expected
+    QUALITY_ISSUES = 2                                                      ## The link is up but has quality and/or bandwidth degradation
+    STABILITY_ISSUES = 3                                                    ## The link has stability issues and preventing workloads making forward
+                                                                            ## progress
+
+class zes_pci_link_status_t(c_int):
+    def __str__(self):
+        return str(zes_pci_link_status_v(self.value))
+
+
+###############################################################################
+## @brief PCI link quality degradation reasons
+class zes_pci_link_qual_issue_flags_v(IntEnum):
+    REPLAYS = ZE_BIT(0)                                                     ## A significant number of replays are occurring
+    SPEED = ZE_BIT(1)                                                       ## There is a degradation in the maximum bandwidth of the link
+
+class zes_pci_link_qual_issue_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief PCI link stability issues
+class zes_pci_link_stab_issue_flags_v(IntEnum):
+    RETRAINING = ZE_BIT(0)                                                  ## Link retraining has occurred to deal with quality issues
+
+class zes_pci_link_stab_issue_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Dynamic PCI state
+class zes_pci_state_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("status", zes_pci_link_status_t),                              ## [out] The current status of the port
+        ("qualityIssues", zes_pci_link_qual_issue_flags_t),             ## [out] If status is ::ZES_PCI_LINK_STATUS_QUALITY_ISSUES, 
+                                                                        ## then this gives a combination of ::zes_pci_link_qual_issue_flag_t for
+                                                                        ## quality issues that have been detected;
+                                                                        ## otherwise, 0 indicates there are no quality issues with the link at
+                                                                        ## this time."
+        ("stabilityIssues", zes_pci_link_stab_issue_flags_t),           ## [out] If status is ::ZES_PCI_LINK_STATUS_STABILITY_ISSUES, 
+                                                                        ## then this gives a combination of ::zes_pci_link_stab_issue_flag_t for
+                                                                        ## reasons for the connection instability;
+                                                                        ## otherwise, 0 indicates there are no connection stability issues at
+                                                                        ## this time."
+        ("speed", zes_pci_speed_t)                                      ## [out] The current port configure speed
+    ]
+
+###############################################################################
+## @brief PCI bar types
+class zes_pci_bar_type_v(IntEnum):
+    MMIO = 0                                                                ## MMIO registers
+    ROM = 1                                                                 ## ROM aperture
+    MEM = 2                                                                 ## Device memory
+
+class zes_pci_bar_type_t(c_int):
+    def __str__(self):
+        return str(zes_pci_bar_type_v(self.value))
+
+
+###############################################################################
+## @brief Properties of a pci bar
+class zes_pci_bar_properties_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("type", zes_pci_bar_type_t),                                   ## [out] The type of bar
+        ("index", c_ulong),                                             ## [out] The index of the bar
+        ("base", c_ulonglong),                                          ## [out] Base address of the bar.
+        ("size", c_ulonglong)                                           ## [out] Size of the bar.
+    ]
+
+###############################################################################
+## @brief Properties of a pci bar, including the resizable bar.
+class zes_pci_bar_properties_1_2_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("type", zes_pci_bar_type_t),                                   ## [out] The type of bar
+        ("index", c_ulong),                                             ## [out] The index of the bar
+        ("base", c_ulonglong),                                          ## [out] Base address of the bar.
+        ("size", c_ulonglong),                                          ## [out] Size of the bar.
+        ("resizableBarSupported", ze_bool_t),                           ## [out] Support for Resizable Bar on this device.
+        ("resizableBarEnabled", ze_bool_t)                              ## [out] Resizable Bar enabled on this device
+    ]
+
+###############################################################################
+## @brief PCI stats counters
+## 
+## @details
+##     - Percent replays is calculated by taking two snapshots (s1, s2) and
+##       using the equation: %replay = 10^6 * (s2.replayCounter -
+##       s1.replayCounter) / (s2.maxBandwidth * (s2.timestamp - s1.timestamp))
+##     - Percent throughput is calculated by taking two snapshots (s1, s2) and
+##       using the equation: %bw = 10^6 * ((s2.rxCounter - s1.rxCounter) +
+##       (s2.txCounter - s1.txCounter)) / (s2.maxBandwidth * (s2.timestamp -
+##       s1.timestamp))
+class zes_pci_stats_t(Structure):
+    _fields_ = [
+        ("timestamp", c_ulonglong),                                     ## [out] Monotonic timestamp counter in microseconds when the measurement
+                                                                        ## was made.
+                                                                        ## This timestamp should only be used to calculate delta time between
+                                                                        ## snapshots of this structure.
+                                                                        ## Never take the delta of this timestamp with the timestamp from a
+                                                                        ## different structure since they are not guaranteed to have the same base.
+                                                                        ## The absolute value of the timestamp is only valid during within the
+                                                                        ## application and may be different on the next execution.
+        ("replayCounter", c_ulonglong),                                 ## [out] Monotonic counter for the number of replay packets (sum of all
+                                                                        ## lanes). Will always be 0 when the `haveReplayCounters` member of
+                                                                        ## ::zes_pci_properties_t is FALSE.
+        ("packetCounter", c_ulonglong),                                 ## [out] Monotonic counter for the number of packets (sum of all lanes).
+                                                                        ## Will always be 0 when the `havePacketCounters` member of
+                                                                        ## ::zes_pci_properties_t is FALSE.
+        ("rxCounter", c_ulonglong),                                     ## [out] Monotonic counter for the number of bytes received (sum of all
+                                                                        ## lanes). Will always be 0 when the `haveBandwidthCounters` member of
+                                                                        ## ::zes_pci_properties_t is FALSE.
+        ("txCounter", c_ulonglong),                                     ## [out] Monotonic counter for the number of bytes transmitted (including
+                                                                        ## replays) (sum of all lanes). Will always be 0 when the
+                                                                        ## `haveBandwidthCounters` member of ::zes_pci_properties_t is FALSE.
+        ("speed", zes_pci_speed_t)                                      ## [out] The current speed of the link (sum of all lanes)
+    ]
+
+###############################################################################
+## @brief Overclock domains.
+class zes_overclock_domain_v(IntEnum):
+    CARD = 1                                                                ## Overclocking card level properties such as temperature limits.
+    PACKAGE = 2                                                             ## Overclocking package level properties such as power limits.
+    GPU_ALL = 4                                                             ## Overclocking a GPU that has all accelerator assets on the same PLL/VR.
+    GPU_RENDER_COMPUTE = 8                                                  ## Overclocking a GPU with render and compute assets on the same PLL/VR.
+    GPU_RENDER = 16                                                         ## Overclocking a GPU with render assets on its own PLL/VR.
+    GPU_COMPUTE = 32                                                        ## Overclocking a GPU with compute assets on its own PLL/VR.
+    GPU_MEDIA = 64                                                          ## Overclocking a GPU with media assets on its own PLL/VR.
+    VRAM = 128                                                              ## Overclocking device local memory.
+    ADM = 256                                                               ## Overclocking LLC/L4 cache.
+
+class zes_overclock_domain_t(c_int):
+    def __str__(self):
+        return str(zes_overclock_domain_v(self.value))
+
+
+###############################################################################
+## @brief Overclock controls.
+class zes_overclock_control_v(IntEnum):
+    VF = 1                                                                  ## This control permits setting a custom V-F curve.
+    FREQ_OFFSET = 2                                                         ## The V-F curve of the overclock domain can be shifted up or down using
+                                                                            ## this control.
+    VMAX_OFFSET = 4                                                         ## This control is used to increase the permitted voltage above the
+                                                                            ## shipped voltage maximum.
+    FREQ = 8                                                                ## This control permits direct changes to the operating frequency.
+    VOLT_LIMIT = 16                                                         ## This control prevents frequencies that would push the voltage above
+                                                                            ## this value, typically used by V-F scanners.
+    POWER_SUSTAINED_LIMIT = 32                                              ## This control changes the sustained power limit (PL1).
+    POWER_BURST_LIMIT = 64                                                  ## This control changes the burst power limit (PL2).
+    POWER_PEAK_LIMIT = 128                                                  ## his control changes the peak power limit (PL4).
+    ICCMAX_LIMIT = 256                                                      ## This control changes the value of IccMax..
+    TEMP_LIMIT = 512                                                        ## This control changes the value of TjMax.
+    ITD_DISABLE = 1024                                                      ## This control permits disabling the adaptive voltage feature ITD
+    ACM_DISABLE = 2048                                                      ## This control permits disabling the adaptive voltage feature ACM.
+
+class zes_overclock_control_t(c_int):
+    def __str__(self):
+        return str(zes_overclock_control_v(self.value))
+
+
+###############################################################################
+## @brief Overclock modes.
+class zes_overclock_mode_v(IntEnum):
+    MODE_OFF = 0                                                            ## Overclock mode is off
+    MODE_STOCK = 2                                                          ## Stock (manufacturing settings) are being used.
+    MODE_ON = 3                                                             ## Overclock mode is on.
+    MODE_UNAVAILABLE = 4                                                    ## Overclocking is unavailable at this time since the system is running
+                                                                            ## on battery.
+    MODE_DISABLED = 5                                                       ## Overclock mode is disabled.
+
+class zes_overclock_mode_t(c_int):
+    def __str__(self):
+        return str(zes_overclock_mode_v(self.value))
+
+
+###############################################################################
+## @brief Overclock control states.
+class zes_control_state_v(IntEnum):
+    STATE_UNSET = 0                                                         ## No overclock control has not been changed by the driver since the last
+                                                                            ## boot/reset.
+    STATE_ACTIVE = 2                                                        ## The overclock control has been set and it is active.
+    STATE_DISABLED = 3                                                      ## The overclock control value has been disabled due to the current power
+                                                                            ## configuration (typically when running on DC).
+
+class zes_control_state_t(c_int):
+    def __str__(self):
+        return str(zes_control_state_v(self.value))
+
+
+###############################################################################
+## @brief Overclock pending actions.
+class zes_pending_action_v(IntEnum):
+    PENDING_NONE = 0                                                        ## There no pending actions. .
+    PENDING_IMMINENT = 1                                                    ## The requested change is in progress and should complete soon.
+    PENDING_COLD_RESET = 2                                                  ## The requested change requires a device cold reset (hotplug, system
+                                                                            ## boot).
+    PENDING_WARM_RESET = 3                                                  ## The requested change requires a device warm reset (PCIe FLR).
+
+class zes_pending_action_t(c_int):
+    def __str__(self):
+        return str(zes_pending_action_v(self.value))
+
+
+###############################################################################
+## @brief Overclock V-F curve programing.
+class zes_vf_program_type_v(IntEnum):
+    VF_ARBITRARY = 0                                                        ## Can program an arbitrary number of V-F points up to the maximum number
+                                                                            ## and each point can have arbitrary voltage and frequency values within
+                                                                            ## the min/max/step limits
+    VF_FREQ_FIXED = 1                                                       ## Can only program the voltage for the V-F points that it reads back -
+                                                                            ## the frequency of those points cannot be changed
+    VF_VOLT_FIXED = 2                                                       ## Can only program the frequency for the V-F points that is reads back -
+                                                                            ## the voltage of each point cannot be changed.
+
+class zes_vf_program_type_t(c_int):
+    def __str__(self):
+        return str(zes_vf_program_type_v(self.value))
+
+
+###############################################################################
+## @brief VF type
+class zes_vf_type_v(IntEnum):
+    VOLT = 0                                                                ## VF Voltage point
+    FREQ = 1                                                                ## VF Frequency point
+
+class zes_vf_type_t(c_int):
+    def __str__(self):
+        return str(zes_vf_type_v(self.value))
+
+
+###############################################################################
+## @brief VF type
+class zes_vf_array_type_v(IntEnum):
+    USER_VF_ARRAY = 0                                                       ## User V-F array
+    DEFAULT_VF_ARRAY = 1                                                    ## Default V-F array
+    LIVE_VF_ARRAY = 2                                                       ## Live V-F array
+
+class zes_vf_array_type_t(c_int):
+    def __str__(self):
+        return str(zes_vf_array_type_v(self.value))
+
+
+###############################################################################
+## @brief Overclock properties
+## 
+## @details
+##     - Information on the overclock domain type and all the contols that are
+##       part of the domain.
+class zes_overclock_properties_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("domainType", zes_overclock_domain_t),                         ## [out] The hardware block that this overclock domain controls (GPU,
+                                                                        ## VRAM, ...)
+        ("AvailableControls", c_ulong),                                 ## [out] Returns the overclock controls that are supported (a bit for
+                                                                        ## each of enum ::zes_overclock_control_t). If no bits are set, the
+                                                                        ## domain doesn't support overclocking.
+        ("VFProgramType", zes_vf_program_type_t),                       ## [out] Type of V-F curve programming that is permitted:.
+        ("NumberOfVFPoints", c_ulong)                                   ## [out] Number of VF points that can be programmed - max_num_points
+    ]
+
+###############################################################################
+## @brief Overclock Control properties
+## 
+## @details
+##     - Provides all the control capabilities supported by the device for the
+##       overclock domain.
+class zes_control_property_t(Structure):
+    _fields_ = [
+        ("MinValue", c_double),                                         ## [out]  This provides information about the limits of the control value
+                                                                        ## so that the driver can calculate the set of valid values.
+        ("MaxValue", c_double),                                         ## [out]  This provides information about the limits of the control value
+                                                                        ## so that the driver can calculate the set of valid values.
+        ("StepValue", c_double),                                        ## [out]  This provides information about the limits of the control value
+                                                                        ## so that the driver can calculate the set of valid values.
+        ("RefValue", c_double),                                         ## [out] The reference value provides the anchor point, UIs can combine
+                                                                        ## this with the user offset request to show the anticipated improvement.
+        ("DefaultValue", c_double)                                      ## [out] The shipped out-of-box position of this control. Driver can
+                                                                        ## request this value at any time to return to the out-of-box behavior.
+    ]
+
+###############################################################################
+## @brief Overclock VF properties
+## 
+## @details
+##     - Provides all the VF capabilities supported by the device for the
+##       overclock domain.
+class zes_vf_property_t(Structure):
+    _fields_ = [
+        ("MinFreq", c_double),                                          ## [out] Read the minimum frequency that can be be programmed in the
+                                                                        ## custom V-F point..
+        ("MaxFreq", c_double),                                          ## [out] Read the maximum frequency that can be be programmed in the
+                                                                        ## custom V-F point..
+        ("StepFreq", c_double),                                         ## [out] Read the frequency step that can be be programmed in the custom
+                                                                        ## V-F point..
+        ("MinVolt", c_double),                                          ## [out] Read the minimum voltage that can be be programmed in the custom
+                                                                        ## V-F point..
+        ("MaxVolt", c_double),                                          ## [out] Read the maximum voltage that can be be programmed in the custom
+                                                                        ## V-F point..
+        ("StepVolt", c_double)                                          ## [out] Read the voltage step that can be be programmed in the custom
+                                                                        ## V-F point.
+    ]
+
+###############################################################################
+## @brief Diagnostic results
+class zes_diag_result_v(IntEnum):
+    NO_ERRORS = 0                                                           ## Diagnostic completed without finding errors to repair
+    ABORT = 1                                                               ## Diagnostic had problems running tests
+    FAIL_CANT_REPAIR = 2                                                    ## Diagnostic had problems setting up repairs
+    REBOOT_FOR_REPAIR = 3                                                   ## Diagnostics found errors, setup for repair and reboot is required to
+                                                                            ## complete the process
+
+class zes_diag_result_t(c_int):
+    def __str__(self):
+        return str(zes_diag_result_v(self.value))
+
+
+###############################################################################
+## @brief Diagnostic test index to use for the very first test.
+ZES_DIAG_FIRST_TEST_INDEX = 0x0
+
+###############################################################################
+## @brief Diagnostic test index to use for the very last test.
+ZES_DIAG_LAST_TEST_INDEX = 0xFFFFFFFF
+
+###############################################################################
+## @brief Diagnostic test
+class zes_diag_test_t(Structure):
+    _fields_ = [
+        ("index", c_ulong),                                             ## [out] Index of the test
+        ("name", c_char * ZES_STRING_PROPERTY_SIZE)                     ## [out] Name of the test
+    ]
+
+###############################################################################
+## @brief Diagnostics test suite properties
+class zes_diag_properties_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("onSubdevice", ze_bool_t),                                     ## [out] True if the resource is located on a sub-device; false means
+                                                                        ## that the resource is on the device of the calling Sysman handle
+        ("subdeviceId", c_ulong),                                       ## [out] If onSubdevice is true, this gives the ID of the sub-device
+        ("name", c_char * ZES_STRING_PROPERTY_SIZE),                    ## [out] Name of the diagnostics test suite
+        ("haveTests", ze_bool_t)                                        ## [out] Indicates if this test suite has individual tests which can be
+                                                                        ## run separately (use the function ::zesDiagnosticsGetTests() to get the
+                                                                        ## list of these tests)
+    ]
+
+###############################################################################
+## @brief ECC State
+class zes_device_ecc_state_v(IntEnum):
+    UNAVAILABLE = 0                                                         ## None
+    ENABLED = 1                                                             ## ECC enabled.
+    DISABLED = 2                                                            ## ECC disabled.
+
+class zes_device_ecc_state_t(c_int):
+    def __str__(self):
+        return str(zes_device_ecc_state_v(self.value))
+
+
+###############################################################################
+## @brief State Change Requirements
+class zes_device_action_v(IntEnum):
+    NONE = 0                                                                ## No action.
+    WARM_CARD_RESET = 1                                                     ## Warm reset of the card.
+    COLD_CARD_RESET = 2                                                     ## Cold reset of the card.
+    COLD_SYSTEM_REBOOT = 3                                                  ## Cold reboot of the system.
+
+class zes_device_action_t(c_int):
+    def __str__(self):
+        return str(zes_device_action_v(self.value))
+
+
+###############################################################################
+## @brief ECC State Descriptor
+class zes_device_ecc_desc_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("state", zes_device_ecc_state_t)                               ## [out] ECC state
+    ]
+
+###############################################################################
+## @brief ECC State
+class zes_device_ecc_properties_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("currentState", zes_device_ecc_state_t),                       ## [out] Current ECC state
+        ("pendingState", zes_device_ecc_state_t),                       ## [out] Pending ECC state
+        ("pendingAction", zes_device_action_t)                          ## [out] Pending action
+    ]
+
+###############################################################################
+## @brief Accelerator engine groups
+class zes_engine_group_v(IntEnum):
+    ALL = 0                                                                 ## Access information about all engines combined.
+    COMPUTE_ALL = 1                                                         ## Access information about all compute engines combined. Compute engines
+                                                                            ## can only process compute kernels (no 3D content).
+    MEDIA_ALL = 2                                                           ## Access information about all media engines combined.
+    COPY_ALL = 3                                                            ## Access information about all copy (blitter) engines combined.
+    COMPUTE_SINGLE = 4                                                      ## Access information about a single compute engine - this is an engine
+                                                                            ## that can process compute kernels. Note that single engines may share
+                                                                            ## the same underlying accelerator resources as other engines so activity
+                                                                            ## of such an engine may not be indicative of the underlying resource
+                                                                            ## utilization - use ::ZES_ENGINE_GROUP_3D_RENDER_COMPUTE_ALL for that.
+    RENDER_SINGLE = 5                                                       ## Access information about a single render engine - this is an engine
+                                                                            ## that can process both 3D content and compute kernels. Note that single
+                                                                            ## engines may share the same underlying accelerator resources as other
+                                                                            ## engines so activity of such an engine may not be indicative of the
+                                                                            ## underlying resource utilization - use
+                                                                            ## ::ZES_ENGINE_GROUP_3D_RENDER_COMPUTE_ALL for that.
+    MEDIA_DECODE_SINGLE = 6                                                 ## [DEPRECATED] No longer supported.
+    MEDIA_ENCODE_SINGLE = 7                                                 ## [DEPRECATED] No longer supported.
+    COPY_SINGLE = 8                                                         ## Access information about a single media encode engine. Note that
+                                                                            ## single engines may share the same underlying accelerator resources as
+                                                                            ## other engines so activity of such an engine may not be indicative of
+                                                                            ## the underlying resource utilization - use ::ZES_ENGINE_GROUP_COPY_ALL
+                                                                            ## for that.
+    MEDIA_ENHANCEMENT_SINGLE = 9                                            ## Access information about a single media enhancement engine. Note that
+                                                                            ## single engines may share the same underlying accelerator resources as
+                                                                            ## other engines so activity of such an engine may not be indicative of
+                                                                            ## the underlying resource utilization - use ::ZES_ENGINE_GROUP_MEDIA_ALL
+                                                                            ## for that.
+    _3D_SINGLE = 10                                                         ## [DEPRECATED] No longer supported.
+    _3D_RENDER_COMPUTE_ALL = 11                                             ## [DEPRECATED] No longer supported.
+    RENDER_ALL = 12                                                         ## Access information about all render engines combined. Render engines
+                                                                            ## are those than process both 3D content and compute kernels.
+    _3D_ALL = 13                                                            ## [DEPRECATED] No longer supported.
+    MEDIA_CODEC_SINGLE = 14                                                 ## Access information about a single media engine. Note that single
+                                                                            ## engines may share the same underlying accelerator resources as other
+                                                                            ## engines so activity of such an engine may not be indicative of the
+                                                                            ## underlying resource utilization - use ::ZES_ENGINE_GROUP_MEDIA_ALL for
+                                                                            ## that.
+
+class zes_engine_group_t(c_int):
+    def __str__(self):
+        return str(zes_engine_group_v(self.value))
+
+
+###############################################################################
+## @brief Engine group properties
+class zes_engine_properties_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("type", zes_engine_group_t),                                   ## [out] The engine group
+        ("onSubdevice", ze_bool_t),                                     ## [out] True if this resource is located on a sub-device; false means
+                                                                        ## that the resource is on the device of the calling Sysman handle
+        ("subdeviceId", c_ulong)                                        ## [out] If onSubdevice is true, this gives the ID of the sub-device
+    ]
+
+###############################################################################
+## @brief Engine activity counters
+## 
+## @details
+##     - Percent utilization is calculated by taking two snapshots (s1, s2) and
+##       using the equation: %util = (s2.activeTime - s1.activeTime) /
+##       (s2.timestamp - s1.timestamp)
+##     - The `activeTime` time units are implementation-specific since the
+##       value is only intended to be used for calculating utilization
+##       percentage.
+##     - The `timestamp` should only be used to calculate delta between
+##       snapshots of this structure.
+##     - The application should never take the delta of `timestamp` with the
+##       timestamp from a different structure since they are not guaranteed to
+##       have the same base.
+##     - When taking the delta, the difference between `timestamp` samples
+##       could be `0`, if the frequency of sampling the snapshots is higher
+##       than the frequency of the timestamp update.
+##     - The absolute value of `timestamp` is only valid during within the
+##       application and may be different on the next execution.
+class zes_engine_stats_t(Structure):
+    _fields_ = [
+        ("activeTime", c_ulonglong),                                    ## [out] Monotonic counter where the resource is actively running
+                                                                        ## workloads.
+        ("timestamp", c_ulonglong)                                      ## [out] Monotonic counter when activeTime counter was sampled.
+    ]
+
+###############################################################################
+## @brief Event types
+class zes_event_type_flags_v(IntEnum):
+    DEVICE_DETACH = ZE_BIT(0)                                               ## Event is triggered when the device is no longer available (due to a
+                                                                            ## reset or being disabled).
+    DEVICE_ATTACH = ZE_BIT(1)                                               ## Event is triggered after the device is available again.
+    DEVICE_SLEEP_STATE_ENTER = ZE_BIT(2)                                    ## Event is triggered when the driver is about to put the device into a
+                                                                            ## deep sleep state
+    DEVICE_SLEEP_STATE_EXIT = ZE_BIT(3)                                     ## Event is triggered when the driver is waking the device up from a deep
+                                                                            ## sleep state
+    FREQ_THROTTLED = ZE_BIT(4)                                              ## Event is triggered when the frequency starts being throttled
+    ENERGY_THRESHOLD_CROSSED = ZE_BIT(5)                                    ## Event is triggered when the energy consumption threshold is reached
+                                                                            ## (use ::zesPowerSetEnergyThreshold() to configure).
+    TEMP_CRITICAL = ZE_BIT(6)                                               ## Event is triggered when the critical temperature is reached (use
+                                                                            ## ::zesTemperatureSetConfig() to configure - disabled by default).
+    TEMP_THRESHOLD1 = ZE_BIT(7)                                             ## Event is triggered when the temperature crosses threshold 1 (use
+                                                                            ## ::zesTemperatureSetConfig() to configure - disabled by default).
+    TEMP_THRESHOLD2 = ZE_BIT(8)                                             ## Event is triggered when the temperature crosses threshold 2 (use
+                                                                            ## ::zesTemperatureSetConfig() to configure - disabled by default).
+    MEM_HEALTH = ZE_BIT(9)                                                  ## Event is triggered when the health of device memory changes.
+    FABRIC_PORT_HEALTH = ZE_BIT(10)                                         ## Event is triggered when the health of fabric ports change.
+    PCI_LINK_HEALTH = ZE_BIT(11)                                            ## Event is triggered when the health of the PCI link changes.
+    RAS_CORRECTABLE_ERRORS = ZE_BIT(12)                                     ## Event is triggered when accelerator RAS correctable errors cross
+                                                                            ## thresholds (use ::zesRasSetConfig() to configure - disabled by
+                                                                            ## default).
+    RAS_UNCORRECTABLE_ERRORS = ZE_BIT(13)                                   ## Event is triggered when accelerator RAS uncorrectable errors cross
+                                                                            ## thresholds (use ::zesRasSetConfig() to configure - disabled by
+                                                                            ## default).
+    DEVICE_RESET_REQUIRED = ZE_BIT(14)                                      ## Event is triggered when the device needs to be reset (use
+                                                                            ## ::zesDeviceGetState() to determine the reasons for the reset).
+    SURVIVABILITY_MODE_DETECTED = ZE_BIT(15)                                ## Event is triggered when graphics driver encounter an error condition.
+
+class zes_event_type_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Maximum Fabric port model string size
+ZES_MAX_FABRIC_PORT_MODEL_SIZE = 256
+
+###############################################################################
+## @brief Maximum size of the buffer that will return information about link
+##        types
+ZES_MAX_FABRIC_LINK_TYPE_SIZE = 256
+
+###############################################################################
+## @brief Fabric port status
+class zes_fabric_port_status_v(IntEnum):
+    UNKNOWN = 0                                                             ## The port status cannot be determined
+    HEALTHY = 1                                                             ## The port is up and operating as expected
+    DEGRADED = 2                                                            ## The port is up but has quality and/or speed degradation
+    FAILED = 3                                                              ## Port connection instabilities are preventing workloads making forward
+                                                                            ## progress
+    DISABLED = 4                                                            ## The port is configured down
+
+class zes_fabric_port_status_t(c_int):
+    def __str__(self):
+        return str(zes_fabric_port_status_v(self.value))
+
+
+###############################################################################
+## @brief Fabric port quality degradation reasons
+class zes_fabric_port_qual_issue_flags_v(IntEnum):
+    LINK_ERRORS = ZE_BIT(0)                                                 ## Excessive link errors are occurring
+    SPEED = ZE_BIT(1)                                                       ## There is a degradation in the bitrate and/or width of the link
+
+class zes_fabric_port_qual_issue_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Fabric port failure reasons
+class zes_fabric_port_failure_flags_v(IntEnum):
+    FAILED = ZE_BIT(0)                                                      ## A previously operating link has failed. Hardware will automatically
+                                                                            ## retrain this port. This state will persist until either the physical
+                                                                            ## connection is removed or the link trains successfully.
+    TRAINING_TIMEOUT = ZE_BIT(1)                                            ## A connection has not been established within an expected time.
+                                                                            ## Hardware will continue to attempt port training. This status will
+                                                                            ## persist until either the physical connection is removed or the link
+                                                                            ## successfully trains.
+    FLAPPING = ZE_BIT(2)                                                    ## Port has excessively trained and then transitioned down for some
+                                                                            ## period of time. Driver will allow port to continue to train, but will
+                                                                            ## not enable the port for use until the port has been disabled and
+                                                                            ## subsequently re-enabled using ::zesFabricPortSetConfig().
+
+class zes_fabric_port_failure_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Unique identifier for a fabric port
+## 
+## @details
+##     - This not a universal identifier. The identified is garanteed to be
+##       unique for the current hardware configuration of the system. Changes
+##       in the hardware may result in a different identifier for a given port.
+##     - The main purpose of this identifier to build up an instantaneous
+##       topology map of system connectivity. An application should enumerate
+##       all fabric ports and match the `remotePortId` member of
+##       ::zes_fabric_port_state_t to the `portId` member of
+##       ::zes_fabric_port_properties_t.
+class zes_fabric_port_id_t(Structure):
+    _fields_ = [
+        ("fabricId", c_ulong),                                          ## [out] Unique identifier for the fabric end-point
+        ("attachId", c_ulong),                                          ## [out] Unique identifier for the device attachment point
+        ("portNumber", c_ubyte)                                         ## [out] The logical port number (this is typically marked somewhere on
+                                                                        ## the physical device)
+    ]
+
+###############################################################################
+## @brief Fabric port speed in one direction
+class zes_fabric_port_speed_t(Structure):
+    _fields_ = [
+        ("bitRate", c_int64_t),                                         ## [out] Bits/sec that the link is operating at. A value of -1 means that
+                                                                        ## this property is unknown.
+        ("width", c_int32_t)                                            ## [out] The number of lanes. A value of -1 means that this property is
+                                                                        ## unknown.
+    ]
+
+###############################################################################
+## @brief Fabric port properties
+class zes_fabric_port_properties_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("model", c_char * ZES_MAX_FABRIC_PORT_MODEL_SIZE),             ## [out] Description of port technology. Will be set to the string
+                                                                        ## "unkown" if this cannot be determined for this port.
+        ("onSubdevice", ze_bool_t),                                     ## [out] True if the port is located on a sub-device; false means that
+                                                                        ## the port is on the device of the calling Sysman handle
+        ("subdeviceId", c_ulong),                                       ## [out] If onSubdevice is true, this gives the ID of the sub-device
+        ("portId", zes_fabric_port_id_t),                               ## [out] The unique port identifier
+        ("maxRxSpeed", zes_fabric_port_speed_t),                        ## [out] Maximum speed supported by the receive side of the port (sum of
+                                                                        ## all lanes)
+        ("maxTxSpeed", zes_fabric_port_speed_t)                         ## [out] Maximum speed supported by the transmit side of the port (sum of
+                                                                        ## all lanes)
+    ]
+
+###############################################################################
+## @brief Provides information about the fabric link attached to a port
+class zes_fabric_link_type_t(Structure):
+    _fields_ = [
+        ("desc", c_char * ZES_MAX_FABRIC_LINK_TYPE_SIZE)                ## [out] Description of link technology. Will be set to the string
+                                                                        ## "unkown" if this cannot be determined for this link.
+    ]
+
+###############################################################################
+## @brief Fabric port configuration
+class zes_fabric_port_config_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("enabled", ze_bool_t),                                         ## [in,out] Port is configured up/down
+        ("beaconing", ze_bool_t)                                        ## [in,out] Beaconing is configured on/off
+    ]
+
+###############################################################################
+## @brief Fabric port state
+class zes_fabric_port_state_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("status", zes_fabric_port_status_t),                           ## [out] The current status of the port
+        ("qualityIssues", zes_fabric_port_qual_issue_flags_t),          ## [out] If status is ::ZES_FABRIC_PORT_STATUS_DEGRADED,
+                                                                        ## then this gives a combination of ::zes_fabric_port_qual_issue_flag_t
+                                                                        ## for quality issues that have been detected;
+                                                                        ## otherwise, 0 indicates there are no quality issues with the link at
+                                                                        ## this time.
+        ("failureReasons", zes_fabric_port_failure_flags_t),            ## [out] If status is ::ZES_FABRIC_PORT_STATUS_FAILED,
+                                                                        ## then this gives a combination of ::zes_fabric_port_failure_flag_t for
+                                                                        ## reasons for the connection instability;
+                                                                        ## otherwise, 0 indicates there are no connection stability issues at
+                                                                        ## this time.
+        ("remotePortId", zes_fabric_port_id_t),                         ## [out] The unique port identifier for the remote connection point if
+                                                                        ## status is ::ZES_FABRIC_PORT_STATUS_HEALTHY,
+                                                                        ## ::ZES_FABRIC_PORT_STATUS_DEGRADED or ::ZES_FABRIC_PORT_STATUS_FAILED
+        ("rxSpeed", zes_fabric_port_speed_t),                           ## [out] Current maximum receive speed (sum of all lanes)
+        ("txSpeed", zes_fabric_port_speed_t)                            ## [out] Current maximum transmit speed (sum of all lanes)
+    ]
+
+###############################################################################
+## @brief Fabric port throughput.
+class zes_fabric_port_throughput_t(Structure):
+    _fields_ = [
+        ("timestamp", c_ulonglong),                                     ## [out] Monotonic timestamp counter in microseconds when the measurement
+                                                                        ## was made.
+                                                                        ## This timestamp should only be used to calculate delta time between
+                                                                        ## snapshots of this structure.
+                                                                        ## Never take the delta of this timestamp with the timestamp from a
+                                                                        ## different structure since they are not guaranteed to have the same base.
+                                                                        ## The absolute value of the timestamp is only valid during within the
+                                                                        ## application and may be different on the next execution.
+        ("rxCounter", c_ulonglong),                                     ## [out] Monotonic counter for the number of bytes received (sum of all
+                                                                        ## lanes). This includes all protocol overhead, not only the GPU traffic.
+        ("txCounter", c_ulonglong)                                      ## [out] Monotonic counter for the number of bytes transmitted (sum of
+                                                                        ## all lanes). This includes all protocol overhead, not only the GPU
+                                                                        ## traffic.
+    ]
+
+###############################################################################
+## @brief Fabric Port Error Counters
+class zes_fabric_port_error_counters_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("linkFailureCount", c_ulonglong),                              ## [out] Link Failure Error Count reported per port
+        ("fwCommErrorCount", c_ulonglong),                              ## [out] Firmware Communication Error Count reported per device
+        ("fwErrorCount", c_ulonglong),                                  ## [out] Firmware reported Error Count reported per device
+        ("linkDegradeCount", c_ulonglong)                               ## [out] Link Degrade Error Count reported per port
+    ]
+
+###############################################################################
+## @brief Fan resource speed mode
+class zes_fan_speed_mode_v(IntEnum):
+    DEFAULT = 0                                                             ## The fan speed is operating using the hardware default settings
+    FIXED = 1                                                               ## The fan speed is currently set to a fixed value
+    TABLE = 2                                                               ## The fan speed is currently controlled dynamically by hardware based on
+                                                                            ## a temp/speed table
+
+class zes_fan_speed_mode_t(c_int):
+    def __str__(self):
+        return str(zes_fan_speed_mode_v(self.value))
+
+
+###############################################################################
+## @brief Fan speed units
+class zes_fan_speed_units_v(IntEnum):
+    RPM = 0                                                                 ## The fan speed is in units of revolutions per minute (rpm)
+    PERCENT = 1                                                             ## The fan speed is a percentage of the maximum speed of the fan
+
+class zes_fan_speed_units_t(c_int):
+    def __str__(self):
+        return str(zes_fan_speed_units_v(self.value))
+
+
+###############################################################################
+## @brief Fan speed
+class zes_fan_speed_t(Structure):
+    _fields_ = [
+        ("speed", c_int32_t),                                           ## [in,out] The speed of the fan. On output, a value of -1 indicates that
+                                                                        ## there is no fixed fan speed setting.
+        ("units", zes_fan_speed_units_t)                                ## [in,out] The units that the fan speed is expressed in. On output, if
+                                                                        ## fan speed is -1 then units should be ignored.
+    ]
+
+###############################################################################
+## @brief Fan temperature/speed pair
+class zes_fan_temp_speed_t(Structure):
+    _fields_ = [
+        ("temperature", c_ulong),                                       ## [in,out] Temperature in degrees Celsius.
+        ("speed", zes_fan_speed_t)                                      ## [in,out] The speed of the fan
+    ]
+
+###############################################################################
+## @brief Maximum number of fan temperature/speed pairs in the fan speed table.
+ZES_FAN_TEMP_SPEED_PAIR_COUNT = 32
+
+###############################################################################
+## @brief Fan speed table
+class zes_fan_speed_table_t(Structure):
+    _fields_ = [
+        ("numPoints", c_int32_t),                                       ## [in,out] The number of valid points in the fan speed table. 0 means
+                                                                        ## that there is no fan speed table configured. -1 means that a fan speed
+                                                                        ## table is not supported by the hardware.
+        ("table", zes_fan_temp_speed_t * ZES_FAN_TEMP_SPEED_PAIR_COUNT) ## [in,out] Array of temperature/fan speed pairs. The table is ordered
+                                                                        ## based on temperature from lowest to highest.
+    ]
+
+###############################################################################
+## @brief Fan properties
+class zes_fan_properties_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("onSubdevice", ze_bool_t),                                     ## [out] True if the resource is located on a sub-device; false means
+                                                                        ## that the resource is on the device of the calling Sysman handle
+        ("subdeviceId", c_ulong),                                       ## [out] If onSubdevice is true, this gives the ID of the sub-device
+        ("canControl", ze_bool_t),                                      ## [out] Indicates if software can control the fan speed assuming the
+                                                                        ## user has permissions
+        ("supportedModes", c_ulong),                                    ## [out] Bitfield of supported fan configuration modes
+                                                                        ## (1<<::zes_fan_speed_mode_t)
+        ("supportedUnits", c_ulong),                                    ## [out] Bitfield of supported fan speed units
+                                                                        ## (1<<::zes_fan_speed_units_t)
+        ("maxRPM", c_int32_t),                                          ## [out] The maximum RPM of the fan. A value of -1 means that this
+                                                                        ## property is unknown. 
+        ("maxPoints", c_int32_t)                                        ## [out] The maximum number of points in the fan temp/speed table. A
+                                                                        ## value of -1 means that this fan doesn't support providing a temp/speed
+                                                                        ## table.
+    ]
+
+###############################################################################
+## @brief Fan configuration
+class zes_fan_config_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("mode", zes_fan_speed_mode_t),                                 ## [in,out] The fan speed mode (fixed, temp-speed table)
+        ("speedFixed", zes_fan_speed_t),                                ## [in,out] The current fixed fan speed setting
+        ("speedTable", zes_fan_speed_table_t)                           ## [out] A table containing temperature/speed pairs
+    ]
+
+###############################################################################
+## @brief Firmware properties
+class zes_firmware_properties_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("onSubdevice", ze_bool_t),                                     ## [out] True if the resource is located on a sub-device; false means
+                                                                        ## that the resource is on the device of the calling Sysman handle
+        ("subdeviceId", c_ulong),                                       ## [out] If onSubdevice is true, this gives the ID of the sub-device
+        ("canControl", ze_bool_t),                                      ## [out] Indicates if software can flash the firmware assuming the user
+                                                                        ## has permissions
+        ("name", c_char * ZES_STRING_PROPERTY_SIZE),                    ## [out] NULL terminated string value. The string "unknown" will be
+                                                                        ## returned if this property cannot be determined.
+        ("version", c_char * ZES_STRING_PROPERTY_SIZE)                  ## [out] NULL terminated string value. The string "unknown" will be
+                                                                        ## returned if this property cannot be determined.
+    ]
+
+###############################################################################
+## @brief Frequency domains.
+class zes_freq_domain_v(IntEnum):
+    GPU = 0                                                                 ## GPU Core Domain.
+    MEMORY = 1                                                              ## Local Memory Domain.
+    MEDIA = 2                                                               ## GPU Media Domain.
+
+class zes_freq_domain_t(c_int):
+    def __str__(self):
+        return str(zes_freq_domain_v(self.value))
+
+
+###############################################################################
+## @brief Frequency properties
+## 
+## @details
+##     - Indicates if this frequency domain can be overclocked (if true,
+##       functions such as ::zesFrequencyOcSetFrequencyTarget() are supported).
+##     - The min/max hardware frequencies are specified for non-overclock
+##       configurations. For overclock configurations, use
+##       ::zesFrequencyOcGetFrequencyTarget() to determine the maximum
+##       frequency that can be requested.
+class zes_freq_properties_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("type", zes_freq_domain_t),                                    ## [out] The hardware block that this frequency domain controls (GPU,
+                                                                        ## memory, ...)
+        ("onSubdevice", ze_bool_t),                                     ## [out] True if this resource is located on a sub-device; false means
+                                                                        ## that the resource is on the device of the calling Sysman handle
+        ("subdeviceId", c_ulong),                                       ## [out] If onSubdevice is true, this gives the ID of the sub-device
+        ("canControl", ze_bool_t),                                      ## [out] Indicates if software can control the frequency of this domain
+                                                                        ## assuming the user has permissions
+        ("isThrottleEventSupported", ze_bool_t),                        ## [out] Indicates if software can register to receive event
+                                                                        ## ::ZES_EVENT_TYPE_FLAG_FREQ_THROTTLED
+        ("min", c_double),                                              ## [out] The minimum hardware clock frequency in units of MHz.
+        ("max", c_double)                                               ## [out] The maximum non-overclock hardware clock frequency in units of
+                                                                        ## MHz.
+    ]
+
+###############################################################################
+## @brief Frequency range between which the hardware can operate.
+## 
+## @details
+##     - When setting limits, they will be clamped to the hardware limits.
+##     - When setting limits, ensure that the max frequency is greater than or
+##       equal to the min frequency specified.
+##     - When setting limits to return to factory settings, specify -1 for both
+##       the min and max limit.
+class zes_freq_range_t(Structure):
+    _fields_ = [
+        ("min", c_double),                                              ## [in,out] The min frequency in MHz below which hardware frequency
+                                                                        ## management will not request frequencies. On input, setting to 0 will
+                                                                        ## permit the frequency to go down to the hardware minimum while setting
+                                                                        ## to -1 will return the min frequency limit to the factory value (can be
+                                                                        ## larger than the hardware min). On output, a negative value indicates
+                                                                        ## that no external minimum frequency limit is in effect.
+        ("max", c_double)                                               ## [in,out] The max frequency in MHz above which hardware frequency
+                                                                        ## management will not request frequencies. On input, setting to 0 or a
+                                                                        ## very big number will permit the frequency to go all the way up to the
+                                                                        ## hardware maximum while setting to -1 will return the max frequency to
+                                                                        ## the factory value (which can be less than the hardware max). On
+                                                                        ## output, a negative number indicates that no external maximum frequency
+                                                                        ## limit is in effect.
+    ]
+
+###############################################################################
+## @brief Frequency throttle reasons
+class zes_freq_throttle_reason_flags_v(IntEnum):
+    AVE_PWR_CAP = ZE_BIT(0)                                                 ## frequency throttled due to average power excursion (PL1)
+    BURST_PWR_CAP = ZE_BIT(1)                                               ## frequency throttled due to burst power excursion (PL2)
+    CURRENT_LIMIT = ZE_BIT(2)                                               ## frequency throttled due to current excursion (PL4)
+    THERMAL_LIMIT = ZE_BIT(3)                                               ## frequency throttled due to thermal excursion (T > TjMax)
+    PSU_ALERT = ZE_BIT(4)                                                   ## frequency throttled due to power supply assertion
+    SW_RANGE = ZE_BIT(5)                                                    ## frequency throttled due to software supplied frequency range
+    HW_RANGE = ZE_BIT(6)                                                    ## frequency throttled due to a sub block that has a lower frequency
+                                                                            ## range when it receives clocks
+
+class zes_freq_throttle_reason_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Frequency state
+class zes_freq_state_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("currentVoltage", c_double),                                   ## [out] Current voltage in Volts. A negative value indicates that this
+                                                                        ## property is not known.
+        ("request", c_double),                                          ## [out] The current frequency request in MHz. A negative value indicates
+                                                                        ## that this property is not known.
+        ("tdp", c_double),                                              ## [out] The maximum frequency in MHz supported under the current TDP
+                                                                        ## conditions. This fluctuates dynamically based on the power and thermal
+                                                                        ## limits of the part. A negative value indicates that this property is
+                                                                        ## not known.
+        ("efficient", c_double),                                        ## [out] The efficient minimum frequency in MHz. A negative value
+                                                                        ## indicates that this property is not known.
+        ("actual", c_double),                                           ## [out] The resolved frequency in MHz. A negative value indicates that
+                                                                        ## this property is not known.
+        ("throttleReasons", zes_freq_throttle_reason_flags_t)           ## [out] The reasons that the frequency is being limited by the hardware.
+                                                                        ## Returns 0 (frequency not throttled) or a combination of ::zes_freq_throttle_reason_flag_t.
+    ]
+
+###############################################################################
+## @brief Frequency throttle time snapshot
+## 
+## @details
+##     - Percent time throttled is calculated by taking two snapshots (s1, s2)
+##       and using the equation: %throttled = (s2.throttleTime -
+##       s1.throttleTime) / (s2.timestamp - s1.timestamp)
+class zes_freq_throttle_time_t(Structure):
+    _fields_ = [
+        ("throttleTime", c_ulonglong),                                  ## [out] The monotonic counter of time in microseconds that the frequency
+                                                                        ## has been limited by the hardware.
+        ("timestamp", c_ulonglong)                                      ## [out] Microsecond timestamp when throttleTime was captured.
+                                                                        ## This timestamp should only be used to calculate delta time between
+                                                                        ## snapshots of this structure.
+                                                                        ## Never take the delta of this timestamp with the timestamp from a
+                                                                        ## different structure since they are not guaranteed to have the same base.
+                                                                        ## The absolute value of the timestamp is only valid during within the
+                                                                        ## application and may be different on the next execution.
+    ]
+
+###############################################################################
+## @brief Overclocking modes
+## 
+## @details
+##     - [DEPRECATED] No longer supported.
+class zes_oc_mode_v(IntEnum):
+    OFF = 0                                                                 ## Overclocking if off - hardware is running using factory default
+                                                                            ## voltages/frequencies.
+    OVERRIDE = 1                                                            ## Overclock override mode - In this mode, a fixed user-supplied voltage
+                                                                            ## is applied independent of the frequency request. The maximum permitted
+                                                                            ## frequency can also be increased. This mode disables INTERPOLATIVE and
+                                                                            ## FIXED modes.
+    INTERPOLATIVE = 2                                                       ## Overclock interpolative mode - In this mode, the voltage/frequency
+                                                                            ## curve can be extended with a new voltage/frequency point that will be
+                                                                            ## interpolated. The existing voltage/frequency points can also be offset
+                                                                            ## (up or down) by a fixed voltage. This mode disables FIXED and OVERRIDE
+                                                                            ## modes.
+    FIXED = 3                                                               ## Overclocking fixed Mode - In this mode, hardware will disable most
+                                                                            ## frequency throttling and lock the frequency and voltage at the
+                                                                            ## specified overclock values. This mode disables OVERRIDE and
+                                                                            ## INTERPOLATIVE modes. This mode can damage the part, most of the
+                                                                            ## protections are disabled on this mode.
+
+class zes_oc_mode_t(c_int):
+    def __str__(self):
+        return str(zes_oc_mode_v(self.value))
+
+
+###############################################################################
+## @brief Overclocking properties
+## 
+## @details
+##     - Provides all the overclocking capabilities and properties supported by
+##       the device for the frequency domain.
+##     - [DEPRECATED] No longer supported.
+class zes_oc_capabilities_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("isOcSupported", ze_bool_t),                                   ## [out] Indicates if any overclocking features are supported on this
+                                                                        ## frequency domain.
+        ("maxFactoryDefaultFrequency", c_double),                       ## [out] Factory default non-overclock maximum frequency in Mhz.
+        ("maxFactoryDefaultVoltage", c_double),                         ## [out] Factory default voltage used for the non-overclock maximum
+                                                                        ## frequency in MHz.
+        ("maxOcFrequency", c_double),                                   ## [out] Maximum hardware overclocking frequency limit in Mhz.
+        ("minOcVoltageOffset", c_double),                               ## [out] The minimum voltage offset that can be applied to the
+                                                                        ## voltage/frequency curve. Note that this number can be negative.
+        ("maxOcVoltageOffset", c_double),                               ## [out] The maximum voltage offset that can be applied to the
+                                                                        ## voltage/frequency curve.
+        ("maxOcVoltage", c_double),                                     ## [out] The maximum overclock voltage that hardware supports.
+        ("isTjMaxSupported", ze_bool_t),                                ## [out] Indicates if the maximum temperature limit (TjMax) can be
+                                                                        ## changed for this frequency domain.
+        ("isIccMaxSupported", ze_bool_t),                               ## [out] Indicates if the maximum current (IccMax) can be changed for
+                                                                        ## this frequency domain.
+        ("isHighVoltModeCapable", ze_bool_t),                           ## [out] Indicates if this frequency domains supports a feature to set
+                                                                        ## very high voltages.
+        ("isHighVoltModeEnabled", ze_bool_t),                           ## [out] Indicates if very high voltages are permitted on this frequency
+                                                                        ## domain.
+        ("isExtendedModeSupported", ze_bool_t),                         ## [out] Indicates if the extended overclocking features are supported.
+                                                                        ## If this is supported, increments are on 1 Mhz basis.
+        ("isFixedModeSupported", ze_bool_t)                             ## [out] Indicates if the fixed mode is supported. In this mode, hardware
+                                                                        ## will disable most frequency throttling and lock the frequency and
+                                                                        ## voltage at the specified overclock values.
+    ]
+
+###############################################################################
+## @brief LED properties
+class zes_led_properties_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("onSubdevice", ze_bool_t),                                     ## [out] True if the resource is located on a sub-device; false means
+                                                                        ## that the resource is on the device of the calling Sysman handle
+        ("subdeviceId", c_ulong),                                       ## [out] If onSubdevice is true, this gives the ID of the sub-device
+        ("canControl", ze_bool_t),                                      ## [out] Indicates if software can control the LED assuming the user has
+                                                                        ## permissions
+        ("haveRGB", ze_bool_t)                                          ## [out] Indicates if the LED is RGB capable
+    ]
+
+###############################################################################
+## @brief LED color
+class zes_led_color_t(Structure):
+    _fields_ = [
+        ("red", c_double),                                              ## [in,out][range(0.0, 1.0)] The LED red value. On output, a value less
+                                                                        ## than 0.0 indicates that the color is not known.
+        ("green", c_double),                                            ## [in,out][range(0.0, 1.0)] The LED green value. On output, a value less
+                                                                        ## than 0.0 indicates that the color is not known.
+        ("blue", c_double)                                              ## [in,out][range(0.0, 1.0)] The LED blue value. On output, a value less
+                                                                        ## than 0.0 indicates that the color is not known.
+    ]
+
+###############################################################################
+## @brief LED state
+class zes_led_state_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("isOn", ze_bool_t),                                            ## [out] Indicates if the LED is on or off
+        ("color", zes_led_color_t)                                      ## [out] Color of the LED
+    ]
+
+###############################################################################
+## @brief Memory module types
+class zes_mem_type_v(IntEnum):
+    HBM = 0                                                                 ## HBM memory
+    DDR = 1                                                                 ## DDR memory
+    DDR3 = 2                                                                ## DDR3 memory
+    DDR4 = 3                                                                ## DDR4 memory
+    DDR5 = 4                                                                ## DDR5 memory
+    LPDDR = 5                                                               ## LPDDR memory
+    LPDDR3 = 6                                                              ## LPDDR3 memory
+    LPDDR4 = 7                                                              ## LPDDR4 memory
+    LPDDR5 = 8                                                              ## LPDDR5 memory
+    SRAM = 9                                                                ## SRAM memory
+    L1 = 10                                                                 ## L1 cache
+    L3 = 11                                                                 ## L3 cache
+    GRF = 12                                                                ## Execution unit register file
+    SLM = 13                                                                ## Execution unit shared local memory
+    GDDR4 = 14                                                              ## GDDR4 memory
+    GDDR5 = 15                                                              ## GDDR5 memory
+    GDDR5X = 16                                                             ## GDDR5X memory
+    GDDR6 = 17                                                              ## GDDR6 memory
+    GDDR6X = 18                                                             ## GDDR6X memory
+    GDDR7 = 19                                                              ## GDDR7 memory
+
+class zes_mem_type_t(c_int):
+    def __str__(self):
+        return str(zes_mem_type_v(self.value))
+
+
+###############################################################################
+## @brief Memory module location
+class zes_mem_loc_v(IntEnum):
+    SYSTEM = 0                                                              ## System memory
+    DEVICE = 1                                                              ## On board local device memory
+
+class zes_mem_loc_t(c_int):
+    def __str__(self):
+        return str(zes_mem_loc_v(self.value))
+
+
+###############################################################################
+## @brief Memory health
+class zes_mem_health_v(IntEnum):
+    UNKNOWN = 0                                                             ## The memory health cannot be determined.
+    OK = 1                                                                  ## All memory channels are healthy.
+    DEGRADED = 2                                                            ## Excessive correctable errors have been detected on one or more
+                                                                            ## channels. Device should be reset.
+    CRITICAL = 3                                                            ## Operating with reduced memory to cover banks with too many
+                                                                            ## uncorrectable errors.
+    REPLACE = 4                                                             ## Device should be replaced due to excessive uncorrectable errors.
+
+class zes_mem_health_t(c_int):
+    def __str__(self):
+        return str(zes_mem_health_v(self.value))
+
+
+###############################################################################
+## @brief Memory properties
+class zes_mem_properties_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("type", zes_mem_type_t),                                       ## [out] The memory type
+        ("onSubdevice", ze_bool_t),                                     ## [out] True if this resource is located on a sub-device; false means
+                                                                        ## that the resource is on the device of the calling Sysman handle
+        ("subdeviceId", c_ulong),                                       ## [out] If onSubdevice is true, this gives the ID of the sub-device
+        ("location", zes_mem_loc_t),                                    ## [out] Location of this memory (system, device)
+        ("physicalSize", c_ulonglong),                                  ## [out] Physical memory size in bytes. A value of 0 indicates that this
+                                                                        ## property is not known. However, a call to ::zesMemoryGetState() will
+                                                                        ## correctly return the total size of usable memory.
+        ("busWidth", c_int32_t),                                        ## [out] Width of the memory bus. A value of -1 means that this property
+                                                                        ## is unknown.
+        ("numChannels", c_int32_t)                                      ## [out] The number of memory channels. A value of -1 means that this
+                                                                        ## property is unknown.
+    ]
+
+###############################################################################
+## @brief Memory state - health, allocated
+## 
+## @details
+##     - Percent allocation is given by 100 * (size - free / size.
+##     - Percent free is given by 100 * free / size.
+class zes_mem_state_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("health", zes_mem_health_t),                                   ## [out] Indicates the health of the memory
+        ("free", c_ulonglong),                                          ## [out] The free memory in bytes
+        ("size", c_ulonglong)                                           ## [out] The total allocatable memory in bytes (can be less than the
+                                                                        ## `physicalSize` member of ::zes_mem_properties_t)
+    ]
+
+###############################################################################
+## @brief Memory bandwidth
+## 
+## @details
+##     - Percent bandwidth is calculated by taking two snapshots (s1, s2) and
+##       using the equation: %bw = 10^6 * ((s2.readCounter - s1.readCounter) +
+##       (s2.writeCounter - s1.writeCounter)) / (s2.maxBandwidth *
+##       (s2.timestamp - s1.timestamp))
+##     - Counter can roll over and rollover needs to be handled by comparing
+##       the current read against the previous read
+##     - Counter is a 32 byte transaction count, which means the calculated
+##       delta (delta = current_value - previous_value or delta = 2^32 -
+##       previous_value + current_value in case of rollover) needs to be
+##       multiplied by 32 to get delta between samples in actual byte count
+class zes_mem_bandwidth_t(Structure):
+    _fields_ = [
+        ("readCounter", c_ulonglong),                                   ## [out] Total bytes read from memory
+        ("writeCounter", c_ulonglong),                                  ## [out] Total bytes written to memory
+        ("maxBandwidth", c_ulonglong),                                  ## [out] Current maximum bandwidth in units of bytes/sec
+        ("timestamp", c_ulonglong)                                      ## [out] The timestamp in microseconds when these measurements were sampled.
+                                                                        ## This timestamp should only be used to calculate delta time between
+                                                                        ## snapshots of this structure.
+                                                                        ## Never take the delta of this timestamp with the timestamp from a
+                                                                        ## different structure since they are not guaranteed to have the same base.
+                                                                        ## The absolute value of the timestamp is only valid during within the
+                                                                        ## application and may be different on the next execution.
+    ]
+
+###############################################################################
+## @brief Extension properties for Memory bandwidth
+## 
+## @details
+##     - Number of counter bits
+##     - [DEPRECATED] No longer supported.
+class zes_mem_ext_bandwidth_t(Structure):
+    _fields_ = [
+        ("memoryTimestampValidBits", c_ulong)                           ## [out] Returns the number of valid bits in the timestamp values
+    ]
+
+###############################################################################
+## @brief Static information about a Performance Factor domain
+class zes_perf_properties_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("onSubdevice", ze_bool_t),                                     ## [out] True if this Performance Factor affects accelerators located on
+                                                                        ## a sub-device
+        ("subdeviceId", c_ulong),                                       ## [out] If onSubdevice is true, this gives the ID of the sub-device
+        ("engines", zes_engine_type_flags_t)                            ## [out] Bitfield of accelerator engine types that are affected by this
+                                                                        ## Performance Factor.
+    ]
+
+###############################################################################
+## @brief Power Domain
+class zes_power_domain_v(IntEnum):
+    UNKNOWN = 0                                                             ## The PUnit power domain level cannot be determined.
+    CARD = 1                                                                ## The PUnit power domain is a card-level power domain.
+    PACKAGE = 2                                                             ## The PUnit power domain is a package-level power domain.
+    STACK = 3                                                               ## The PUnit power domain is a stack-level power domain.
+    MEMORY = 4                                                              ## The PUnit power domain is a memory-level power domain.
+    GPU = 5                                                                 ## The PUnit power domain is a GPU-level power domain.
+
+class zes_power_domain_t(c_int):
+    def __str__(self):
+        return str(zes_power_domain_v(self.value))
+
+
+###############################################################################
+## @brief Power Level Type
+class zes_power_level_v(IntEnum):
+    UNKNOWN = 0                                                             ## The PUnit power monitoring duration cannot be determined.
+    SUSTAINED = 1                                                           ## The PUnit determines effective power draw by computing a moving
+                                                                            ## average of the actual power draw over a time interval (longer than
+                                                                            ## BURST).
+    BURST = 2                                                               ## The PUnit determines effective power draw by computing a moving
+                                                                            ## average of the actual power draw over a time interval (longer than
+                                                                            ## PEAK).
+    PEAK = 3                                                                ## The PUnit determines effective power draw by computing a moving
+                                                                            ## average of the actual power draw over a very short time interval.
+    INSTANTANEOUS = 4                                                       ## The PUnit predicts effective power draw using the current device
+                                                                            ## configuration (frequency, voltage, etc...) & throttles proactively to
+                                                                            ## stay within the specified limit.
+
+class zes_power_level_t(c_int):
+    def __str__(self):
+        return str(zes_power_level_v(self.value))
+
+
+###############################################################################
+## @brief Power Source Type
+class zes_power_source_v(IntEnum):
+    ANY = 0                                                                 ## Limit active no matter whether the power source is mains powered or
+                                                                            ## battery powered.
+    MAINS = 1                                                               ## Limit active only when the device is mains powered.
+    BATTERY = 2                                                             ## Limit active only when the device is battery powered.
+
+class zes_power_source_t(c_int):
+    def __str__(self):
+        return str(zes_power_source_v(self.value))
+
+
+###############################################################################
+## @brief Limit Unit
+class zes_limit_unit_v(IntEnum):
+    UNKNOWN = 0                                                             ## The PUnit power monitoring unit cannot be determined.
+    CURRENT = 1                                                             ## The limit is specified in milliamperes of current drawn.
+    POWER = 2                                                               ## The limit is specified in milliwatts of power generated.
+
+class zes_limit_unit_t(c_int):
+    def __str__(self):
+        return str(zes_limit_unit_v(self.value))
+
+
+###############################################################################
+## @brief Properties related to device power settings
+class zes_power_properties_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("onSubdevice", ze_bool_t),                                     ## [out] True if this resource is located on a sub-device; false means
+                                                                        ## that the resource is on the device of the calling Sysman handle
+        ("subdeviceId", c_ulong),                                       ## [out] If onSubdevice is true, this gives the ID of the sub-device
+        ("canControl", ze_bool_t),                                      ## [out] Software can change the power limits of this domain assuming the
+                                                                        ## user has permissions.
+        ("isEnergyThresholdSupported", ze_bool_t),                      ## [out] Indicates if this power domain supports the energy threshold
+                                                                        ## event (::ZES_EVENT_TYPE_FLAG_ENERGY_THRESHOLD_CROSSED).
+        ("defaultLimit", c_int32_t),                                    ## [out] (Deprecated) The factory default TDP power limit of the part in
+                                                                        ## milliwatts. A value of -1 means that this is not known.
+        ("minLimit", c_int32_t),                                        ## [out] (Deprecated) The minimum power limit in milliwatts that can be
+                                                                        ## requested. A value of -1 means that this is not known.
+        ("maxLimit", c_int32_t)                                         ## [out] (Deprecated) The maximum power limit in milliwatts that can be
+                                                                        ## requested. A value of -1 means that this is not known.
+    ]
+
+###############################################################################
+## @brief Energy counter snapshot
+## 
+## @details
+##     - Average power is calculated by taking two snapshots (s1, s2) and using
+##       the equation: PowerWatts = (s2.energy - s1.energy) / (s2.timestamp -
+##       s1.timestamp)
+class zes_power_energy_counter_t(Structure):
+    _fields_ = [
+        ("energy", c_ulonglong),                                        ## [out] The monotonic energy counter in microjoules.
+        ("timestamp", c_ulonglong)                                      ## [out] Microsecond timestamp when energy was captured.
+                                                                        ## This timestamp should only be used to calculate delta time between
+                                                                        ## snapshots of this structure.
+                                                                        ## Never take the delta of this timestamp with the timestamp from a
+                                                                        ## different structure since they are not guaranteed to have the same base.
+                                                                        ## The absolute value of the timestamp is only valid during within the
+                                                                        ## application and may be different on the next execution.
+    ]
+
+###############################################################################
+## @brief Sustained power limits
+## 
+## @details
+##     - The power controller (Punit) will throttle the operating frequency if
+##       the power averaged over a window (typically seconds) exceeds this
+##       limit.
+##     - [DEPRECATED] No longer supported.
+class zes_power_sustained_limit_t(Structure):
+    _fields_ = [
+        ("enabled", ze_bool_t),                                         ## [in,out] indicates if the limit is enabled (true) or ignored (false)
+        ("power", c_int32_t),                                           ## [in,out] power limit in milliwatts
+        ("interval", c_int32_t)                                         ## [in,out] power averaging window (Tau) in milliseconds
+    ]
+
+###############################################################################
+## @brief Burst power limit
+## 
+## @details
+##     - The power controller (Punit) will throttle the operating frequency of
+##       the device if the power averaged over a few milliseconds exceeds a
+##       limit known as PL2. Typically PL2 > PL1 so that it permits the
+##       frequency to burst higher for short periods than would be otherwise
+##       permitted by PL1.
+##     - [DEPRECATED] No longer supported.
+class zes_power_burst_limit_t(Structure):
+    _fields_ = [
+        ("enabled", ze_bool_t),                                         ## [in,out] indicates if the limit is enabled (true) or ignored (false)
+        ("power", c_int32_t)                                            ## [in,out] power limit in milliwatts
+    ]
+
+###############################################################################
+## @brief Peak power limit
+## 
+## @details
+##     - The power controller (Punit) will reactively/proactively throttle the
+##       operating frequency of the device when the instantaneous/100usec power
+##       exceeds this limit. The limit is known as PL4 or Psys. It expresses
+##       the maximum power that can be drawn from the power supply.
+##     - If this power limit is removed or set too high, the power supply will
+##       generate an interrupt when it detects an overcurrent condition and the
+##       power controller will throttle the device frequencies down to min. It
+##       is thus better to tune the PL4 value in order to avoid such
+##       excursions.
+##     - [DEPRECATED] No longer supported.
+class zes_power_peak_limit_t(Structure):
+    _fields_ = [
+        ("powerAC", c_int32_t),                                         ## [in,out] power limit in milliwatts for the AC power source.
+        ("powerDC", c_int32_t)                                          ## [in,out] power limit in milliwatts for the DC power source. On input,
+                                                                        ## this is ignored if the product does not have a battery. On output,
+                                                                        ## this will be -1 if the product does not have a battery.
+    ]
+
+###############################################################################
+## @brief Energy threshold
+## 
+## @details
+##     - .
+class zes_energy_threshold_t(Structure):
+    _fields_ = [
+        ("enable", ze_bool_t),                                          ## [in,out] Indicates if the energy threshold is enabled.
+        ("threshold", c_double),                                        ## [in,out] The energy threshold in Joules. Will be 0.0 if no threshold
+                                                                        ## has been set.
+        ("processId", c_ulong)                                          ## [in,out] The host process ID that set the energy threshold. Will be
+                                                                        ## 0xFFFFFFFF if no threshold has been set.
+    ]
+
+###############################################################################
+## @brief PSU voltage status
+class zes_psu_voltage_status_v(IntEnum):
+    UNKNOWN = 0                                                             ## The status of the power supply voltage controllers cannot be
+                                                                            ## determined
+    NORMAL = 1                                                              ## No unusual voltages have been detected
+    OVER = 2                                                                ## Over-voltage has occurred
+    UNDER = 3                                                               ## Under-voltage has occurred
+
+class zes_psu_voltage_status_t(c_int):
+    def __str__(self):
+        return str(zes_psu_voltage_status_v(self.value))
+
+
+###############################################################################
+## @brief Static properties of the power supply
+class zes_psu_properties_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("onSubdevice", ze_bool_t),                                     ## [out] True if the resource is located on a sub-device; false means
+                                                                        ## that the resource is on the device of the calling Sysman handle
+        ("subdeviceId", c_ulong),                                       ## [out] If onSubdevice is true, this gives the ID of the sub-device
+        ("haveFan", ze_bool_t),                                         ## [out] True if the power supply has a fan
+        ("ampLimit", c_int32_t)                                         ## [out] The maximum electrical current in milliamperes that can be
+                                                                        ## drawn. A value of -1 indicates that this property cannot be
+                                                                        ## determined.
+    ]
+
+###############################################################################
+## @brief Dynamic state of the power supply
+class zes_psu_state_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("voltStatus", zes_psu_voltage_status_t),                       ## [out] The current PSU voltage status
+        ("fanFailed", ze_bool_t),                                       ## [out] Indicates if the fan has failed
+        ("temperature", c_int32_t),                                     ## [out] Read the current heatsink temperature in degrees Celsius. A
+                                                                        ## value of -1 indicates that this property cannot be determined.
+        ("current", c_int32_t)                                          ## [out] The amps being drawn in milliamperes. A value of -1 indicates
+                                                                        ## that this property cannot be determined.
+    ]
+
+###############################################################################
+## @brief RAS error type
+class zes_ras_error_type_v(IntEnum):
+    CORRECTABLE = 0                                                         ## Errors were corrected by hardware
+    UNCORRECTABLE = 1                                                       ## Error were not corrected
+
+class zes_ras_error_type_t(c_int):
+    def __str__(self):
+        return str(zes_ras_error_type_v(self.value))
+
+
+###############################################################################
+## @brief RAS error categories
+class zes_ras_error_cat_v(IntEnum):
+    RESET = 0                                                               ## The number of accelerator engine resets attempted by the driver
+    PROGRAMMING_ERRORS = 1                                                  ## The number of hardware exceptions generated by the way workloads have
+                                                                            ## programmed the hardware
+    DRIVER_ERRORS = 2                                                       ## The number of low level driver communication errors have occurred
+    COMPUTE_ERRORS = 3                                                      ## The number of errors that have occurred in the compute accelerator
+                                                                            ## hardware
+    NON_COMPUTE_ERRORS = 4                                                  ## The number of errors that have occurred in the fixed-function
+                                                                            ## accelerator hardware
+    CACHE_ERRORS = 5                                                        ## The number of errors that have occurred in caches (L1/L3/register
+                                                                            ## file/shared local memory/sampler)
+    DISPLAY_ERRORS = 6                                                      ## The number of errors that have occurred in the display
+
+class zes_ras_error_cat_t(c_int):
+    def __str__(self):
+        return str(zes_ras_error_cat_v(self.value))
+
+
+###############################################################################
+## @brief The maximum number of categories
+ZES_MAX_RAS_ERROR_CATEGORY_COUNT = 7
+
+###############################################################################
+## @brief RAS properties
+class zes_ras_properties_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("type", zes_ras_error_type_t),                                 ## [out] The type of RAS error
+        ("onSubdevice", ze_bool_t),                                     ## [out] True if the resource is located on a sub-device; false means
+                                                                        ## that the resource is on the device of the calling Sysman handle
+        ("subdeviceId", c_ulong)                                        ## [out] If onSubdevice is true, this gives the ID of the sub-device
+    ]
+
+###############################################################################
+## @brief RAS error details
+class zes_ras_state_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("category", c_ulonglong * ZES_MAX_RAS_ERROR_CATEGORY_COUNT)    ## [in][out] Breakdown of error by category
+    ]
+
+###############################################################################
+## @brief RAS error configuration - thresholds used for triggering RAS events
+##        (::ZES_EVENT_TYPE_FLAG_RAS_CORRECTABLE_ERRORS,
+##        ::ZES_EVENT_TYPE_FLAG_RAS_UNCORRECTABLE_ERRORS)
+## 
+## @details
+##     - The driver maintains a total counter which is updated every time a
+##       hardware block covered by the corresponding RAS error set notifies
+##       that an error has occurred. When this total count goes above the
+##       totalThreshold specified below, a RAS event is triggered.
+##     - The driver also maintains a counter for each category of RAS error
+##       (see ::zes_ras_state_t for a breakdown). Each time a hardware block of
+##       that category notifies that an error has occurred, that corresponding
+##       category counter is updated. When it goes above the threshold
+##       specified in detailedThresholds, a RAS event is triggered.
+class zes_ras_config_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("totalThreshold", c_ulonglong),                                ## [in,out] If the total RAS errors exceeds this threshold, the event
+                                                                        ## will be triggered. A value of 0ULL disables triggering the event based
+                                                                        ## on the total counter.
+        ("detailedThresholds", zes_ras_state_t)                         ## [in,out] If the RAS errors for each category exceed the threshold for
+                                                                        ## that category, the event will be triggered. A value of 0ULL will
+                                                                        ## disable an event being triggered for that category.
+    ]
+
+###############################################################################
+## @brief Scheduler mode
+class zes_sched_mode_v(IntEnum):
+    TIMEOUT = 0                                                             ## Multiple applications or contexts are submitting work to the hardware.
+                                                                            ## When higher priority work arrives, the scheduler attempts to pause the
+                                                                            ## current executing work within some timeout interval, then submits the
+                                                                            ## other work.
+    TIMESLICE = 1                                                           ## The scheduler attempts to fairly timeslice hardware execution time
+                                                                            ## between multiple contexts submitting work to the hardware
+                                                                            ## concurrently.
+    EXCLUSIVE = 2                                                           ## Any application or context can run indefinitely on the hardware
+                                                                            ## without being preempted or terminated. All pending work for other
+                                                                            ## contexts must wait until the running context completes with no further
+                                                                            ## submitted work.
+    COMPUTE_UNIT_DEBUG = 3                                                  ## [DEPRECATED] No longer supported.
+
+class zes_sched_mode_t(c_int):
+    def __str__(self):
+        return str(zes_sched_mode_v(self.value))
+
+
+###############################################################################
+## @brief Properties related to scheduler component
+class zes_sched_properties_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("onSubdevice", ze_bool_t),                                     ## [out] True if this resource is located on a sub-device; false means
+                                                                        ## that the resource is on the device of the calling Sysman handle
+        ("subdeviceId", c_ulong),                                       ## [out] If onSubdevice is true, this gives the ID of the sub-device
+        ("canControl", ze_bool_t),                                      ## [out] Software can change the scheduler component configuration
+                                                                        ## assuming the user has permissions.
+        ("engines", zes_engine_type_flags_t),                           ## [out] Bitfield of accelerator engine types that are managed by this
+                                                                        ## scheduler component. Note that there can be more than one scheduler
+                                                                        ## component for the same type of accelerator engine.
+        ("supportedModes", c_ulong)                                     ## [out] Bitfield of scheduler modes that can be configured for this
+                                                                        ## scheduler component (bitfield of 1<<::zes_sched_mode_t).
+    ]
+
+###############################################################################
+## @brief Disable forward progress guard timeout.
+ZES_SCHED_WATCHDOG_DISABLE = (~(0ULL))
+
+###############################################################################
+## @brief Configuration for timeout scheduler mode (::ZES_SCHED_MODE_TIMEOUT)
+class zes_sched_timeout_properties_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("watchdogTimeout", c_ulonglong)                                ## [in,out] The maximum time in microseconds that the scheduler will wait
+                                                                        ## for a batch of work submitted to a hardware engine to complete or to
+                                                                        ## be preempted so as to run another context.
+                                                                        ## If this time is exceeded, the hardware engine is reset and the context terminated.
+                                                                        ## If set to ::ZES_SCHED_WATCHDOG_DISABLE, a running workload can run as
+                                                                        ## long as it wants without being terminated, but preemption attempts to
+                                                                        ## run other contexts are permitted but not enforced.
+    ]
+
+###############################################################################
+## @brief Configuration for timeslice scheduler mode
+##        (::ZES_SCHED_MODE_TIMESLICE)
+class zes_sched_timeslice_properties_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("interval", c_ulonglong),                                      ## [in,out] The average interval in microseconds that a submission for a
+                                                                        ## context will run on a hardware engine before being preempted out to
+                                                                        ## run a pending submission for another context.
+        ("yieldTimeout", c_ulonglong)                                   ## [in,out] The maximum time in microseconds that the scheduler will wait
+                                                                        ## to preempt a workload running on an engine before deciding to reset
+                                                                        ## the hardware engine and terminating the associated context.
+    ]
+
+###############################################################################
+## @brief Standby hardware components
+class zes_standby_type_v(IntEnum):
+    GLOBAL = 0                                                              ## Control the overall standby policy of the device/sub-device
+
+class zes_standby_type_t(c_int):
+    def __str__(self):
+        return str(zes_standby_type_v(self.value))
+
+
+###############################################################################
+## @brief Standby hardware component properties
+class zes_standby_properties_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("type", zes_standby_type_t),                                   ## [out] Which standby hardware component this controls
+        ("onSubdevice", ze_bool_t),                                     ## [out] True if the resource is located on a sub-device; false means
+                                                                        ## that the resource is on the device of the calling Sysman handle
+        ("subdeviceId", c_ulong)                                        ## [out] If onSubdevice is true, this gives the ID of the sub-device
+    ]
+
+###############################################################################
+## @brief Standby promotion modes
+class zes_standby_promo_mode_v(IntEnum):
+    DEFAULT = 0                                                             ## Best compromise between performance and energy savings.
+    NEVER = 1                                                               ## The device/component will never shutdown. This can improve performance
+                                                                            ## but uses more energy.
+
+class zes_standby_promo_mode_t(c_int):
+    def __str__(self):
+        return str(zes_standby_promo_mode_v(self.value))
+
+
+###############################################################################
+## @brief Temperature sensors
+class zes_temp_sensors_v(IntEnum):
+    GLOBAL = 0                                                              ## The maximum temperature across all device sensors
+    GPU = 1                                                                 ## The maximum temperature across all sensors in the GPU
+    MEMORY = 2                                                              ## The maximum temperature across all sensors in the local memory
+    GLOBAL_MIN = 3                                                          ## The minimum temperature across all device sensors
+    GPU_MIN = 4                                                             ## The minimum temperature across all sensors in the GPU
+    MEMORY_MIN = 5                                                          ## The minimum temperature across all sensors in the local device memory
+    GPU_BOARD = 6                                                           ## The maximum temperature across all sensors in the GPU Board
+    GPU_BOARD_MIN = 7                                                       ## The minimum temperature across all sensors in the GPU Board
+    VOLTAGE_REGULATOR = 8                                                   ## The maximum temperature across all sensors in the Voltage Regulator
+
+class zes_temp_sensors_t(c_int):
+    def __str__(self):
+        return str(zes_temp_sensors_v(self.value))
+
+
+###############################################################################
+## @brief Temperature sensor properties
+class zes_temp_properties_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("type", zes_temp_sensors_t),                                   ## [out] Which part of the device the temperature sensor measures
+        ("onSubdevice", ze_bool_t),                                     ## [out] True if the resource is located on a sub-device; false means
+                                                                        ## that the resource is on the device of the calling Sysman handle
+        ("subdeviceId", c_ulong),                                       ## [out] If onSubdevice is true, this gives the ID of the sub-device
+        ("maxTemperature", c_double),                                   ## [out] Will contain the maximum temperature for the specific device in
+                                                                        ## degrees Celsius.
+        ("isCriticalTempSupported", ze_bool_t),                         ## [out] Indicates if the critical temperature event
+                                                                        ## ::ZES_EVENT_TYPE_FLAG_TEMP_CRITICAL is supported
+        ("isThreshold1Supported", ze_bool_t),                           ## [out] Indicates if the temperature threshold 1 event
+                                                                        ## ::ZES_EVENT_TYPE_FLAG_TEMP_THRESHOLD1 is supported
+        ("isThreshold2Supported", ze_bool_t)                            ## [out] Indicates if the temperature threshold 2 event
+                                                                        ## ::ZES_EVENT_TYPE_FLAG_TEMP_THRESHOLD2 is supported
+    ]
+
+###############################################################################
+## @brief Temperature sensor threshold
+class zes_temp_threshold_t(Structure):
+    _fields_ = [
+        ("enableLowToHigh", ze_bool_t),                                 ## [in,out] Trigger an event when the temperature crosses from below the
+                                                                        ## threshold to above.
+        ("enableHighToLow", ze_bool_t),                                 ## [in,out] Trigger an event when the temperature crosses from above the
+                                                                        ## threshold to below.
+        ("threshold", c_double)                                         ## [in,out] The threshold in degrees Celsius.
+    ]
+
+###############################################################################
+## @brief Temperature configuration - which events should be triggered and the
+##        trigger conditions.
+class zes_temp_config_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("enableCritical", ze_bool_t),                                  ## [in,out] Indicates if event ::ZES_EVENT_TYPE_FLAG_TEMP_CRITICAL should
+                                                                        ## be triggered by the driver.
+        ("threshold1", zes_temp_threshold_t),                           ## [in,out] Configuration controlling if and when event
+                                                                        ## ::ZES_EVENT_TYPE_FLAG_TEMP_THRESHOLD1 should be triggered by the
+                                                                        ## driver.
+        ("threshold2", zes_temp_threshold_t)                            ## [in,out] Configuration controlling if and when event
+                                                                        ## ::ZES_EVENT_TYPE_FLAG_TEMP_THRESHOLD2 should be triggered by the
+                                                                        ## driver.
+    ]
+
+###############################################################################
+## @brief Power Limits Extension Name
+ZES_POWER_LIMITS_EXT_NAME = "ZES_extension_power_limits"
+
+###############################################################################
+## @brief Power Limits Extension Version(s)
+class zes_power_limits_ext_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class zes_power_limits_ext_version_t(c_int):
+    def __str__(self):
+        return str(zes_power_limits_ext_version_v(self.value))
+
+
+###############################################################################
+## @brief Device power/current limit descriptor.
+class zes_power_limit_ext_desc_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("level", zes_power_level_t),                                   ## [in,out] duration type over which the power draw is measured, i.e.
+                                                                        ## sustained, burst, peak, or critical.
+        ("source", zes_power_source_t),                                 ## [out] source of power used by the system, i.e. AC or DC.
+        ("limitUnit", zes_limit_unit_t),                                ## [out] unit used for specifying limit, i.e. current units (milliamps)
+                                                                        ## or power units (milliwatts).
+        ("enabledStateLocked", ze_bool_t),                              ## [out] indicates if the power limit state (enabled/ignored) can be set
+                                                                        ## (false) or is locked (true).
+        ("enabled", ze_bool_t),                                         ## [in,out] indicates if the limit is enabled (true) or ignored (false).
+                                                                        ## If enabledStateIsLocked is True, this value is ignored.
+        ("intervalValueLocked", ze_bool_t),                             ## [out] indicates if the interval can be modified (false) or is fixed
+                                                                        ## (true).
+        ("interval", c_int32_t),                                        ## [in,out] power averaging window in milliseconds. If
+                                                                        ## intervalValueLocked is true, this value is ignored.
+        ("limitValueLocked", ze_bool_t),                                ## [out] indicates if the limit can be set (false) or if the limit is
+                                                                        ## fixed (true).
+        ("limit", c_int32_t)                                            ## [in,out] limit value. If limitValueLocked is true, this value is
+                                                                        ## ignored. The value should be provided in the unit specified by
+                                                                        ## limitUnit.
+    ]
+
+###############################################################################
+## @brief Extension properties related to device power settings
+## 
+## @details
+##     - This structure may be returned from ::zesPowerGetProperties via the
+##       `pNext` member of ::zes_power_properties_t.
+##     - This structure may also be returned from ::zesPowerGetProperties via
+##       the `pNext` member of ::zes_power_ext_properties_t
+##     - Used for determining the power domain level, i.e. card-level v/s
+##       package-level v/s stack-level & the factory default power limits.
+class zes_power_ext_properties_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("domain", zes_power_domain_t),                                 ## [out] domain that the power limit belongs to.
+        ("defaultLimit", POINTER(zes_power_limit_ext_desc_t))           ## [out] the factory default limit of the part.
+    ]
+
+###############################################################################
+## @brief Engine Activity Extension Name
+ZES_ENGINE_ACTIVITY_EXT_NAME = "ZES_extension_engine_activity"
+
+###############################################################################
+## @brief Engine Activity Extension Version(s)
+class zes_engine_activity_ext_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class zes_engine_activity_ext_version_t(c_int):
+    def __str__(self):
+        return str(zes_engine_activity_ext_version_v(self.value))
+
+
+###############################################################################
+## @brief Extension properties related to Engine Groups
+## 
+## @details
+##     - This structure may be passed to ::zesEngineGetProperties by having the
+##       pNext member of ::zes_engine_properties_t point at this struct.
+##     - Used for SRIOV per Virtual Function device utilization by
+##       ::zes_engine_group_t
+class zes_engine_ext_properties_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("countOfVirtualFunctionInstance", c_ulong)                     ## [out] Number of Virtual Function(VF) instances associated with engine
+                                                                        ## to monitor the utilization of hardware across all Virtual Function
+                                                                        ## from a Physical Function (PF) instance.
+                                                                        ## These VF-by-VF views should provide engine group and individual engine
+                                                                        ## level granularity.
+                                                                        ## This count represents the number of VF instances that are actively
+                                                                        ## using the resource represented by the engine handle.
+    ]
+
+###############################################################################
+## @brief RAS Get State Extension Name
+ZES_RAS_GET_STATE_EXP_NAME = "ZES_extension_ras_state"
+
+###############################################################################
+## @brief RAS Get State Extension Version(s)
+class zes_ras_state_exp_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class zes_ras_state_exp_version_t(c_int):
+    def __str__(self):
+        return str(zes_ras_state_exp_version_v(self.value))
+
+
+###############################################################################
+## @brief RAS error categories
+class zes_ras_error_category_exp_v(IntEnum):
+    RESET = 0                                                               ## The number of accelerator engine resets attempted by the driver
+    PROGRAMMING_ERRORS = 1                                                  ## The number of hardware exceptions generated by the way workloads have
+                                                                            ## programmed the hardware
+    DRIVER_ERRORS = 2                                                       ## The number of low level driver communication errors have occurred
+    COMPUTE_ERRORS = 3                                                      ## The number of errors that have occurred in the compute accelerator
+                                                                            ## hardware
+    NON_COMPUTE_ERRORS = 4                                                  ## The number of errors that have occurred in the fixed-function
+                                                                            ## accelerator hardware
+    CACHE_ERRORS = 5                                                        ## The number of errors that have occurred in caches (L1/L3/register
+                                                                            ## file/shared local memory/sampler)
+    DISPLAY_ERRORS = 6                                                      ## The number of errors that have occurred in the display
+    MEMORY_ERRORS = 7                                                       ## The number of errors that have occurred in Memory
+    SCALE_ERRORS = 8                                                        ## The number of errors that have occurred in Scale Fabric
+    L3FABRIC_ERRORS = 9                                                     ## The number of errors that have occurred in L3 Fabric
+
+class zes_ras_error_category_exp_t(c_int):
+    def __str__(self):
+        return str(zes_ras_error_category_exp_v(self.value))
+
+
+###############################################################################
+## @brief Extension structure for providing RAS error counters for different
+##        error sets
+class zes_ras_state_exp_t(Structure):
+    _fields_ = [
+        ("category", zes_ras_error_category_exp_t),                     ## [out] category for which error counter is provided.
+        ("errorCounter", c_ulonglong)                                   ## [out] Current value of RAS counter for specific error category.
+    ]
+
+###############################################################################
+## @brief Memory State Extension Name
+ZES_MEM_PAGE_OFFLINE_STATE_EXP_NAME = "ZES_extension_mem_state"
+
+###############################################################################
+## @brief Memory State Extension Version(s)
+class zes_mem_page_offline_state_exp_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class zes_mem_page_offline_state_exp_version_t(c_int):
+    def __str__(self):
+        return str(zes_mem_page_offline_state_exp_version_v(self.value))
+
+
+###############################################################################
+## @brief Extension properties for Memory State
+## 
+## @details
+##     - This structure may be returned from ::zesMemoryGetState via the
+##       `pNext` member of ::zes_mem_state_t
+##     - These additional parameters get Memory Page Offline Metrics
+class zes_mem_page_offline_state_exp_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("memoryPageOffline", c_ulong),                                 ## [out] Returns the number of Memory Pages Offline
+        ("maxMemoryPageOffline", c_ulong)                               ## [out] Returns the Allowed Memory Pages Offline
+    ]
+
+###############################################################################
+## @brief Memory Bandwidth Counter Valid Bits Extension Name
+ZES_MEMORY_BANDWIDTH_COUNTER_BITS_EXP_PROPERTIES_NAME = "ZES_extension_mem_bandwidth_counter_bits_properties"
+
+###############################################################################
+## @brief Memory Bandwidth Counter Valid Bits Extension Version(s)
+class zes_mem_bandwidth_counter_bits_exp_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class zes_mem_bandwidth_counter_bits_exp_version_t(c_int):
+    def __str__(self):
+        return str(zes_mem_bandwidth_counter_bits_exp_version_v(self.value))
+
+
+###############################################################################
+## @brief Extension properties for reporting valid bit count for memory
+##        bandwidth counter value
+## 
+## @details
+##     - Number of valid read and write counter bits of memory bandwidth
+##     - This structure may be returned from ::zesMemoryGetProperties via the
+##       `pNext` member of ::zes_mem_properties_t.
+##     - Used for denoting number of valid bits in the counter value returned
+##       in ::zes_mem_bandwidth_t.
+class zes_mem_bandwidth_counter_bits_exp_properties_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("validBitsCount", c_ulong)                                     ## [out] Returns the number of valid bits in the counter values
+    ]
+
+###############################################################################
+## @brief Power Domain Properties Name
+ZES_POWER_DOMAIN_PROPERTIES_EXP_NAME = "ZES_extension_power_domain_properties"
+
+###############################################################################
+## @brief Power Domain Properties Extension Version(s)
+class zes_power_domain_properties_exp_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class zes_power_domain_properties_exp_version_t(c_int):
+    def __str__(self):
+        return str(zes_power_domain_properties_exp_version_v(self.value))
+
+
+###############################################################################
+## @brief Extension structure for providing power domain information associated
+##        with a power handle
+## 
+## @details
+##     - This structure may be returned from ::zesPowerGetProperties via the
+##       `pNext` member of ::zes_power_properties_t.
+##     - Used for associating a power handle with a power domain.
+class zes_power_domain_exp_properties_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("powerDomain", zes_power_domain_t)                             ## [out] Power domain associated with the power handle.
+    ]
+
+###############################################################################
+## @brief Firmware security version
+ZES_FIRMWARE_SECURITY_VERSION_EXP_NAME = "ZES_experimental_firmware_security_version"
+
+###############################################################################
+## @brief Firmware security version Extension Version(s)
+class zes_firmware_security_exp_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class zes_firmware_security_exp_version_t(c_int):
+    def __str__(self):
+        return str(zes_firmware_security_exp_version_v(self.value))
+
+
+###############################################################################
+## @brief Sysman Device Mapping Extension Name
+ZES_SYSMAN_DEVICE_MAPPING_EXP_NAME = "ZES_experimental_sysman_device_mapping"
+
+###############################################################################
+## @brief Sysman Device Mapping Extension Version(s)
+class zes_sysman_device_mapping_exp_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class zes_sysman_device_mapping_exp_version_t(c_int):
+    def __str__(self):
+        return str(zes_sysman_device_mapping_exp_version_v(self.value))
+
+
+###############################################################################
+## @brief Sub Device Properties
+class zes_subdevice_exp_properties_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("subdeviceId", c_ulong),                                       ## [out] this gives the ID of the sub device
+        ("uuid", zes_uuid_t)                                            ## [out] universal unique identifier of the sub device.
+    ]
+
+###############################################################################
+## @brief Virtual Function Management Extension Name
+ZES_VIRTUAL_FUNCTION_MANAGEMENT_EXP_NAME = "ZES_experimental_virtual_function_management"
+
+###############################################################################
+## @brief Virtual Function Management Extension Version(s)
+class zes_vf_management_exp_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0 (deprecated)
+    _1_1 = ZE_MAKE_VERSION( 1, 1 )                                          ## version 1.1 (deprecated)
+    _1_2 = ZE_MAKE_VERSION( 1, 2 )                                          ## version 1.2
+    CURRENT = ZE_MAKE_VERSION( 1, 2 )                                       ## latest known version
+
+class zes_vf_management_exp_version_t(c_int):
+    def __str__(self):
+        return str(zes_vf_management_exp_version_v(self.value))
+
+
+###############################################################################
+## @brief Virtual function memory types (deprecated)
+class zes_vf_info_mem_type_exp_flags_v(IntEnum):
+    MEM_TYPE_SYSTEM = ZE_BIT(0)                                             ## System memory
+    MEM_TYPE_DEVICE = ZE_BIT(1)                                             ## Device local memory
+
+class zes_vf_info_mem_type_exp_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Virtual function utilization flag bit fields (deprecated)
+class zes_vf_info_util_exp_flags_v(IntEnum):
+    INFO_NONE = ZE_BIT(0)                                                   ## No info associated with virtual function
+    INFO_MEM_CPU = ZE_BIT(1)                                                ## System memory utilization associated with virtual function
+    INFO_MEM_GPU = ZE_BIT(2)                                                ## Device memory utilization associated with virtual function
+    INFO_ENGINE = ZE_BIT(3)                                                 ## Engine utilization associated with virtual function
+
+class zes_vf_info_util_exp_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Virtual function management properties (deprecated)
+class zes_vf_exp_properties_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("address", zes_pci_address_t),                                 ## [out] Virtual function BDF address
+        ("uuid", zes_uuid_t),                                           ## [out] universal unique identifier of the device
+        ("flags", zes_vf_info_util_exp_flags_t)                         ## [out] utilization flags available. May be 0 or a valid combination of
+                                                                        ## ::zes_vf_info_util_exp_flag_t.
+    ]
+
+###############################################################################
+## @brief Provides memory utilization values for a virtual function (deprecated)
+class zes_vf_util_mem_exp_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("memTypeFlags", zes_vf_info_mem_type_exp_flags_t),             ## [out] Memory type flags.
+        ("free", c_ulonglong),                                          ## [out] Free memory size in bytes.
+        ("size", c_ulonglong),                                          ## [out] Total allocatable memory in bytes.
+        ("timestamp", c_ulonglong)                                      ## [out] Wall clock time from VF when value was sampled.
+    ]
+
+###############################################################################
+## @brief Provides engine utilization values for a virtual function (deprecated)
+class zes_vf_util_engine_exp_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("type", zes_engine_group_t),                                   ## [out] The engine group.
+        ("activeCounterValue", c_ulonglong),                            ## [out] Represents active counter.
+        ("samplingCounterValue", c_ulonglong),                          ## [out] Represents counter value when activeCounterValue was sampled.
+        ("timestamp", c_ulonglong)                                      ## [out] Wall clock time when the activeCounterValue was sampled.
+    ]
+
+###############################################################################
+## @brief Virtual function management capabilities (deprecated)
+class zes_vf_exp_capabilities_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("address", zes_pci_address_t),                                 ## [out] Virtual function BDF address
+        ("vfDeviceMemSize", c_ulong),                                   ## [out] Virtual function memory size in kilo bytes
+        ("vfID", c_ulong)                                               ## [out] Virtual Function ID
+    ]
+
+###############################################################################
+## @brief Virtual function management capabilities
+class zes_vf_exp2_capabilities_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("address", zes_pci_address_t),                                 ## [out] Virtual function BDF address
+        ("vfDeviceMemSize", c_ulonglong),                               ## [out] Virtual function memory size in bytes
+        ("vfID", c_ulong)                                               ## [out] Virtual Function ID
+    ]
+
+###############################################################################
+## @brief Provides memory utilization values for a virtual function
+class zes_vf_util_mem_exp2_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("vfMemLocation", zes_mem_loc_t),                               ## [out] Location of this memory (system, device)
+        ("vfMemUtilized", c_ulonglong)                                  ## [out] Utilized memory size in bytes.
+    ]
+
+###############################################################################
+## @brief Provides engine utilization values for a virtual function
+## 
+## @details
+##     - Percent utilization is calculated by taking two snapshots (s1, s2) and
+##       using the equation: %util = (s2.activeCounterValue -
+##       s1.activeCounterValue) / (s2.samplingCounterValue -
+##       s1.samplingCounterValue)
+class zes_vf_util_engine_exp2_t(Structure):
+    _fields_ = [
+        ("stype", zes_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("vfEngineType", zes_engine_group_t),                           ## [out] The engine group.
+        ("activeCounterValue", c_ulonglong),                            ## [out] Represents active counter.
+        ("samplingCounterValue", c_ulonglong)                           ## [out] Represents counter value when activeCounterValue was sampled.
+                                                                        ## Refer to the formulae above for calculating the utilization percent
+    ]
+
+###############################################################################
+__use_win_types = "Windows" == platform.uname()[0]
+
+###############################################################################
+## @brief Function-pointer for zesInit
+if __use_win_types:
+    _zesInit_t = WINFUNCTYPE( ze_result_t, zes_init_flags_t )
+else:
+    _zesInit_t = CFUNCTYPE( ze_result_t, zes_init_flags_t )
+
+
+###############################################################################
+## @brief Table of Global functions pointers
+class _zes_global_dditable_t(Structure):
+    _fields_ = [
+        ("pfnInit", c_void_p)                                           ## _zesInit_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zesDeviceGetProperties
+if __use_win_types:
+    _zesDeviceGetProperties_t = WINFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(zes_device_properties_t) )
+else:
+    _zesDeviceGetProperties_t = CFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(zes_device_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zesDeviceGetState
+if __use_win_types:
+    _zesDeviceGetState_t = WINFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(zes_device_state_t) )
+else:
+    _zesDeviceGetState_t = CFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(zes_device_state_t) )
+
+###############################################################################
+## @brief Function-pointer for zesDeviceReset
+if __use_win_types:
+    _zesDeviceReset_t = WINFUNCTYPE( ze_result_t, zes_device_handle_t, ze_bool_t )
+else:
+    _zesDeviceReset_t = CFUNCTYPE( ze_result_t, zes_device_handle_t, ze_bool_t )
+
+###############################################################################
+## @brief Function-pointer for zesDeviceProcessesGetState
+if __use_win_types:
+    _zesDeviceProcessesGetState_t = WINFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(c_ulong), POINTER(zes_process_state_t) )
+else:
+    _zesDeviceProcessesGetState_t = CFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(c_ulong), POINTER(zes_process_state_t) )
+
+###############################################################################
+## @brief Function-pointer for zesDevicePciGetProperties
+if __use_win_types:
+    _zesDevicePciGetProperties_t = WINFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(zes_pci_properties_t) )
+else:
+    _zesDevicePciGetProperties_t = CFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(zes_pci_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zesDevicePciGetState
+if __use_win_types:
+    _zesDevicePciGetState_t = WINFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(zes_pci_state_t) )
+else:
+    _zesDevicePciGetState_t = CFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(zes_pci_state_t) )
+
+###############################################################################
+## @brief Function-pointer for zesDevicePciGetBars
+if __use_win_types:
+    _zesDevicePciGetBars_t = WINFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(c_ulong), POINTER(zes_pci_bar_properties_t) )
+else:
+    _zesDevicePciGetBars_t = CFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(c_ulong), POINTER(zes_pci_bar_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zesDevicePciGetStats
+if __use_win_types:
+    _zesDevicePciGetStats_t = WINFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(zes_pci_stats_t) )
+else:
+    _zesDevicePciGetStats_t = CFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(zes_pci_stats_t) )
+
+###############################################################################
+## @brief Function-pointer for zesDeviceEnumDiagnosticTestSuites
+if __use_win_types:
+    _zesDeviceEnumDiagnosticTestSuites_t = WINFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(c_ulong), POINTER(zes_diag_handle_t) )
+else:
+    _zesDeviceEnumDiagnosticTestSuites_t = CFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(c_ulong), POINTER(zes_diag_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zesDeviceEnumEngineGroups
+if __use_win_types:
+    _zesDeviceEnumEngineGroups_t = WINFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(c_ulong), POINTER(zes_engine_handle_t) )
+else:
+    _zesDeviceEnumEngineGroups_t = CFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(c_ulong), POINTER(zes_engine_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zesDeviceEventRegister
+if __use_win_types:
+    _zesDeviceEventRegister_t = WINFUNCTYPE( ze_result_t, zes_device_handle_t, zes_event_type_flags_t )
+else:
+    _zesDeviceEventRegister_t = CFUNCTYPE( ze_result_t, zes_device_handle_t, zes_event_type_flags_t )
+
+###############################################################################
+## @brief Function-pointer for zesDeviceEnumFabricPorts
+if __use_win_types:
+    _zesDeviceEnumFabricPorts_t = WINFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(c_ulong), POINTER(zes_fabric_port_handle_t) )
+else:
+    _zesDeviceEnumFabricPorts_t = CFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(c_ulong), POINTER(zes_fabric_port_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zesDeviceEnumFans
+if __use_win_types:
+    _zesDeviceEnumFans_t = WINFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(c_ulong), POINTER(zes_fan_handle_t) )
+else:
+    _zesDeviceEnumFans_t = CFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(c_ulong), POINTER(zes_fan_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zesDeviceEnumFirmwares
+if __use_win_types:
+    _zesDeviceEnumFirmwares_t = WINFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(c_ulong), POINTER(zes_firmware_handle_t) )
+else:
+    _zesDeviceEnumFirmwares_t = CFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(c_ulong), POINTER(zes_firmware_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zesDeviceEnumFrequencyDomains
+if __use_win_types:
+    _zesDeviceEnumFrequencyDomains_t = WINFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(c_ulong), POINTER(zes_freq_handle_t) )
+else:
+    _zesDeviceEnumFrequencyDomains_t = CFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(c_ulong), POINTER(zes_freq_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zesDeviceEnumLeds
+if __use_win_types:
+    _zesDeviceEnumLeds_t = WINFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(c_ulong), POINTER(zes_led_handle_t) )
+else:
+    _zesDeviceEnumLeds_t = CFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(c_ulong), POINTER(zes_led_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zesDeviceEnumMemoryModules
+if __use_win_types:
+    _zesDeviceEnumMemoryModules_t = WINFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(c_ulong), POINTER(zes_mem_handle_t) )
+else:
+    _zesDeviceEnumMemoryModules_t = CFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(c_ulong), POINTER(zes_mem_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zesDeviceEnumPerformanceFactorDomains
+if __use_win_types:
+    _zesDeviceEnumPerformanceFactorDomains_t = WINFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(c_ulong), POINTER(zes_perf_handle_t) )
+else:
+    _zesDeviceEnumPerformanceFactorDomains_t = CFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(c_ulong), POINTER(zes_perf_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zesDeviceEnumPowerDomains
+if __use_win_types:
+    _zesDeviceEnumPowerDomains_t = WINFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(c_ulong), POINTER(zes_pwr_handle_t) )
+else:
+    _zesDeviceEnumPowerDomains_t = CFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(c_ulong), POINTER(zes_pwr_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zesDeviceGetCardPowerDomain
+if __use_win_types:
+    _zesDeviceGetCardPowerDomain_t = WINFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(zes_pwr_handle_t) )
+else:
+    _zesDeviceGetCardPowerDomain_t = CFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(zes_pwr_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zesDeviceEnumPsus
+if __use_win_types:
+    _zesDeviceEnumPsus_t = WINFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(c_ulong), POINTER(zes_psu_handle_t) )
+else:
+    _zesDeviceEnumPsus_t = CFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(c_ulong), POINTER(zes_psu_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zesDeviceEnumRasErrorSets
+if __use_win_types:
+    _zesDeviceEnumRasErrorSets_t = WINFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(c_ulong), POINTER(zes_ras_handle_t) )
+else:
+    _zesDeviceEnumRasErrorSets_t = CFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(c_ulong), POINTER(zes_ras_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zesDeviceEnumSchedulers
+if __use_win_types:
+    _zesDeviceEnumSchedulers_t = WINFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(c_ulong), POINTER(zes_sched_handle_t) )
+else:
+    _zesDeviceEnumSchedulers_t = CFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(c_ulong), POINTER(zes_sched_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zesDeviceEnumStandbyDomains
+if __use_win_types:
+    _zesDeviceEnumStandbyDomains_t = WINFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(c_ulong), POINTER(zes_standby_handle_t) )
+else:
+    _zesDeviceEnumStandbyDomains_t = CFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(c_ulong), POINTER(zes_standby_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zesDeviceEnumTemperatureSensors
+if __use_win_types:
+    _zesDeviceEnumTemperatureSensors_t = WINFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(c_ulong), POINTER(zes_temp_handle_t) )
+else:
+    _zesDeviceEnumTemperatureSensors_t = CFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(c_ulong), POINTER(zes_temp_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zesDeviceEccAvailable
+if __use_win_types:
+    _zesDeviceEccAvailable_t = WINFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(ze_bool_t) )
+else:
+    _zesDeviceEccAvailable_t = CFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(ze_bool_t) )
+
+###############################################################################
+## @brief Function-pointer for zesDeviceEccConfigurable
+if __use_win_types:
+    _zesDeviceEccConfigurable_t = WINFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(ze_bool_t) )
+else:
+    _zesDeviceEccConfigurable_t = CFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(ze_bool_t) )
+
+###############################################################################
+## @brief Function-pointer for zesDeviceGetEccState
+if __use_win_types:
+    _zesDeviceGetEccState_t = WINFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(zes_device_ecc_properties_t) )
+else:
+    _zesDeviceGetEccState_t = CFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(zes_device_ecc_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zesDeviceSetEccState
+if __use_win_types:
+    _zesDeviceSetEccState_t = WINFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(zes_device_ecc_desc_t), POINTER(zes_device_ecc_properties_t) )
+else:
+    _zesDeviceSetEccState_t = CFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(zes_device_ecc_desc_t), POINTER(zes_device_ecc_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zesDeviceGet
+if __use_win_types:
+    _zesDeviceGet_t = WINFUNCTYPE( ze_result_t, zes_driver_handle_t, POINTER(c_ulong), POINTER(zes_device_handle_t) )
+else:
+    _zesDeviceGet_t = CFUNCTYPE( ze_result_t, zes_driver_handle_t, POINTER(c_ulong), POINTER(zes_device_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zesDeviceSetOverclockWaiver
+if __use_win_types:
+    _zesDeviceSetOverclockWaiver_t = WINFUNCTYPE( ze_result_t, zes_device_handle_t )
+else:
+    _zesDeviceSetOverclockWaiver_t = CFUNCTYPE( ze_result_t, zes_device_handle_t )
+
+###############################################################################
+## @brief Function-pointer for zesDeviceGetOverclockDomains
+if __use_win_types:
+    _zesDeviceGetOverclockDomains_t = WINFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(c_ulong) )
+else:
+    _zesDeviceGetOverclockDomains_t = CFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(c_ulong) )
+
+###############################################################################
+## @brief Function-pointer for zesDeviceGetOverclockControls
+if __use_win_types:
+    _zesDeviceGetOverclockControls_t = WINFUNCTYPE( ze_result_t, zes_device_handle_t, zes_overclock_domain_t, POINTER(c_ulong) )
+else:
+    _zesDeviceGetOverclockControls_t = CFUNCTYPE( ze_result_t, zes_device_handle_t, zes_overclock_domain_t, POINTER(c_ulong) )
+
+###############################################################################
+## @brief Function-pointer for zesDeviceResetOverclockSettings
+if __use_win_types:
+    _zesDeviceResetOverclockSettings_t = WINFUNCTYPE( ze_result_t, zes_device_handle_t, ze_bool_t )
+else:
+    _zesDeviceResetOverclockSettings_t = CFUNCTYPE( ze_result_t, zes_device_handle_t, ze_bool_t )
+
+###############################################################################
+## @brief Function-pointer for zesDeviceReadOverclockState
+if __use_win_types:
+    _zesDeviceReadOverclockState_t = WINFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(zes_overclock_mode_t), POINTER(ze_bool_t), POINTER(ze_bool_t), POINTER(zes_pending_action_t), POINTER(ze_bool_t) )
+else:
+    _zesDeviceReadOverclockState_t = CFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(zes_overclock_mode_t), POINTER(ze_bool_t), POINTER(ze_bool_t), POINTER(zes_pending_action_t), POINTER(ze_bool_t) )
+
+###############################################################################
+## @brief Function-pointer for zesDeviceEnumOverclockDomains
+if __use_win_types:
+    _zesDeviceEnumOverclockDomains_t = WINFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(c_ulong), POINTER(zes_overclock_handle_t) )
+else:
+    _zesDeviceEnumOverclockDomains_t = CFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(c_ulong), POINTER(zes_overclock_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zesDeviceResetExt
+if __use_win_types:
+    _zesDeviceResetExt_t = WINFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(zes_reset_properties_t) )
+else:
+    _zesDeviceResetExt_t = CFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(zes_reset_properties_t) )
+
+
+###############################################################################
+## @brief Table of Device functions pointers
+class _zes_device_dditable_t(Structure):
+    _fields_ = [
+        ("pfnGetProperties", c_void_p),                                 ## _zesDeviceGetProperties_t
+        ("pfnGetState", c_void_p),                                      ## _zesDeviceGetState_t
+        ("pfnReset", c_void_p),                                         ## _zesDeviceReset_t
+        ("pfnProcessesGetState", c_void_p),                             ## _zesDeviceProcessesGetState_t
+        ("pfnPciGetProperties", c_void_p),                              ## _zesDevicePciGetProperties_t
+        ("pfnPciGetState", c_void_p),                                   ## _zesDevicePciGetState_t
+        ("pfnPciGetBars", c_void_p),                                    ## _zesDevicePciGetBars_t
+        ("pfnPciGetStats", c_void_p),                                   ## _zesDevicePciGetStats_t
+        ("pfnEnumDiagnosticTestSuites", c_void_p),                      ## _zesDeviceEnumDiagnosticTestSuites_t
+        ("pfnEnumEngineGroups", c_void_p),                              ## _zesDeviceEnumEngineGroups_t
+        ("pfnEventRegister", c_void_p),                                 ## _zesDeviceEventRegister_t
+        ("pfnEnumFabricPorts", c_void_p),                               ## _zesDeviceEnumFabricPorts_t
+        ("pfnEnumFans", c_void_p),                                      ## _zesDeviceEnumFans_t
+        ("pfnEnumFirmwares", c_void_p),                                 ## _zesDeviceEnumFirmwares_t
+        ("pfnEnumFrequencyDomains", c_void_p),                          ## _zesDeviceEnumFrequencyDomains_t
+        ("pfnEnumLeds", c_void_p),                                      ## _zesDeviceEnumLeds_t
+        ("pfnEnumMemoryModules", c_void_p),                             ## _zesDeviceEnumMemoryModules_t
+        ("pfnEnumPerformanceFactorDomains", c_void_p),                  ## _zesDeviceEnumPerformanceFactorDomains_t
+        ("pfnEnumPowerDomains", c_void_p),                              ## _zesDeviceEnumPowerDomains_t
+        ("pfnGetCardPowerDomain", c_void_p),                            ## _zesDeviceGetCardPowerDomain_t
+        ("pfnEnumPsus", c_void_p),                                      ## _zesDeviceEnumPsus_t
+        ("pfnEnumRasErrorSets", c_void_p),                              ## _zesDeviceEnumRasErrorSets_t
+        ("pfnEnumSchedulers", c_void_p),                                ## _zesDeviceEnumSchedulers_t
+        ("pfnEnumStandbyDomains", c_void_p),                            ## _zesDeviceEnumStandbyDomains_t
+        ("pfnEnumTemperatureSensors", c_void_p),                        ## _zesDeviceEnumTemperatureSensors_t
+        ("pfnEccAvailable", c_void_p),                                  ## _zesDeviceEccAvailable_t
+        ("pfnEccConfigurable", c_void_p),                               ## _zesDeviceEccConfigurable_t
+        ("pfnGetEccState", c_void_p),                                   ## _zesDeviceGetEccState_t
+        ("pfnSetEccState", c_void_p),                                   ## _zesDeviceSetEccState_t
+        ("pfnGet", c_void_p),                                           ## _zesDeviceGet_t
+        ("pfnSetOverclockWaiver", c_void_p),                            ## _zesDeviceSetOverclockWaiver_t
+        ("pfnGetOverclockDomains", c_void_p),                           ## _zesDeviceGetOverclockDomains_t
+        ("pfnGetOverclockControls", c_void_p),                          ## _zesDeviceGetOverclockControls_t
+        ("pfnResetOverclockSettings", c_void_p),                        ## _zesDeviceResetOverclockSettings_t
+        ("pfnReadOverclockState", c_void_p),                            ## _zesDeviceReadOverclockState_t
+        ("pfnEnumOverclockDomains", c_void_p),                          ## _zesDeviceEnumOverclockDomains_t
+        ("pfnResetExt", c_void_p)                                       ## _zesDeviceResetExt_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zesDeviceGetSubDevicePropertiesExp
+if __use_win_types:
+    _zesDeviceGetSubDevicePropertiesExp_t = WINFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(c_ulong), POINTER(zes_subdevice_exp_properties_t) )
+else:
+    _zesDeviceGetSubDevicePropertiesExp_t = CFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(c_ulong), POINTER(zes_subdevice_exp_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zesDeviceEnumActiveVFExp
+if __use_win_types:
+    _zesDeviceEnumActiveVFExp_t = WINFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(c_ulong), POINTER(zes_vf_handle_t) )
+else:
+    _zesDeviceEnumActiveVFExp_t = CFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(c_ulong), POINTER(zes_vf_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zesDeviceEnumEnabledVFExp
+if __use_win_types:
+    _zesDeviceEnumEnabledVFExp_t = WINFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(c_ulong), POINTER(zes_vf_handle_t) )
+else:
+    _zesDeviceEnumEnabledVFExp_t = CFUNCTYPE( ze_result_t, zes_device_handle_t, POINTER(c_ulong), POINTER(zes_vf_handle_t) )
+
+
+###############################################################################
+## @brief Table of DeviceExp functions pointers
+class _zes_device_exp_dditable_t(Structure):
+    _fields_ = [
+        ("pfnGetSubDevicePropertiesExp", c_void_p),                     ## _zesDeviceGetSubDevicePropertiesExp_t
+        ("pfnEnumActiveVFExp", c_void_p),                               ## _zesDeviceEnumActiveVFExp_t
+        ("pfnEnumEnabledVFExp", c_void_p)                               ## _zesDeviceEnumEnabledVFExp_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zesDriverEventListen
+if __use_win_types:
+    _zesDriverEventListen_t = WINFUNCTYPE( ze_result_t, ze_driver_handle_t, c_ulong, c_ulong, POINTER(zes_device_handle_t), POINTER(c_ulong), POINTER(zes_event_type_flags_t) )
+else:
+    _zesDriverEventListen_t = CFUNCTYPE( ze_result_t, ze_driver_handle_t, c_ulong, c_ulong, POINTER(zes_device_handle_t), POINTER(c_ulong), POINTER(zes_event_type_flags_t) )
+
+###############################################################################
+## @brief Function-pointer for zesDriverEventListenEx
+if __use_win_types:
+    _zesDriverEventListenEx_t = WINFUNCTYPE( ze_result_t, ze_driver_handle_t, c_ulonglong, c_ulong, POINTER(zes_device_handle_t), POINTER(c_ulong), POINTER(zes_event_type_flags_t) )
+else:
+    _zesDriverEventListenEx_t = CFUNCTYPE( ze_result_t, ze_driver_handle_t, c_ulonglong, c_ulong, POINTER(zes_device_handle_t), POINTER(c_ulong), POINTER(zes_event_type_flags_t) )
+
+###############################################################################
+## @brief Function-pointer for zesDriverGet
+if __use_win_types:
+    _zesDriverGet_t = WINFUNCTYPE( ze_result_t, POINTER(c_ulong), POINTER(zes_driver_handle_t) )
+else:
+    _zesDriverGet_t = CFUNCTYPE( ze_result_t, POINTER(c_ulong), POINTER(zes_driver_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zesDriverGetExtensionProperties
+if __use_win_types:
+    _zesDriverGetExtensionProperties_t = WINFUNCTYPE( ze_result_t, zes_driver_handle_t, POINTER(c_ulong), POINTER(zes_driver_extension_properties_t) )
+else:
+    _zesDriverGetExtensionProperties_t = CFUNCTYPE( ze_result_t, zes_driver_handle_t, POINTER(c_ulong), POINTER(zes_driver_extension_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zesDriverGetExtensionFunctionAddress
+if __use_win_types:
+    _zesDriverGetExtensionFunctionAddress_t = WINFUNCTYPE( ze_result_t, zes_driver_handle_t, c_char_p, POINTER(c_void_p) )
+else:
+    _zesDriverGetExtensionFunctionAddress_t = CFUNCTYPE( ze_result_t, zes_driver_handle_t, c_char_p, POINTER(c_void_p) )
+
+
+###############################################################################
+## @brief Table of Driver functions pointers
+class _zes_driver_dditable_t(Structure):
+    _fields_ = [
+        ("pfnEventListen", c_void_p),                                   ## _zesDriverEventListen_t
+        ("pfnEventListenEx", c_void_p),                                 ## _zesDriverEventListenEx_t
+        ("pfnGet", c_void_p),                                           ## _zesDriverGet_t
+        ("pfnGetExtensionProperties", c_void_p),                        ## _zesDriverGetExtensionProperties_t
+        ("pfnGetExtensionFunctionAddress", c_void_p)                    ## _zesDriverGetExtensionFunctionAddress_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zesDriverGetDeviceByUuidExp
+if __use_win_types:
+    _zesDriverGetDeviceByUuidExp_t = WINFUNCTYPE( ze_result_t, zes_driver_handle_t, zes_uuid_t, POINTER(zes_device_handle_t), POINTER(ze_bool_t), POINTER(c_ulong) )
+else:
+    _zesDriverGetDeviceByUuidExp_t = CFUNCTYPE( ze_result_t, zes_driver_handle_t, zes_uuid_t, POINTER(zes_device_handle_t), POINTER(ze_bool_t), POINTER(c_ulong) )
+
+
+###############################################################################
+## @brief Table of DriverExp functions pointers
+class _zes_driver_exp_dditable_t(Structure):
+    _fields_ = [
+        ("pfnGetDeviceByUuidExp", c_void_p)                             ## _zesDriverGetDeviceByUuidExp_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zesOverclockGetDomainProperties
+if __use_win_types:
+    _zesOverclockGetDomainProperties_t = WINFUNCTYPE( ze_result_t, zes_overclock_handle_t, POINTER(zes_overclock_properties_t) )
+else:
+    _zesOverclockGetDomainProperties_t = CFUNCTYPE( ze_result_t, zes_overclock_handle_t, POINTER(zes_overclock_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zesOverclockGetDomainVFProperties
+if __use_win_types:
+    _zesOverclockGetDomainVFProperties_t = WINFUNCTYPE( ze_result_t, zes_overclock_handle_t, POINTER(zes_vf_property_t) )
+else:
+    _zesOverclockGetDomainVFProperties_t = CFUNCTYPE( ze_result_t, zes_overclock_handle_t, POINTER(zes_vf_property_t) )
+
+###############################################################################
+## @brief Function-pointer for zesOverclockGetDomainControlProperties
+if __use_win_types:
+    _zesOverclockGetDomainControlProperties_t = WINFUNCTYPE( ze_result_t, zes_overclock_handle_t, zes_overclock_control_t, POINTER(zes_control_property_t) )
+else:
+    _zesOverclockGetDomainControlProperties_t = CFUNCTYPE( ze_result_t, zes_overclock_handle_t, zes_overclock_control_t, POINTER(zes_control_property_t) )
+
+###############################################################################
+## @brief Function-pointer for zesOverclockGetControlCurrentValue
+if __use_win_types:
+    _zesOverclockGetControlCurrentValue_t = WINFUNCTYPE( ze_result_t, zes_overclock_handle_t, zes_overclock_control_t, POINTER(c_double) )
+else:
+    _zesOverclockGetControlCurrentValue_t = CFUNCTYPE( ze_result_t, zes_overclock_handle_t, zes_overclock_control_t, POINTER(c_double) )
+
+###############################################################################
+## @brief Function-pointer for zesOverclockGetControlPendingValue
+if __use_win_types:
+    _zesOverclockGetControlPendingValue_t = WINFUNCTYPE( ze_result_t, zes_overclock_handle_t, zes_overclock_control_t, POINTER(c_double) )
+else:
+    _zesOverclockGetControlPendingValue_t = CFUNCTYPE( ze_result_t, zes_overclock_handle_t, zes_overclock_control_t, POINTER(c_double) )
+
+###############################################################################
+## @brief Function-pointer for zesOverclockSetControlUserValue
+if __use_win_types:
+    _zesOverclockSetControlUserValue_t = WINFUNCTYPE( ze_result_t, zes_overclock_handle_t, zes_overclock_control_t, c_double, POINTER(zes_pending_action_t) )
+else:
+    _zesOverclockSetControlUserValue_t = CFUNCTYPE( ze_result_t, zes_overclock_handle_t, zes_overclock_control_t, c_double, POINTER(zes_pending_action_t) )
+
+###############################################################################
+## @brief Function-pointer for zesOverclockGetControlState
+if __use_win_types:
+    _zesOverclockGetControlState_t = WINFUNCTYPE( ze_result_t, zes_overclock_handle_t, zes_overclock_control_t, POINTER(zes_control_state_t), POINTER(zes_pending_action_t) )
+else:
+    _zesOverclockGetControlState_t = CFUNCTYPE( ze_result_t, zes_overclock_handle_t, zes_overclock_control_t, POINTER(zes_control_state_t), POINTER(zes_pending_action_t) )
+
+###############################################################################
+## @brief Function-pointer for zesOverclockGetVFPointValues
+if __use_win_types:
+    _zesOverclockGetVFPointValues_t = WINFUNCTYPE( ze_result_t, zes_overclock_handle_t, zes_vf_type_t, zes_vf_array_type_t, c_ulong, POINTER(c_ulong) )
+else:
+    _zesOverclockGetVFPointValues_t = CFUNCTYPE( ze_result_t, zes_overclock_handle_t, zes_vf_type_t, zes_vf_array_type_t, c_ulong, POINTER(c_ulong) )
+
+###############################################################################
+## @brief Function-pointer for zesOverclockSetVFPointValues
+if __use_win_types:
+    _zesOverclockSetVFPointValues_t = WINFUNCTYPE( ze_result_t, zes_overclock_handle_t, zes_vf_type_t, c_ulong, c_ulong )
+else:
+    _zesOverclockSetVFPointValues_t = CFUNCTYPE( ze_result_t, zes_overclock_handle_t, zes_vf_type_t, c_ulong, c_ulong )
+
+
+###############################################################################
+## @brief Table of Overclock functions pointers
+class _zes_overclock_dditable_t(Structure):
+    _fields_ = [
+        ("pfnGetDomainProperties", c_void_p),                           ## _zesOverclockGetDomainProperties_t
+        ("pfnGetDomainVFProperties", c_void_p),                         ## _zesOverclockGetDomainVFProperties_t
+        ("pfnGetDomainControlProperties", c_void_p),                    ## _zesOverclockGetDomainControlProperties_t
+        ("pfnGetControlCurrentValue", c_void_p),                        ## _zesOverclockGetControlCurrentValue_t
+        ("pfnGetControlPendingValue", c_void_p),                        ## _zesOverclockGetControlPendingValue_t
+        ("pfnSetControlUserValue", c_void_p),                           ## _zesOverclockSetControlUserValue_t
+        ("pfnGetControlState", c_void_p),                               ## _zesOverclockGetControlState_t
+        ("pfnGetVFPointValues", c_void_p),                              ## _zesOverclockGetVFPointValues_t
+        ("pfnSetVFPointValues", c_void_p)                               ## _zesOverclockSetVFPointValues_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zesSchedulerGetProperties
+if __use_win_types:
+    _zesSchedulerGetProperties_t = WINFUNCTYPE( ze_result_t, zes_sched_handle_t, POINTER(zes_sched_properties_t) )
+else:
+    _zesSchedulerGetProperties_t = CFUNCTYPE( ze_result_t, zes_sched_handle_t, POINTER(zes_sched_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zesSchedulerGetCurrentMode
+if __use_win_types:
+    _zesSchedulerGetCurrentMode_t = WINFUNCTYPE( ze_result_t, zes_sched_handle_t, POINTER(zes_sched_mode_t) )
+else:
+    _zesSchedulerGetCurrentMode_t = CFUNCTYPE( ze_result_t, zes_sched_handle_t, POINTER(zes_sched_mode_t) )
+
+###############################################################################
+## @brief Function-pointer for zesSchedulerGetTimeoutModeProperties
+if __use_win_types:
+    _zesSchedulerGetTimeoutModeProperties_t = WINFUNCTYPE( ze_result_t, zes_sched_handle_t, ze_bool_t, POINTER(zes_sched_timeout_properties_t) )
+else:
+    _zesSchedulerGetTimeoutModeProperties_t = CFUNCTYPE( ze_result_t, zes_sched_handle_t, ze_bool_t, POINTER(zes_sched_timeout_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zesSchedulerGetTimesliceModeProperties
+if __use_win_types:
+    _zesSchedulerGetTimesliceModeProperties_t = WINFUNCTYPE( ze_result_t, zes_sched_handle_t, ze_bool_t, POINTER(zes_sched_timeslice_properties_t) )
+else:
+    _zesSchedulerGetTimesliceModeProperties_t = CFUNCTYPE( ze_result_t, zes_sched_handle_t, ze_bool_t, POINTER(zes_sched_timeslice_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zesSchedulerSetTimeoutMode
+if __use_win_types:
+    _zesSchedulerSetTimeoutMode_t = WINFUNCTYPE( ze_result_t, zes_sched_handle_t, POINTER(zes_sched_timeout_properties_t), POINTER(ze_bool_t) )
+else:
+    _zesSchedulerSetTimeoutMode_t = CFUNCTYPE( ze_result_t, zes_sched_handle_t, POINTER(zes_sched_timeout_properties_t), POINTER(ze_bool_t) )
+
+###############################################################################
+## @brief Function-pointer for zesSchedulerSetTimesliceMode
+if __use_win_types:
+    _zesSchedulerSetTimesliceMode_t = WINFUNCTYPE( ze_result_t, zes_sched_handle_t, POINTER(zes_sched_timeslice_properties_t), POINTER(ze_bool_t) )
+else:
+    _zesSchedulerSetTimesliceMode_t = CFUNCTYPE( ze_result_t, zes_sched_handle_t, POINTER(zes_sched_timeslice_properties_t), POINTER(ze_bool_t) )
+
+###############################################################################
+## @brief Function-pointer for zesSchedulerSetExclusiveMode
+if __use_win_types:
+    _zesSchedulerSetExclusiveMode_t = WINFUNCTYPE( ze_result_t, zes_sched_handle_t, POINTER(ze_bool_t) )
+else:
+    _zesSchedulerSetExclusiveMode_t = CFUNCTYPE( ze_result_t, zes_sched_handle_t, POINTER(ze_bool_t) )
+
+###############################################################################
+## @brief Function-pointer for zesSchedulerSetComputeUnitDebugMode
+if __use_win_types:
+    _zesSchedulerSetComputeUnitDebugMode_t = WINFUNCTYPE( ze_result_t, zes_sched_handle_t, POINTER(ze_bool_t) )
+else:
+    _zesSchedulerSetComputeUnitDebugMode_t = CFUNCTYPE( ze_result_t, zes_sched_handle_t, POINTER(ze_bool_t) )
+
+
+###############################################################################
+## @brief Table of Scheduler functions pointers
+class _zes_scheduler_dditable_t(Structure):
+    _fields_ = [
+        ("pfnGetProperties", c_void_p),                                 ## _zesSchedulerGetProperties_t
+        ("pfnGetCurrentMode", c_void_p),                                ## _zesSchedulerGetCurrentMode_t
+        ("pfnGetTimeoutModeProperties", c_void_p),                      ## _zesSchedulerGetTimeoutModeProperties_t
+        ("pfnGetTimesliceModeProperties", c_void_p),                    ## _zesSchedulerGetTimesliceModeProperties_t
+        ("pfnSetTimeoutMode", c_void_p),                                ## _zesSchedulerSetTimeoutMode_t
+        ("pfnSetTimesliceMode", c_void_p),                              ## _zesSchedulerSetTimesliceMode_t
+        ("pfnSetExclusiveMode", c_void_p),                              ## _zesSchedulerSetExclusiveMode_t
+        ("pfnSetComputeUnitDebugMode", c_void_p)                        ## _zesSchedulerSetComputeUnitDebugMode_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zesPerformanceFactorGetProperties
+if __use_win_types:
+    _zesPerformanceFactorGetProperties_t = WINFUNCTYPE( ze_result_t, zes_perf_handle_t, POINTER(zes_perf_properties_t) )
+else:
+    _zesPerformanceFactorGetProperties_t = CFUNCTYPE( ze_result_t, zes_perf_handle_t, POINTER(zes_perf_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zesPerformanceFactorGetConfig
+if __use_win_types:
+    _zesPerformanceFactorGetConfig_t = WINFUNCTYPE( ze_result_t, zes_perf_handle_t, POINTER(c_double) )
+else:
+    _zesPerformanceFactorGetConfig_t = CFUNCTYPE( ze_result_t, zes_perf_handle_t, POINTER(c_double) )
+
+###############################################################################
+## @brief Function-pointer for zesPerformanceFactorSetConfig
+if __use_win_types:
+    _zesPerformanceFactorSetConfig_t = WINFUNCTYPE( ze_result_t, zes_perf_handle_t, c_double )
+else:
+    _zesPerformanceFactorSetConfig_t = CFUNCTYPE( ze_result_t, zes_perf_handle_t, c_double )
+
+
+###############################################################################
+## @brief Table of PerformanceFactor functions pointers
+class _zes_performance_factor_dditable_t(Structure):
+    _fields_ = [
+        ("pfnGetProperties", c_void_p),                                 ## _zesPerformanceFactorGetProperties_t
+        ("pfnGetConfig", c_void_p),                                     ## _zesPerformanceFactorGetConfig_t
+        ("pfnSetConfig", c_void_p)                                      ## _zesPerformanceFactorSetConfig_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zesPowerGetProperties
+if __use_win_types:
+    _zesPowerGetProperties_t = WINFUNCTYPE( ze_result_t, zes_pwr_handle_t, POINTER(zes_power_properties_t) )
+else:
+    _zesPowerGetProperties_t = CFUNCTYPE( ze_result_t, zes_pwr_handle_t, POINTER(zes_power_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zesPowerGetEnergyCounter
+if __use_win_types:
+    _zesPowerGetEnergyCounter_t = WINFUNCTYPE( ze_result_t, zes_pwr_handle_t, POINTER(zes_power_energy_counter_t) )
+else:
+    _zesPowerGetEnergyCounter_t = CFUNCTYPE( ze_result_t, zes_pwr_handle_t, POINTER(zes_power_energy_counter_t) )
+
+###############################################################################
+## @brief Function-pointer for zesPowerGetLimits
+if __use_win_types:
+    _zesPowerGetLimits_t = WINFUNCTYPE( ze_result_t, zes_pwr_handle_t, POINTER(zes_power_sustained_limit_t), POINTER(zes_power_burst_limit_t), POINTER(zes_power_peak_limit_t) )
+else:
+    _zesPowerGetLimits_t = CFUNCTYPE( ze_result_t, zes_pwr_handle_t, POINTER(zes_power_sustained_limit_t), POINTER(zes_power_burst_limit_t), POINTER(zes_power_peak_limit_t) )
+
+###############################################################################
+## @brief Function-pointer for zesPowerSetLimits
+if __use_win_types:
+    _zesPowerSetLimits_t = WINFUNCTYPE( ze_result_t, zes_pwr_handle_t, POINTER(zes_power_sustained_limit_t), POINTER(zes_power_burst_limit_t), POINTER(zes_power_peak_limit_t) )
+else:
+    _zesPowerSetLimits_t = CFUNCTYPE( ze_result_t, zes_pwr_handle_t, POINTER(zes_power_sustained_limit_t), POINTER(zes_power_burst_limit_t), POINTER(zes_power_peak_limit_t) )
+
+###############################################################################
+## @brief Function-pointer for zesPowerGetEnergyThreshold
+if __use_win_types:
+    _zesPowerGetEnergyThreshold_t = WINFUNCTYPE( ze_result_t, zes_pwr_handle_t, POINTER(zes_energy_threshold_t) )
+else:
+    _zesPowerGetEnergyThreshold_t = CFUNCTYPE( ze_result_t, zes_pwr_handle_t, POINTER(zes_energy_threshold_t) )
+
+###############################################################################
+## @brief Function-pointer for zesPowerSetEnergyThreshold
+if __use_win_types:
+    _zesPowerSetEnergyThreshold_t = WINFUNCTYPE( ze_result_t, zes_pwr_handle_t, c_double )
+else:
+    _zesPowerSetEnergyThreshold_t = CFUNCTYPE( ze_result_t, zes_pwr_handle_t, c_double )
+
+###############################################################################
+## @brief Function-pointer for zesPowerGetLimitsExt
+if __use_win_types:
+    _zesPowerGetLimitsExt_t = WINFUNCTYPE( ze_result_t, zes_pwr_handle_t, POINTER(c_ulong), POINTER(zes_power_limit_ext_desc_t) )
+else:
+    _zesPowerGetLimitsExt_t = CFUNCTYPE( ze_result_t, zes_pwr_handle_t, POINTER(c_ulong), POINTER(zes_power_limit_ext_desc_t) )
+
+###############################################################################
+## @brief Function-pointer for zesPowerSetLimitsExt
+if __use_win_types:
+    _zesPowerSetLimitsExt_t = WINFUNCTYPE( ze_result_t, zes_pwr_handle_t, POINTER(c_ulong), POINTER(zes_power_limit_ext_desc_t) )
+else:
+    _zesPowerSetLimitsExt_t = CFUNCTYPE( ze_result_t, zes_pwr_handle_t, POINTER(c_ulong), POINTER(zes_power_limit_ext_desc_t) )
+
+
+###############################################################################
+## @brief Table of Power functions pointers
+class _zes_power_dditable_t(Structure):
+    _fields_ = [
+        ("pfnGetProperties", c_void_p),                                 ## _zesPowerGetProperties_t
+        ("pfnGetEnergyCounter", c_void_p),                              ## _zesPowerGetEnergyCounter_t
+        ("pfnGetLimits", c_void_p),                                     ## _zesPowerGetLimits_t
+        ("pfnSetLimits", c_void_p),                                     ## _zesPowerSetLimits_t
+        ("pfnGetEnergyThreshold", c_void_p),                            ## _zesPowerGetEnergyThreshold_t
+        ("pfnSetEnergyThreshold", c_void_p),                            ## _zesPowerSetEnergyThreshold_t
+        ("pfnGetLimitsExt", c_void_p),                                  ## _zesPowerGetLimitsExt_t
+        ("pfnSetLimitsExt", c_void_p)                                   ## _zesPowerSetLimitsExt_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zesFrequencyGetProperties
+if __use_win_types:
+    _zesFrequencyGetProperties_t = WINFUNCTYPE( ze_result_t, zes_freq_handle_t, POINTER(zes_freq_properties_t) )
+else:
+    _zesFrequencyGetProperties_t = CFUNCTYPE( ze_result_t, zes_freq_handle_t, POINTER(zes_freq_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zesFrequencyGetAvailableClocks
+if __use_win_types:
+    _zesFrequencyGetAvailableClocks_t = WINFUNCTYPE( ze_result_t, zes_freq_handle_t, POINTER(c_ulong), POINTER(c_double) )
+else:
+    _zesFrequencyGetAvailableClocks_t = CFUNCTYPE( ze_result_t, zes_freq_handle_t, POINTER(c_ulong), POINTER(c_double) )
+
+###############################################################################
+## @brief Function-pointer for zesFrequencyGetRange
+if __use_win_types:
+    _zesFrequencyGetRange_t = WINFUNCTYPE( ze_result_t, zes_freq_handle_t, POINTER(zes_freq_range_t) )
+else:
+    _zesFrequencyGetRange_t = CFUNCTYPE( ze_result_t, zes_freq_handle_t, POINTER(zes_freq_range_t) )
+
+###############################################################################
+## @brief Function-pointer for zesFrequencySetRange
+if __use_win_types:
+    _zesFrequencySetRange_t = WINFUNCTYPE( ze_result_t, zes_freq_handle_t, POINTER(zes_freq_range_t) )
+else:
+    _zesFrequencySetRange_t = CFUNCTYPE( ze_result_t, zes_freq_handle_t, POINTER(zes_freq_range_t) )
+
+###############################################################################
+## @brief Function-pointer for zesFrequencyGetState
+if __use_win_types:
+    _zesFrequencyGetState_t = WINFUNCTYPE( ze_result_t, zes_freq_handle_t, POINTER(zes_freq_state_t) )
+else:
+    _zesFrequencyGetState_t = CFUNCTYPE( ze_result_t, zes_freq_handle_t, POINTER(zes_freq_state_t) )
+
+###############################################################################
+## @brief Function-pointer for zesFrequencyGetThrottleTime
+if __use_win_types:
+    _zesFrequencyGetThrottleTime_t = WINFUNCTYPE( ze_result_t, zes_freq_handle_t, POINTER(zes_freq_throttle_time_t) )
+else:
+    _zesFrequencyGetThrottleTime_t = CFUNCTYPE( ze_result_t, zes_freq_handle_t, POINTER(zes_freq_throttle_time_t) )
+
+###############################################################################
+## @brief Function-pointer for zesFrequencyOcGetCapabilities
+if __use_win_types:
+    _zesFrequencyOcGetCapabilities_t = WINFUNCTYPE( ze_result_t, zes_freq_handle_t, POINTER(zes_oc_capabilities_t) )
+else:
+    _zesFrequencyOcGetCapabilities_t = CFUNCTYPE( ze_result_t, zes_freq_handle_t, POINTER(zes_oc_capabilities_t) )
+
+###############################################################################
+## @brief Function-pointer for zesFrequencyOcGetFrequencyTarget
+if __use_win_types:
+    _zesFrequencyOcGetFrequencyTarget_t = WINFUNCTYPE( ze_result_t, zes_freq_handle_t, POINTER(c_double) )
+else:
+    _zesFrequencyOcGetFrequencyTarget_t = CFUNCTYPE( ze_result_t, zes_freq_handle_t, POINTER(c_double) )
+
+###############################################################################
+## @brief Function-pointer for zesFrequencyOcSetFrequencyTarget
+if __use_win_types:
+    _zesFrequencyOcSetFrequencyTarget_t = WINFUNCTYPE( ze_result_t, zes_freq_handle_t, c_double )
+else:
+    _zesFrequencyOcSetFrequencyTarget_t = CFUNCTYPE( ze_result_t, zes_freq_handle_t, c_double )
+
+###############################################################################
+## @brief Function-pointer for zesFrequencyOcGetVoltageTarget
+if __use_win_types:
+    _zesFrequencyOcGetVoltageTarget_t = WINFUNCTYPE( ze_result_t, zes_freq_handle_t, POINTER(c_double), POINTER(c_double) )
+else:
+    _zesFrequencyOcGetVoltageTarget_t = CFUNCTYPE( ze_result_t, zes_freq_handle_t, POINTER(c_double), POINTER(c_double) )
+
+###############################################################################
+## @brief Function-pointer for zesFrequencyOcSetVoltageTarget
+if __use_win_types:
+    _zesFrequencyOcSetVoltageTarget_t = WINFUNCTYPE( ze_result_t, zes_freq_handle_t, c_double, c_double )
+else:
+    _zesFrequencyOcSetVoltageTarget_t = CFUNCTYPE( ze_result_t, zes_freq_handle_t, c_double, c_double )
+
+###############################################################################
+## @brief Function-pointer for zesFrequencyOcSetMode
+if __use_win_types:
+    _zesFrequencyOcSetMode_t = WINFUNCTYPE( ze_result_t, zes_freq_handle_t, zes_oc_mode_t )
+else:
+    _zesFrequencyOcSetMode_t = CFUNCTYPE( ze_result_t, zes_freq_handle_t, zes_oc_mode_t )
+
+###############################################################################
+## @brief Function-pointer for zesFrequencyOcGetMode
+if __use_win_types:
+    _zesFrequencyOcGetMode_t = WINFUNCTYPE( ze_result_t, zes_freq_handle_t, POINTER(zes_oc_mode_t) )
+else:
+    _zesFrequencyOcGetMode_t = CFUNCTYPE( ze_result_t, zes_freq_handle_t, POINTER(zes_oc_mode_t) )
+
+###############################################################################
+## @brief Function-pointer for zesFrequencyOcGetIccMax
+if __use_win_types:
+    _zesFrequencyOcGetIccMax_t = WINFUNCTYPE( ze_result_t, zes_freq_handle_t, POINTER(c_double) )
+else:
+    _zesFrequencyOcGetIccMax_t = CFUNCTYPE( ze_result_t, zes_freq_handle_t, POINTER(c_double) )
+
+###############################################################################
+## @brief Function-pointer for zesFrequencyOcSetIccMax
+if __use_win_types:
+    _zesFrequencyOcSetIccMax_t = WINFUNCTYPE( ze_result_t, zes_freq_handle_t, c_double )
+else:
+    _zesFrequencyOcSetIccMax_t = CFUNCTYPE( ze_result_t, zes_freq_handle_t, c_double )
+
+###############################################################################
+## @brief Function-pointer for zesFrequencyOcGetTjMax
+if __use_win_types:
+    _zesFrequencyOcGetTjMax_t = WINFUNCTYPE( ze_result_t, zes_freq_handle_t, POINTER(c_double) )
+else:
+    _zesFrequencyOcGetTjMax_t = CFUNCTYPE( ze_result_t, zes_freq_handle_t, POINTER(c_double) )
+
+###############################################################################
+## @brief Function-pointer for zesFrequencyOcSetTjMax
+if __use_win_types:
+    _zesFrequencyOcSetTjMax_t = WINFUNCTYPE( ze_result_t, zes_freq_handle_t, c_double )
+else:
+    _zesFrequencyOcSetTjMax_t = CFUNCTYPE( ze_result_t, zes_freq_handle_t, c_double )
+
+
+###############################################################################
+## @brief Table of Frequency functions pointers
+class _zes_frequency_dditable_t(Structure):
+    _fields_ = [
+        ("pfnGetProperties", c_void_p),                                 ## _zesFrequencyGetProperties_t
+        ("pfnGetAvailableClocks", c_void_p),                            ## _zesFrequencyGetAvailableClocks_t
+        ("pfnGetRange", c_void_p),                                      ## _zesFrequencyGetRange_t
+        ("pfnSetRange", c_void_p),                                      ## _zesFrequencySetRange_t
+        ("pfnGetState", c_void_p),                                      ## _zesFrequencyGetState_t
+        ("pfnGetThrottleTime", c_void_p),                               ## _zesFrequencyGetThrottleTime_t
+        ("pfnOcGetCapabilities", c_void_p),                             ## _zesFrequencyOcGetCapabilities_t
+        ("pfnOcGetFrequencyTarget", c_void_p),                          ## _zesFrequencyOcGetFrequencyTarget_t
+        ("pfnOcSetFrequencyTarget", c_void_p),                          ## _zesFrequencyOcSetFrequencyTarget_t
+        ("pfnOcGetVoltageTarget", c_void_p),                            ## _zesFrequencyOcGetVoltageTarget_t
+        ("pfnOcSetVoltageTarget", c_void_p),                            ## _zesFrequencyOcSetVoltageTarget_t
+        ("pfnOcSetMode", c_void_p),                                     ## _zesFrequencyOcSetMode_t
+        ("pfnOcGetMode", c_void_p),                                     ## _zesFrequencyOcGetMode_t
+        ("pfnOcGetIccMax", c_void_p),                                   ## _zesFrequencyOcGetIccMax_t
+        ("pfnOcSetIccMax", c_void_p),                                   ## _zesFrequencyOcSetIccMax_t
+        ("pfnOcGetTjMax", c_void_p),                                    ## _zesFrequencyOcGetTjMax_t
+        ("pfnOcSetTjMax", c_void_p)                                     ## _zesFrequencyOcSetTjMax_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zesEngineGetProperties
+if __use_win_types:
+    _zesEngineGetProperties_t = WINFUNCTYPE( ze_result_t, zes_engine_handle_t, POINTER(zes_engine_properties_t) )
+else:
+    _zesEngineGetProperties_t = CFUNCTYPE( ze_result_t, zes_engine_handle_t, POINTER(zes_engine_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zesEngineGetActivity
+if __use_win_types:
+    _zesEngineGetActivity_t = WINFUNCTYPE( ze_result_t, zes_engine_handle_t, POINTER(zes_engine_stats_t) )
+else:
+    _zesEngineGetActivity_t = CFUNCTYPE( ze_result_t, zes_engine_handle_t, POINTER(zes_engine_stats_t) )
+
+###############################################################################
+## @brief Function-pointer for zesEngineGetActivityExt
+if __use_win_types:
+    _zesEngineGetActivityExt_t = WINFUNCTYPE( ze_result_t, zes_engine_handle_t, POINTER(c_ulong), POINTER(zes_engine_stats_t) )
+else:
+    _zesEngineGetActivityExt_t = CFUNCTYPE( ze_result_t, zes_engine_handle_t, POINTER(c_ulong), POINTER(zes_engine_stats_t) )
+
+
+###############################################################################
+## @brief Table of Engine functions pointers
+class _zes_engine_dditable_t(Structure):
+    _fields_ = [
+        ("pfnGetProperties", c_void_p),                                 ## _zesEngineGetProperties_t
+        ("pfnGetActivity", c_void_p),                                   ## _zesEngineGetActivity_t
+        ("pfnGetActivityExt", c_void_p)                                 ## _zesEngineGetActivityExt_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zesStandbyGetProperties
+if __use_win_types:
+    _zesStandbyGetProperties_t = WINFUNCTYPE( ze_result_t, zes_standby_handle_t, POINTER(zes_standby_properties_t) )
+else:
+    _zesStandbyGetProperties_t = CFUNCTYPE( ze_result_t, zes_standby_handle_t, POINTER(zes_standby_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zesStandbyGetMode
+if __use_win_types:
+    _zesStandbyGetMode_t = WINFUNCTYPE( ze_result_t, zes_standby_handle_t, POINTER(zes_standby_promo_mode_t) )
+else:
+    _zesStandbyGetMode_t = CFUNCTYPE( ze_result_t, zes_standby_handle_t, POINTER(zes_standby_promo_mode_t) )
+
+###############################################################################
+## @brief Function-pointer for zesStandbySetMode
+if __use_win_types:
+    _zesStandbySetMode_t = WINFUNCTYPE( ze_result_t, zes_standby_handle_t, zes_standby_promo_mode_t )
+else:
+    _zesStandbySetMode_t = CFUNCTYPE( ze_result_t, zes_standby_handle_t, zes_standby_promo_mode_t )
+
+
+###############################################################################
+## @brief Table of Standby functions pointers
+class _zes_standby_dditable_t(Structure):
+    _fields_ = [
+        ("pfnGetProperties", c_void_p),                                 ## _zesStandbyGetProperties_t
+        ("pfnGetMode", c_void_p),                                       ## _zesStandbyGetMode_t
+        ("pfnSetMode", c_void_p)                                        ## _zesStandbySetMode_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zesFirmwareGetProperties
+if __use_win_types:
+    _zesFirmwareGetProperties_t = WINFUNCTYPE( ze_result_t, zes_firmware_handle_t, POINTER(zes_firmware_properties_t) )
+else:
+    _zesFirmwareGetProperties_t = CFUNCTYPE( ze_result_t, zes_firmware_handle_t, POINTER(zes_firmware_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zesFirmwareFlash
+if __use_win_types:
+    _zesFirmwareFlash_t = WINFUNCTYPE( ze_result_t, zes_firmware_handle_t, c_void_p, c_ulong )
+else:
+    _zesFirmwareFlash_t = CFUNCTYPE( ze_result_t, zes_firmware_handle_t, c_void_p, c_ulong )
+
+###############################################################################
+## @brief Function-pointer for zesFirmwareGetFlashProgress
+if __use_win_types:
+    _zesFirmwareGetFlashProgress_t = WINFUNCTYPE( ze_result_t, zes_firmware_handle_t, POINTER(c_ulong) )
+else:
+    _zesFirmwareGetFlashProgress_t = CFUNCTYPE( ze_result_t, zes_firmware_handle_t, POINTER(c_ulong) )
+
+###############################################################################
+## @brief Function-pointer for zesFirmwareGetConsoleLogs
+if __use_win_types:
+    _zesFirmwareGetConsoleLogs_t = WINFUNCTYPE( ze_result_t, zes_firmware_handle_t, POINTER(c_size_t), c_char_p )
+else:
+    _zesFirmwareGetConsoleLogs_t = CFUNCTYPE( ze_result_t, zes_firmware_handle_t, POINTER(c_size_t), c_char_p )
+
+
+###############################################################################
+## @brief Table of Firmware functions pointers
+class _zes_firmware_dditable_t(Structure):
+    _fields_ = [
+        ("pfnGetProperties", c_void_p),                                 ## _zesFirmwareGetProperties_t
+        ("pfnFlash", c_void_p),                                         ## _zesFirmwareFlash_t
+        ("pfnGetFlashProgress", c_void_p),                              ## _zesFirmwareGetFlashProgress_t
+        ("pfnGetConsoleLogs", c_void_p)                                 ## _zesFirmwareGetConsoleLogs_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zesFirmwareGetSecurityVersionExp
+if __use_win_types:
+    _zesFirmwareGetSecurityVersionExp_t = WINFUNCTYPE( ze_result_t, zes_firmware_handle_t, c_char_p )
+else:
+    _zesFirmwareGetSecurityVersionExp_t = CFUNCTYPE( ze_result_t, zes_firmware_handle_t, c_char_p )
+
+###############################################################################
+## @brief Function-pointer for zesFirmwareSetSecurityVersionExp
+if __use_win_types:
+    _zesFirmwareSetSecurityVersionExp_t = WINFUNCTYPE( ze_result_t, zes_firmware_handle_t )
+else:
+    _zesFirmwareSetSecurityVersionExp_t = CFUNCTYPE( ze_result_t, zes_firmware_handle_t )
+
+
+###############################################################################
+## @brief Table of FirmwareExp functions pointers
+class _zes_firmware_exp_dditable_t(Structure):
+    _fields_ = [
+        ("pfnGetSecurityVersionExp", c_void_p),                         ## _zesFirmwareGetSecurityVersionExp_t
+        ("pfnSetSecurityVersionExp", c_void_p)                          ## _zesFirmwareSetSecurityVersionExp_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zesMemoryGetProperties
+if __use_win_types:
+    _zesMemoryGetProperties_t = WINFUNCTYPE( ze_result_t, zes_mem_handle_t, POINTER(zes_mem_properties_t) )
+else:
+    _zesMemoryGetProperties_t = CFUNCTYPE( ze_result_t, zes_mem_handle_t, POINTER(zes_mem_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zesMemoryGetState
+if __use_win_types:
+    _zesMemoryGetState_t = WINFUNCTYPE( ze_result_t, zes_mem_handle_t, POINTER(zes_mem_state_t) )
+else:
+    _zesMemoryGetState_t = CFUNCTYPE( ze_result_t, zes_mem_handle_t, POINTER(zes_mem_state_t) )
+
+###############################################################################
+## @brief Function-pointer for zesMemoryGetBandwidth
+if __use_win_types:
+    _zesMemoryGetBandwidth_t = WINFUNCTYPE( ze_result_t, zes_mem_handle_t, POINTER(zes_mem_bandwidth_t) )
+else:
+    _zesMemoryGetBandwidth_t = CFUNCTYPE( ze_result_t, zes_mem_handle_t, POINTER(zes_mem_bandwidth_t) )
+
+
+###############################################################################
+## @brief Table of Memory functions pointers
+class _zes_memory_dditable_t(Structure):
+    _fields_ = [
+        ("pfnGetProperties", c_void_p),                                 ## _zesMemoryGetProperties_t
+        ("pfnGetState", c_void_p),                                      ## _zesMemoryGetState_t
+        ("pfnGetBandwidth", c_void_p)                                   ## _zesMemoryGetBandwidth_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zesFabricPortGetProperties
+if __use_win_types:
+    _zesFabricPortGetProperties_t = WINFUNCTYPE( ze_result_t, zes_fabric_port_handle_t, POINTER(zes_fabric_port_properties_t) )
+else:
+    _zesFabricPortGetProperties_t = CFUNCTYPE( ze_result_t, zes_fabric_port_handle_t, POINTER(zes_fabric_port_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zesFabricPortGetLinkType
+if __use_win_types:
+    _zesFabricPortGetLinkType_t = WINFUNCTYPE( ze_result_t, zes_fabric_port_handle_t, POINTER(zes_fabric_link_type_t) )
+else:
+    _zesFabricPortGetLinkType_t = CFUNCTYPE( ze_result_t, zes_fabric_port_handle_t, POINTER(zes_fabric_link_type_t) )
+
+###############################################################################
+## @brief Function-pointer for zesFabricPortGetConfig
+if __use_win_types:
+    _zesFabricPortGetConfig_t = WINFUNCTYPE( ze_result_t, zes_fabric_port_handle_t, POINTER(zes_fabric_port_config_t) )
+else:
+    _zesFabricPortGetConfig_t = CFUNCTYPE( ze_result_t, zes_fabric_port_handle_t, POINTER(zes_fabric_port_config_t) )
+
+###############################################################################
+## @brief Function-pointer for zesFabricPortSetConfig
+if __use_win_types:
+    _zesFabricPortSetConfig_t = WINFUNCTYPE( ze_result_t, zes_fabric_port_handle_t, POINTER(zes_fabric_port_config_t) )
+else:
+    _zesFabricPortSetConfig_t = CFUNCTYPE( ze_result_t, zes_fabric_port_handle_t, POINTER(zes_fabric_port_config_t) )
+
+###############################################################################
+## @brief Function-pointer for zesFabricPortGetState
+if __use_win_types:
+    _zesFabricPortGetState_t = WINFUNCTYPE( ze_result_t, zes_fabric_port_handle_t, POINTER(zes_fabric_port_state_t) )
+else:
+    _zesFabricPortGetState_t = CFUNCTYPE( ze_result_t, zes_fabric_port_handle_t, POINTER(zes_fabric_port_state_t) )
+
+###############################################################################
+## @brief Function-pointer for zesFabricPortGetThroughput
+if __use_win_types:
+    _zesFabricPortGetThroughput_t = WINFUNCTYPE( ze_result_t, zes_fabric_port_handle_t, POINTER(zes_fabric_port_throughput_t) )
+else:
+    _zesFabricPortGetThroughput_t = CFUNCTYPE( ze_result_t, zes_fabric_port_handle_t, POINTER(zes_fabric_port_throughput_t) )
+
+###############################################################################
+## @brief Function-pointer for zesFabricPortGetFabricErrorCounters
+if __use_win_types:
+    _zesFabricPortGetFabricErrorCounters_t = WINFUNCTYPE( ze_result_t, zes_fabric_port_handle_t, POINTER(zes_fabric_port_error_counters_t) )
+else:
+    _zesFabricPortGetFabricErrorCounters_t = CFUNCTYPE( ze_result_t, zes_fabric_port_handle_t, POINTER(zes_fabric_port_error_counters_t) )
+
+###############################################################################
+## @brief Function-pointer for zesFabricPortGetMultiPortThroughput
+if __use_win_types:
+    _zesFabricPortGetMultiPortThroughput_t = WINFUNCTYPE( ze_result_t, zes_device_handle_t, c_ulong, POINTER(zes_fabric_port_handle_t), POINTER(zes_fabric_port_throughput_t*) )
+else:
+    _zesFabricPortGetMultiPortThroughput_t = CFUNCTYPE( ze_result_t, zes_device_handle_t, c_ulong, POINTER(zes_fabric_port_handle_t), POINTER(zes_fabric_port_throughput_t*) )
+
+
+###############################################################################
+## @brief Table of FabricPort functions pointers
+class _zes_fabric_port_dditable_t(Structure):
+    _fields_ = [
+        ("pfnGetProperties", c_void_p),                                 ## _zesFabricPortGetProperties_t
+        ("pfnGetLinkType", c_void_p),                                   ## _zesFabricPortGetLinkType_t
+        ("pfnGetConfig", c_void_p),                                     ## _zesFabricPortGetConfig_t
+        ("pfnSetConfig", c_void_p),                                     ## _zesFabricPortSetConfig_t
+        ("pfnGetState", c_void_p),                                      ## _zesFabricPortGetState_t
+        ("pfnGetThroughput", c_void_p),                                 ## _zesFabricPortGetThroughput_t
+        ("pfnGetFabricErrorCounters", c_void_p),                        ## _zesFabricPortGetFabricErrorCounters_t
+        ("pfnGetMultiPortThroughput", c_void_p)                         ## _zesFabricPortGetMultiPortThroughput_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zesTemperatureGetProperties
+if __use_win_types:
+    _zesTemperatureGetProperties_t = WINFUNCTYPE( ze_result_t, zes_temp_handle_t, POINTER(zes_temp_properties_t) )
+else:
+    _zesTemperatureGetProperties_t = CFUNCTYPE( ze_result_t, zes_temp_handle_t, POINTER(zes_temp_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zesTemperatureGetConfig
+if __use_win_types:
+    _zesTemperatureGetConfig_t = WINFUNCTYPE( ze_result_t, zes_temp_handle_t, POINTER(zes_temp_config_t) )
+else:
+    _zesTemperatureGetConfig_t = CFUNCTYPE( ze_result_t, zes_temp_handle_t, POINTER(zes_temp_config_t) )
+
+###############################################################################
+## @brief Function-pointer for zesTemperatureSetConfig
+if __use_win_types:
+    _zesTemperatureSetConfig_t = WINFUNCTYPE( ze_result_t, zes_temp_handle_t, POINTER(zes_temp_config_t) )
+else:
+    _zesTemperatureSetConfig_t = CFUNCTYPE( ze_result_t, zes_temp_handle_t, POINTER(zes_temp_config_t) )
+
+###############################################################################
+## @brief Function-pointer for zesTemperatureGetState
+if __use_win_types:
+    _zesTemperatureGetState_t = WINFUNCTYPE( ze_result_t, zes_temp_handle_t, POINTER(c_double) )
+else:
+    _zesTemperatureGetState_t = CFUNCTYPE( ze_result_t, zes_temp_handle_t, POINTER(c_double) )
+
+
+###############################################################################
+## @brief Table of Temperature functions pointers
+class _zes_temperature_dditable_t(Structure):
+    _fields_ = [
+        ("pfnGetProperties", c_void_p),                                 ## _zesTemperatureGetProperties_t
+        ("pfnGetConfig", c_void_p),                                     ## _zesTemperatureGetConfig_t
+        ("pfnSetConfig", c_void_p),                                     ## _zesTemperatureSetConfig_t
+        ("pfnGetState", c_void_p)                                       ## _zesTemperatureGetState_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zesPsuGetProperties
+if __use_win_types:
+    _zesPsuGetProperties_t = WINFUNCTYPE( ze_result_t, zes_psu_handle_t, POINTER(zes_psu_properties_t) )
+else:
+    _zesPsuGetProperties_t = CFUNCTYPE( ze_result_t, zes_psu_handle_t, POINTER(zes_psu_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zesPsuGetState
+if __use_win_types:
+    _zesPsuGetState_t = WINFUNCTYPE( ze_result_t, zes_psu_handle_t, POINTER(zes_psu_state_t) )
+else:
+    _zesPsuGetState_t = CFUNCTYPE( ze_result_t, zes_psu_handle_t, POINTER(zes_psu_state_t) )
+
+
+###############################################################################
+## @brief Table of Psu functions pointers
+class _zes_psu_dditable_t(Structure):
+    _fields_ = [
+        ("pfnGetProperties", c_void_p),                                 ## _zesPsuGetProperties_t
+        ("pfnGetState", c_void_p)                                       ## _zesPsuGetState_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zesFanGetProperties
+if __use_win_types:
+    _zesFanGetProperties_t = WINFUNCTYPE( ze_result_t, zes_fan_handle_t, POINTER(zes_fan_properties_t) )
+else:
+    _zesFanGetProperties_t = CFUNCTYPE( ze_result_t, zes_fan_handle_t, POINTER(zes_fan_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zesFanGetConfig
+if __use_win_types:
+    _zesFanGetConfig_t = WINFUNCTYPE( ze_result_t, zes_fan_handle_t, POINTER(zes_fan_config_t) )
+else:
+    _zesFanGetConfig_t = CFUNCTYPE( ze_result_t, zes_fan_handle_t, POINTER(zes_fan_config_t) )
+
+###############################################################################
+## @brief Function-pointer for zesFanSetDefaultMode
+if __use_win_types:
+    _zesFanSetDefaultMode_t = WINFUNCTYPE( ze_result_t, zes_fan_handle_t )
+else:
+    _zesFanSetDefaultMode_t = CFUNCTYPE( ze_result_t, zes_fan_handle_t )
+
+###############################################################################
+## @brief Function-pointer for zesFanSetFixedSpeedMode
+if __use_win_types:
+    _zesFanSetFixedSpeedMode_t = WINFUNCTYPE( ze_result_t, zes_fan_handle_t, POINTER(zes_fan_speed_t) )
+else:
+    _zesFanSetFixedSpeedMode_t = CFUNCTYPE( ze_result_t, zes_fan_handle_t, POINTER(zes_fan_speed_t) )
+
+###############################################################################
+## @brief Function-pointer for zesFanSetSpeedTableMode
+if __use_win_types:
+    _zesFanSetSpeedTableMode_t = WINFUNCTYPE( ze_result_t, zes_fan_handle_t, POINTER(zes_fan_speed_table_t) )
+else:
+    _zesFanSetSpeedTableMode_t = CFUNCTYPE( ze_result_t, zes_fan_handle_t, POINTER(zes_fan_speed_table_t) )
+
+###############################################################################
+## @brief Function-pointer for zesFanGetState
+if __use_win_types:
+    _zesFanGetState_t = WINFUNCTYPE( ze_result_t, zes_fan_handle_t, zes_fan_speed_units_t, POINTER(c_int32_t) )
+else:
+    _zesFanGetState_t = CFUNCTYPE( ze_result_t, zes_fan_handle_t, zes_fan_speed_units_t, POINTER(c_int32_t) )
+
+
+###############################################################################
+## @brief Table of Fan functions pointers
+class _zes_fan_dditable_t(Structure):
+    _fields_ = [
+        ("pfnGetProperties", c_void_p),                                 ## _zesFanGetProperties_t
+        ("pfnGetConfig", c_void_p),                                     ## _zesFanGetConfig_t
+        ("pfnSetDefaultMode", c_void_p),                                ## _zesFanSetDefaultMode_t
+        ("pfnSetFixedSpeedMode", c_void_p),                             ## _zesFanSetFixedSpeedMode_t
+        ("pfnSetSpeedTableMode", c_void_p),                             ## _zesFanSetSpeedTableMode_t
+        ("pfnGetState", c_void_p)                                       ## _zesFanGetState_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zesLedGetProperties
+if __use_win_types:
+    _zesLedGetProperties_t = WINFUNCTYPE( ze_result_t, zes_led_handle_t, POINTER(zes_led_properties_t) )
+else:
+    _zesLedGetProperties_t = CFUNCTYPE( ze_result_t, zes_led_handle_t, POINTER(zes_led_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zesLedGetState
+if __use_win_types:
+    _zesLedGetState_t = WINFUNCTYPE( ze_result_t, zes_led_handle_t, POINTER(zes_led_state_t) )
+else:
+    _zesLedGetState_t = CFUNCTYPE( ze_result_t, zes_led_handle_t, POINTER(zes_led_state_t) )
+
+###############################################################################
+## @brief Function-pointer for zesLedSetState
+if __use_win_types:
+    _zesLedSetState_t = WINFUNCTYPE( ze_result_t, zes_led_handle_t, ze_bool_t )
+else:
+    _zesLedSetState_t = CFUNCTYPE( ze_result_t, zes_led_handle_t, ze_bool_t )
+
+###############################################################################
+## @brief Function-pointer for zesLedSetColor
+if __use_win_types:
+    _zesLedSetColor_t = WINFUNCTYPE( ze_result_t, zes_led_handle_t, POINTER(zes_led_color_t) )
+else:
+    _zesLedSetColor_t = CFUNCTYPE( ze_result_t, zes_led_handle_t, POINTER(zes_led_color_t) )
+
+
+###############################################################################
+## @brief Table of Led functions pointers
+class _zes_led_dditable_t(Structure):
+    _fields_ = [
+        ("pfnGetProperties", c_void_p),                                 ## _zesLedGetProperties_t
+        ("pfnGetState", c_void_p),                                      ## _zesLedGetState_t
+        ("pfnSetState", c_void_p),                                      ## _zesLedSetState_t
+        ("pfnSetColor", c_void_p)                                       ## _zesLedSetColor_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zesRasGetProperties
+if __use_win_types:
+    _zesRasGetProperties_t = WINFUNCTYPE( ze_result_t, zes_ras_handle_t, POINTER(zes_ras_properties_t) )
+else:
+    _zesRasGetProperties_t = CFUNCTYPE( ze_result_t, zes_ras_handle_t, POINTER(zes_ras_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zesRasGetConfig
+if __use_win_types:
+    _zesRasGetConfig_t = WINFUNCTYPE( ze_result_t, zes_ras_handle_t, POINTER(zes_ras_config_t) )
+else:
+    _zesRasGetConfig_t = CFUNCTYPE( ze_result_t, zes_ras_handle_t, POINTER(zes_ras_config_t) )
+
+###############################################################################
+## @brief Function-pointer for zesRasSetConfig
+if __use_win_types:
+    _zesRasSetConfig_t = WINFUNCTYPE( ze_result_t, zes_ras_handle_t, POINTER(zes_ras_config_t) )
+else:
+    _zesRasSetConfig_t = CFUNCTYPE( ze_result_t, zes_ras_handle_t, POINTER(zes_ras_config_t) )
+
+###############################################################################
+## @brief Function-pointer for zesRasGetState
+if __use_win_types:
+    _zesRasGetState_t = WINFUNCTYPE( ze_result_t, zes_ras_handle_t, ze_bool_t, POINTER(zes_ras_state_t) )
+else:
+    _zesRasGetState_t = CFUNCTYPE( ze_result_t, zes_ras_handle_t, ze_bool_t, POINTER(zes_ras_state_t) )
+
+
+###############################################################################
+## @brief Table of Ras functions pointers
+class _zes_ras_dditable_t(Structure):
+    _fields_ = [
+        ("pfnGetProperties", c_void_p),                                 ## _zesRasGetProperties_t
+        ("pfnGetConfig", c_void_p),                                     ## _zesRasGetConfig_t
+        ("pfnSetConfig", c_void_p),                                     ## _zesRasSetConfig_t
+        ("pfnGetState", c_void_p)                                       ## _zesRasGetState_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zesRasGetStateExp
+if __use_win_types:
+    _zesRasGetStateExp_t = WINFUNCTYPE( ze_result_t, zes_ras_handle_t, POINTER(c_ulong), POINTER(zes_ras_state_exp_t) )
+else:
+    _zesRasGetStateExp_t = CFUNCTYPE( ze_result_t, zes_ras_handle_t, POINTER(c_ulong), POINTER(zes_ras_state_exp_t) )
+
+###############################################################################
+## @brief Function-pointer for zesRasClearStateExp
+if __use_win_types:
+    _zesRasClearStateExp_t = WINFUNCTYPE( ze_result_t, zes_ras_handle_t, zes_ras_error_category_exp_t )
+else:
+    _zesRasClearStateExp_t = CFUNCTYPE( ze_result_t, zes_ras_handle_t, zes_ras_error_category_exp_t )
+
+
+###############################################################################
+## @brief Table of RasExp functions pointers
+class _zes_ras_exp_dditable_t(Structure):
+    _fields_ = [
+        ("pfnGetStateExp", c_void_p),                                   ## _zesRasGetStateExp_t
+        ("pfnClearStateExp", c_void_p)                                  ## _zesRasClearStateExp_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zesDiagnosticsGetProperties
+if __use_win_types:
+    _zesDiagnosticsGetProperties_t = WINFUNCTYPE( ze_result_t, zes_diag_handle_t, POINTER(zes_diag_properties_t) )
+else:
+    _zesDiagnosticsGetProperties_t = CFUNCTYPE( ze_result_t, zes_diag_handle_t, POINTER(zes_diag_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zesDiagnosticsGetTests
+if __use_win_types:
+    _zesDiagnosticsGetTests_t = WINFUNCTYPE( ze_result_t, zes_diag_handle_t, POINTER(c_ulong), POINTER(zes_diag_test_t) )
+else:
+    _zesDiagnosticsGetTests_t = CFUNCTYPE( ze_result_t, zes_diag_handle_t, POINTER(c_ulong), POINTER(zes_diag_test_t) )
+
+###############################################################################
+## @brief Function-pointer for zesDiagnosticsRunTests
+if __use_win_types:
+    _zesDiagnosticsRunTests_t = WINFUNCTYPE( ze_result_t, zes_diag_handle_t, c_ulong, c_ulong, POINTER(zes_diag_result_t) )
+else:
+    _zesDiagnosticsRunTests_t = CFUNCTYPE( ze_result_t, zes_diag_handle_t, c_ulong, c_ulong, POINTER(zes_diag_result_t) )
+
+
+###############################################################################
+## @brief Table of Diagnostics functions pointers
+class _zes_diagnostics_dditable_t(Structure):
+    _fields_ = [
+        ("pfnGetProperties", c_void_p),                                 ## _zesDiagnosticsGetProperties_t
+        ("pfnGetTests", c_void_p),                                      ## _zesDiagnosticsGetTests_t
+        ("pfnRunTests", c_void_p)                                       ## _zesDiagnosticsRunTests_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zesVFManagementGetVFPropertiesExp
+if __use_win_types:
+    _zesVFManagementGetVFPropertiesExp_t = WINFUNCTYPE( ze_result_t, zes_vf_handle_t, POINTER(zes_vf_exp_properties_t) )
+else:
+    _zesVFManagementGetVFPropertiesExp_t = CFUNCTYPE( ze_result_t, zes_vf_handle_t, POINTER(zes_vf_exp_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zesVFManagementGetVFMemoryUtilizationExp
+if __use_win_types:
+    _zesVFManagementGetVFMemoryUtilizationExp_t = WINFUNCTYPE( ze_result_t, zes_vf_handle_t, POINTER(c_ulong), POINTER(zes_vf_util_mem_exp_t) )
+else:
+    _zesVFManagementGetVFMemoryUtilizationExp_t = CFUNCTYPE( ze_result_t, zes_vf_handle_t, POINTER(c_ulong), POINTER(zes_vf_util_mem_exp_t) )
+
+###############################################################################
+## @brief Function-pointer for zesVFManagementGetVFEngineUtilizationExp
+if __use_win_types:
+    _zesVFManagementGetVFEngineUtilizationExp_t = WINFUNCTYPE( ze_result_t, zes_vf_handle_t, POINTER(c_ulong), POINTER(zes_vf_util_engine_exp_t) )
+else:
+    _zesVFManagementGetVFEngineUtilizationExp_t = CFUNCTYPE( ze_result_t, zes_vf_handle_t, POINTER(c_ulong), POINTER(zes_vf_util_engine_exp_t) )
+
+###############################################################################
+## @brief Function-pointer for zesVFManagementSetVFTelemetryModeExp
+if __use_win_types:
+    _zesVFManagementSetVFTelemetryModeExp_t = WINFUNCTYPE( ze_result_t, zes_vf_handle_t, zes_vf_info_util_exp_flags_t, ze_bool_t )
+else:
+    _zesVFManagementSetVFTelemetryModeExp_t = CFUNCTYPE( ze_result_t, zes_vf_handle_t, zes_vf_info_util_exp_flags_t, ze_bool_t )
+
+###############################################################################
+## @brief Function-pointer for zesVFManagementSetVFTelemetrySamplingIntervalExp
+if __use_win_types:
+    _zesVFManagementSetVFTelemetrySamplingIntervalExp_t = WINFUNCTYPE( ze_result_t, zes_vf_handle_t, zes_vf_info_util_exp_flags_t, c_ulonglong )
+else:
+    _zesVFManagementSetVFTelemetrySamplingIntervalExp_t = CFUNCTYPE( ze_result_t, zes_vf_handle_t, zes_vf_info_util_exp_flags_t, c_ulonglong )
+
+###############################################################################
+## @brief Function-pointer for zesVFManagementGetVFCapabilitiesExp
+if __use_win_types:
+    _zesVFManagementGetVFCapabilitiesExp_t = WINFUNCTYPE( ze_result_t, zes_vf_handle_t, POINTER(zes_vf_exp_capabilities_t) )
+else:
+    _zesVFManagementGetVFCapabilitiesExp_t = CFUNCTYPE( ze_result_t, zes_vf_handle_t, POINTER(zes_vf_exp_capabilities_t) )
+
+###############################################################################
+## @brief Function-pointer for zesVFManagementGetVFMemoryUtilizationExp2
+if __use_win_types:
+    _zesVFManagementGetVFMemoryUtilizationExp2_t = WINFUNCTYPE( ze_result_t, zes_vf_handle_t, POINTER(c_ulong), POINTER(zes_vf_util_mem_exp2_t) )
+else:
+    _zesVFManagementGetVFMemoryUtilizationExp2_t = CFUNCTYPE( ze_result_t, zes_vf_handle_t, POINTER(c_ulong), POINTER(zes_vf_util_mem_exp2_t) )
+
+###############################################################################
+## @brief Function-pointer for zesVFManagementGetVFEngineUtilizationExp2
+if __use_win_types:
+    _zesVFManagementGetVFEngineUtilizationExp2_t = WINFUNCTYPE( ze_result_t, zes_vf_handle_t, POINTER(c_ulong), POINTER(zes_vf_util_engine_exp2_t) )
+else:
+    _zesVFManagementGetVFEngineUtilizationExp2_t = CFUNCTYPE( ze_result_t, zes_vf_handle_t, POINTER(c_ulong), POINTER(zes_vf_util_engine_exp2_t) )
+
+###############################################################################
+## @brief Function-pointer for zesVFManagementGetVFCapabilitiesExp2
+if __use_win_types:
+    _zesVFManagementGetVFCapabilitiesExp2_t = WINFUNCTYPE( ze_result_t, zes_vf_handle_t, POINTER(zes_vf_exp2_capabilities_t) )
+else:
+    _zesVFManagementGetVFCapabilitiesExp2_t = CFUNCTYPE( ze_result_t, zes_vf_handle_t, POINTER(zes_vf_exp2_capabilities_t) )
+
+
+###############################################################################
+## @brief Table of VFManagementExp functions pointers
+class _zes_vf_management_exp_dditable_t(Structure):
+    _fields_ = [
+        ("pfnGetVFPropertiesExp", c_void_p),                            ## _zesVFManagementGetVFPropertiesExp_t
+        ("pfnGetVFMemoryUtilizationExp", c_void_p),                     ## _zesVFManagementGetVFMemoryUtilizationExp_t
+        ("pfnGetVFEngineUtilizationExp", c_void_p),                     ## _zesVFManagementGetVFEngineUtilizationExp_t
+        ("pfnSetVFTelemetryModeExp", c_void_p),                         ## _zesVFManagementSetVFTelemetryModeExp_t
+        ("pfnSetVFTelemetrySamplingIntervalExp", c_void_p),             ## _zesVFManagementSetVFTelemetrySamplingIntervalExp_t
+        ("pfnGetVFCapabilitiesExp", c_void_p),                          ## _zesVFManagementGetVFCapabilitiesExp_t
+        ("pfnGetVFMemoryUtilizationExp2", c_void_p),                    ## _zesVFManagementGetVFMemoryUtilizationExp2_t
+        ("pfnGetVFEngineUtilizationExp2", c_void_p),                    ## _zesVFManagementGetVFEngineUtilizationExp2_t
+        ("pfnGetVFCapabilitiesExp2", c_void_p)                          ## _zesVFManagementGetVFCapabilitiesExp2_t
+    ]
+
+###############################################################################
+class _zes_dditable_t(Structure):
+    _fields_ = [
+        ("Global", _zes_global_dditable_t),
+        ("Device", _zes_device_dditable_t),
+        ("DeviceExp", _zes_device_exp_dditable_t),
+        ("Driver", _zes_driver_dditable_t),
+        ("DriverExp", _zes_driver_exp_dditable_t),
+        ("Overclock", _zes_overclock_dditable_t),
+        ("Scheduler", _zes_scheduler_dditable_t),
+        ("PerformanceFactor", _zes_performance_factor_dditable_t),
+        ("Power", _zes_power_dditable_t),
+        ("Frequency", _zes_frequency_dditable_t),
+        ("Engine", _zes_engine_dditable_t),
+        ("Standby", _zes_standby_dditable_t),
+        ("Firmware", _zes_firmware_dditable_t),
+        ("FirmwareExp", _zes_firmware_exp_dditable_t),
+        ("Memory", _zes_memory_dditable_t),
+        ("FabricPort", _zes_fabric_port_dditable_t),
+        ("Temperature", _zes_temperature_dditable_t),
+        ("Psu", _zes_psu_dditable_t),
+        ("Fan", _zes_fan_dditable_t),
+        ("Led", _zes_led_dditable_t),
+        ("Ras", _zes_ras_dditable_t),
+        ("RasExp", _zes_ras_exp_dditable_t),
+        ("Diagnostics", _zes_diagnostics_dditable_t),
+        ("VFManagementExp", _zes_vf_management_exp_dditable_t)
+    ]
+
+###############################################################################
+## @brief zes device-driver interfaces
+class ZES_DDI:
+    def __init__(self, version : ze_api_version_t):
+        # load the ze_loader library
+        if "Windows" == platform.uname()[0]:
+            self.__dll = WinDLL("ze_loader.dll")
+        else:
+            self.__dll = CDLL("ze_loader.so")
+
+        # fill the ddi tables
+        self.__dditable = _zes_dditable_t()
+
+        # call driver to get function pointers
+        _Global = _zes_global_dditable_t()
+        r = ze_result_v(self.__dll.zesGetGlobalProcAddrTable(version, byref(_Global)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.Global = _Global
+
+        # attach function interface to function address
+        self.zesInit = _zesInit_t(self.__dditable.Global.pfnInit)
+
+        # call driver to get function pointers
+        _Device = _zes_device_dditable_t()
+        r = ze_result_v(self.__dll.zesGetDeviceProcAddrTable(version, byref(_Device)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.Device = _Device
+
+        # attach function interface to function address
+        self.zesDeviceGetProperties = _zesDeviceGetProperties_t(self.__dditable.Device.pfnGetProperties)
+        self.zesDeviceGetState = _zesDeviceGetState_t(self.__dditable.Device.pfnGetState)
+        self.zesDeviceReset = _zesDeviceReset_t(self.__dditable.Device.pfnReset)
+        self.zesDeviceProcessesGetState = _zesDeviceProcessesGetState_t(self.__dditable.Device.pfnProcessesGetState)
+        self.zesDevicePciGetProperties = _zesDevicePciGetProperties_t(self.__dditable.Device.pfnPciGetProperties)
+        self.zesDevicePciGetState = _zesDevicePciGetState_t(self.__dditable.Device.pfnPciGetState)
+        self.zesDevicePciGetBars = _zesDevicePciGetBars_t(self.__dditable.Device.pfnPciGetBars)
+        self.zesDevicePciGetStats = _zesDevicePciGetStats_t(self.__dditable.Device.pfnPciGetStats)
+        self.zesDeviceEnumDiagnosticTestSuites = _zesDeviceEnumDiagnosticTestSuites_t(self.__dditable.Device.pfnEnumDiagnosticTestSuites)
+        self.zesDeviceEnumEngineGroups = _zesDeviceEnumEngineGroups_t(self.__dditable.Device.pfnEnumEngineGroups)
+        self.zesDeviceEventRegister = _zesDeviceEventRegister_t(self.__dditable.Device.pfnEventRegister)
+        self.zesDeviceEnumFabricPorts = _zesDeviceEnumFabricPorts_t(self.__dditable.Device.pfnEnumFabricPorts)
+        self.zesDeviceEnumFans = _zesDeviceEnumFans_t(self.__dditable.Device.pfnEnumFans)
+        self.zesDeviceEnumFirmwares = _zesDeviceEnumFirmwares_t(self.__dditable.Device.pfnEnumFirmwares)
+        self.zesDeviceEnumFrequencyDomains = _zesDeviceEnumFrequencyDomains_t(self.__dditable.Device.pfnEnumFrequencyDomains)
+        self.zesDeviceEnumLeds = _zesDeviceEnumLeds_t(self.__dditable.Device.pfnEnumLeds)
+        self.zesDeviceEnumMemoryModules = _zesDeviceEnumMemoryModules_t(self.__dditable.Device.pfnEnumMemoryModules)
+        self.zesDeviceEnumPerformanceFactorDomains = _zesDeviceEnumPerformanceFactorDomains_t(self.__dditable.Device.pfnEnumPerformanceFactorDomains)
+        self.zesDeviceEnumPowerDomains = _zesDeviceEnumPowerDomains_t(self.__dditable.Device.pfnEnumPowerDomains)
+        self.zesDeviceGetCardPowerDomain = _zesDeviceGetCardPowerDomain_t(self.__dditable.Device.pfnGetCardPowerDomain)
+        self.zesDeviceEnumPsus = _zesDeviceEnumPsus_t(self.__dditable.Device.pfnEnumPsus)
+        self.zesDeviceEnumRasErrorSets = _zesDeviceEnumRasErrorSets_t(self.__dditable.Device.pfnEnumRasErrorSets)
+        self.zesDeviceEnumSchedulers = _zesDeviceEnumSchedulers_t(self.__dditable.Device.pfnEnumSchedulers)
+        self.zesDeviceEnumStandbyDomains = _zesDeviceEnumStandbyDomains_t(self.__dditable.Device.pfnEnumStandbyDomains)
+        self.zesDeviceEnumTemperatureSensors = _zesDeviceEnumTemperatureSensors_t(self.__dditable.Device.pfnEnumTemperatureSensors)
+        self.zesDeviceEccAvailable = _zesDeviceEccAvailable_t(self.__dditable.Device.pfnEccAvailable)
+        self.zesDeviceEccConfigurable = _zesDeviceEccConfigurable_t(self.__dditable.Device.pfnEccConfigurable)
+        self.zesDeviceGetEccState = _zesDeviceGetEccState_t(self.__dditable.Device.pfnGetEccState)
+        self.zesDeviceSetEccState = _zesDeviceSetEccState_t(self.__dditable.Device.pfnSetEccState)
+        self.zesDeviceGet = _zesDeviceGet_t(self.__dditable.Device.pfnGet)
+        self.zesDeviceSetOverclockWaiver = _zesDeviceSetOverclockWaiver_t(self.__dditable.Device.pfnSetOverclockWaiver)
+        self.zesDeviceGetOverclockDomains = _zesDeviceGetOverclockDomains_t(self.__dditable.Device.pfnGetOverclockDomains)
+        self.zesDeviceGetOverclockControls = _zesDeviceGetOverclockControls_t(self.__dditable.Device.pfnGetOverclockControls)
+        self.zesDeviceResetOverclockSettings = _zesDeviceResetOverclockSettings_t(self.__dditable.Device.pfnResetOverclockSettings)
+        self.zesDeviceReadOverclockState = _zesDeviceReadOverclockState_t(self.__dditable.Device.pfnReadOverclockState)
+        self.zesDeviceEnumOverclockDomains = _zesDeviceEnumOverclockDomains_t(self.__dditable.Device.pfnEnumOverclockDomains)
+        self.zesDeviceResetExt = _zesDeviceResetExt_t(self.__dditable.Device.pfnResetExt)
+
+        # call driver to get function pointers
+        _DeviceExp = _zes_device_exp_dditable_t()
+        r = ze_result_v(self.__dll.zesGetDeviceExpProcAddrTable(version, byref(_DeviceExp)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.DeviceExp = _DeviceExp
+
+        # attach function interface to function address
+        self.zesDeviceGetSubDevicePropertiesExp = _zesDeviceGetSubDevicePropertiesExp_t(self.__dditable.DeviceExp.pfnGetSubDevicePropertiesExp)
+        self.zesDeviceEnumActiveVFExp = _zesDeviceEnumActiveVFExp_t(self.__dditable.DeviceExp.pfnEnumActiveVFExp)
+        self.zesDeviceEnumEnabledVFExp = _zesDeviceEnumEnabledVFExp_t(self.__dditable.DeviceExp.pfnEnumEnabledVFExp)
+
+        # call driver to get function pointers
+        _Driver = _zes_driver_dditable_t()
+        r = ze_result_v(self.__dll.zesGetDriverProcAddrTable(version, byref(_Driver)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.Driver = _Driver
+
+        # attach function interface to function address
+        self.zesDriverEventListen = _zesDriverEventListen_t(self.__dditable.Driver.pfnEventListen)
+        self.zesDriverEventListenEx = _zesDriverEventListenEx_t(self.__dditable.Driver.pfnEventListenEx)
+        self.zesDriverGet = _zesDriverGet_t(self.__dditable.Driver.pfnGet)
+        self.zesDriverGetExtensionProperties = _zesDriverGetExtensionProperties_t(self.__dditable.Driver.pfnGetExtensionProperties)
+        self.zesDriverGetExtensionFunctionAddress = _zesDriverGetExtensionFunctionAddress_t(self.__dditable.Driver.pfnGetExtensionFunctionAddress)
+
+        # call driver to get function pointers
+        _DriverExp = _zes_driver_exp_dditable_t()
+        r = ze_result_v(self.__dll.zesGetDriverExpProcAddrTable(version, byref(_DriverExp)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.DriverExp = _DriverExp
+
+        # attach function interface to function address
+        self.zesDriverGetDeviceByUuidExp = _zesDriverGetDeviceByUuidExp_t(self.__dditable.DriverExp.pfnGetDeviceByUuidExp)
+
+        # call driver to get function pointers
+        _Overclock = _zes_overclock_dditable_t()
+        r = ze_result_v(self.__dll.zesGetOverclockProcAddrTable(version, byref(_Overclock)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.Overclock = _Overclock
+
+        # attach function interface to function address
+        self.zesOverclockGetDomainProperties = _zesOverclockGetDomainProperties_t(self.__dditable.Overclock.pfnGetDomainProperties)
+        self.zesOverclockGetDomainVFProperties = _zesOverclockGetDomainVFProperties_t(self.__dditable.Overclock.pfnGetDomainVFProperties)
+        self.zesOverclockGetDomainControlProperties = _zesOverclockGetDomainControlProperties_t(self.__dditable.Overclock.pfnGetDomainControlProperties)
+        self.zesOverclockGetControlCurrentValue = _zesOverclockGetControlCurrentValue_t(self.__dditable.Overclock.pfnGetControlCurrentValue)
+        self.zesOverclockGetControlPendingValue = _zesOverclockGetControlPendingValue_t(self.__dditable.Overclock.pfnGetControlPendingValue)
+        self.zesOverclockSetControlUserValue = _zesOverclockSetControlUserValue_t(self.__dditable.Overclock.pfnSetControlUserValue)
+        self.zesOverclockGetControlState = _zesOverclockGetControlState_t(self.__dditable.Overclock.pfnGetControlState)
+        self.zesOverclockGetVFPointValues = _zesOverclockGetVFPointValues_t(self.__dditable.Overclock.pfnGetVFPointValues)
+        self.zesOverclockSetVFPointValues = _zesOverclockSetVFPointValues_t(self.__dditable.Overclock.pfnSetVFPointValues)
+
+        # call driver to get function pointers
+        _Scheduler = _zes_scheduler_dditable_t()
+        r = ze_result_v(self.__dll.zesGetSchedulerProcAddrTable(version, byref(_Scheduler)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.Scheduler = _Scheduler
+
+        # attach function interface to function address
+        self.zesSchedulerGetProperties = _zesSchedulerGetProperties_t(self.__dditable.Scheduler.pfnGetProperties)
+        self.zesSchedulerGetCurrentMode = _zesSchedulerGetCurrentMode_t(self.__dditable.Scheduler.pfnGetCurrentMode)
+        self.zesSchedulerGetTimeoutModeProperties = _zesSchedulerGetTimeoutModeProperties_t(self.__dditable.Scheduler.pfnGetTimeoutModeProperties)
+        self.zesSchedulerGetTimesliceModeProperties = _zesSchedulerGetTimesliceModeProperties_t(self.__dditable.Scheduler.pfnGetTimesliceModeProperties)
+        self.zesSchedulerSetTimeoutMode = _zesSchedulerSetTimeoutMode_t(self.__dditable.Scheduler.pfnSetTimeoutMode)
+        self.zesSchedulerSetTimesliceMode = _zesSchedulerSetTimesliceMode_t(self.__dditable.Scheduler.pfnSetTimesliceMode)
+        self.zesSchedulerSetExclusiveMode = _zesSchedulerSetExclusiveMode_t(self.__dditable.Scheduler.pfnSetExclusiveMode)
+        self.zesSchedulerSetComputeUnitDebugMode = _zesSchedulerSetComputeUnitDebugMode_t(self.__dditable.Scheduler.pfnSetComputeUnitDebugMode)
+
+        # call driver to get function pointers
+        _PerformanceFactor = _zes_performance_factor_dditable_t()
+        r = ze_result_v(self.__dll.zesGetPerformanceFactorProcAddrTable(version, byref(_PerformanceFactor)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.PerformanceFactor = _PerformanceFactor
+
+        # attach function interface to function address
+        self.zesPerformanceFactorGetProperties = _zesPerformanceFactorGetProperties_t(self.__dditable.PerformanceFactor.pfnGetProperties)
+        self.zesPerformanceFactorGetConfig = _zesPerformanceFactorGetConfig_t(self.__dditable.PerformanceFactor.pfnGetConfig)
+        self.zesPerformanceFactorSetConfig = _zesPerformanceFactorSetConfig_t(self.__dditable.PerformanceFactor.pfnSetConfig)
+
+        # call driver to get function pointers
+        _Power = _zes_power_dditable_t()
+        r = ze_result_v(self.__dll.zesGetPowerProcAddrTable(version, byref(_Power)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.Power = _Power
+
+        # attach function interface to function address
+        self.zesPowerGetProperties = _zesPowerGetProperties_t(self.__dditable.Power.pfnGetProperties)
+        self.zesPowerGetEnergyCounter = _zesPowerGetEnergyCounter_t(self.__dditable.Power.pfnGetEnergyCounter)
+        self.zesPowerGetLimits = _zesPowerGetLimits_t(self.__dditable.Power.pfnGetLimits)
+        self.zesPowerSetLimits = _zesPowerSetLimits_t(self.__dditable.Power.pfnSetLimits)
+        self.zesPowerGetEnergyThreshold = _zesPowerGetEnergyThreshold_t(self.__dditable.Power.pfnGetEnergyThreshold)
+        self.zesPowerSetEnergyThreshold = _zesPowerSetEnergyThreshold_t(self.__dditable.Power.pfnSetEnergyThreshold)
+        self.zesPowerGetLimitsExt = _zesPowerGetLimitsExt_t(self.__dditable.Power.pfnGetLimitsExt)
+        self.zesPowerSetLimitsExt = _zesPowerSetLimitsExt_t(self.__dditable.Power.pfnSetLimitsExt)
+
+        # call driver to get function pointers
+        _Frequency = _zes_frequency_dditable_t()
+        r = ze_result_v(self.__dll.zesGetFrequencyProcAddrTable(version, byref(_Frequency)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.Frequency = _Frequency
+
+        # attach function interface to function address
+        self.zesFrequencyGetProperties = _zesFrequencyGetProperties_t(self.__dditable.Frequency.pfnGetProperties)
+        self.zesFrequencyGetAvailableClocks = _zesFrequencyGetAvailableClocks_t(self.__dditable.Frequency.pfnGetAvailableClocks)
+        self.zesFrequencyGetRange = _zesFrequencyGetRange_t(self.__dditable.Frequency.pfnGetRange)
+        self.zesFrequencySetRange = _zesFrequencySetRange_t(self.__dditable.Frequency.pfnSetRange)
+        self.zesFrequencyGetState = _zesFrequencyGetState_t(self.__dditable.Frequency.pfnGetState)
+        self.zesFrequencyGetThrottleTime = _zesFrequencyGetThrottleTime_t(self.__dditable.Frequency.pfnGetThrottleTime)
+        self.zesFrequencyOcGetCapabilities = _zesFrequencyOcGetCapabilities_t(self.__dditable.Frequency.pfnOcGetCapabilities)
+        self.zesFrequencyOcGetFrequencyTarget = _zesFrequencyOcGetFrequencyTarget_t(self.__dditable.Frequency.pfnOcGetFrequencyTarget)
+        self.zesFrequencyOcSetFrequencyTarget = _zesFrequencyOcSetFrequencyTarget_t(self.__dditable.Frequency.pfnOcSetFrequencyTarget)
+        self.zesFrequencyOcGetVoltageTarget = _zesFrequencyOcGetVoltageTarget_t(self.__dditable.Frequency.pfnOcGetVoltageTarget)
+        self.zesFrequencyOcSetVoltageTarget = _zesFrequencyOcSetVoltageTarget_t(self.__dditable.Frequency.pfnOcSetVoltageTarget)
+        self.zesFrequencyOcSetMode = _zesFrequencyOcSetMode_t(self.__dditable.Frequency.pfnOcSetMode)
+        self.zesFrequencyOcGetMode = _zesFrequencyOcGetMode_t(self.__dditable.Frequency.pfnOcGetMode)
+        self.zesFrequencyOcGetIccMax = _zesFrequencyOcGetIccMax_t(self.__dditable.Frequency.pfnOcGetIccMax)
+        self.zesFrequencyOcSetIccMax = _zesFrequencyOcSetIccMax_t(self.__dditable.Frequency.pfnOcSetIccMax)
+        self.zesFrequencyOcGetTjMax = _zesFrequencyOcGetTjMax_t(self.__dditable.Frequency.pfnOcGetTjMax)
+        self.zesFrequencyOcSetTjMax = _zesFrequencyOcSetTjMax_t(self.__dditable.Frequency.pfnOcSetTjMax)
+
+        # call driver to get function pointers
+        _Engine = _zes_engine_dditable_t()
+        r = ze_result_v(self.__dll.zesGetEngineProcAddrTable(version, byref(_Engine)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.Engine = _Engine
+
+        # attach function interface to function address
+        self.zesEngineGetProperties = _zesEngineGetProperties_t(self.__dditable.Engine.pfnGetProperties)
+        self.zesEngineGetActivity = _zesEngineGetActivity_t(self.__dditable.Engine.pfnGetActivity)
+        self.zesEngineGetActivityExt = _zesEngineGetActivityExt_t(self.__dditable.Engine.pfnGetActivityExt)
+
+        # call driver to get function pointers
+        _Standby = _zes_standby_dditable_t()
+        r = ze_result_v(self.__dll.zesGetStandbyProcAddrTable(version, byref(_Standby)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.Standby = _Standby
+
+        # attach function interface to function address
+        self.zesStandbyGetProperties = _zesStandbyGetProperties_t(self.__dditable.Standby.pfnGetProperties)
+        self.zesStandbyGetMode = _zesStandbyGetMode_t(self.__dditable.Standby.pfnGetMode)
+        self.zesStandbySetMode = _zesStandbySetMode_t(self.__dditable.Standby.pfnSetMode)
+
+        # call driver to get function pointers
+        _Firmware = _zes_firmware_dditable_t()
+        r = ze_result_v(self.__dll.zesGetFirmwareProcAddrTable(version, byref(_Firmware)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.Firmware = _Firmware
+
+        # attach function interface to function address
+        self.zesFirmwareGetProperties = _zesFirmwareGetProperties_t(self.__dditable.Firmware.pfnGetProperties)
+        self.zesFirmwareFlash = _zesFirmwareFlash_t(self.__dditable.Firmware.pfnFlash)
+        self.zesFirmwareGetFlashProgress = _zesFirmwareGetFlashProgress_t(self.__dditable.Firmware.pfnGetFlashProgress)
+        self.zesFirmwareGetConsoleLogs = _zesFirmwareGetConsoleLogs_t(self.__dditable.Firmware.pfnGetConsoleLogs)
+
+        # call driver to get function pointers
+        _FirmwareExp = _zes_firmware_exp_dditable_t()
+        r = ze_result_v(self.__dll.zesGetFirmwareExpProcAddrTable(version, byref(_FirmwareExp)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.FirmwareExp = _FirmwareExp
+
+        # attach function interface to function address
+        self.zesFirmwareGetSecurityVersionExp = _zesFirmwareGetSecurityVersionExp_t(self.__dditable.FirmwareExp.pfnGetSecurityVersionExp)
+        self.zesFirmwareSetSecurityVersionExp = _zesFirmwareSetSecurityVersionExp_t(self.__dditable.FirmwareExp.pfnSetSecurityVersionExp)
+
+        # call driver to get function pointers
+        _Memory = _zes_memory_dditable_t()
+        r = ze_result_v(self.__dll.zesGetMemoryProcAddrTable(version, byref(_Memory)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.Memory = _Memory
+
+        # attach function interface to function address
+        self.zesMemoryGetProperties = _zesMemoryGetProperties_t(self.__dditable.Memory.pfnGetProperties)
+        self.zesMemoryGetState = _zesMemoryGetState_t(self.__dditable.Memory.pfnGetState)
+        self.zesMemoryGetBandwidth = _zesMemoryGetBandwidth_t(self.__dditable.Memory.pfnGetBandwidth)
+
+        # call driver to get function pointers
+        _FabricPort = _zes_fabric_port_dditable_t()
+        r = ze_result_v(self.__dll.zesGetFabricPortProcAddrTable(version, byref(_FabricPort)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.FabricPort = _FabricPort
+
+        # attach function interface to function address
+        self.zesFabricPortGetProperties = _zesFabricPortGetProperties_t(self.__dditable.FabricPort.pfnGetProperties)
+        self.zesFabricPortGetLinkType = _zesFabricPortGetLinkType_t(self.__dditable.FabricPort.pfnGetLinkType)
+        self.zesFabricPortGetConfig = _zesFabricPortGetConfig_t(self.__dditable.FabricPort.pfnGetConfig)
+        self.zesFabricPortSetConfig = _zesFabricPortSetConfig_t(self.__dditable.FabricPort.pfnSetConfig)
+        self.zesFabricPortGetState = _zesFabricPortGetState_t(self.__dditable.FabricPort.pfnGetState)
+        self.zesFabricPortGetThroughput = _zesFabricPortGetThroughput_t(self.__dditable.FabricPort.pfnGetThroughput)
+        self.zesFabricPortGetFabricErrorCounters = _zesFabricPortGetFabricErrorCounters_t(self.__dditable.FabricPort.pfnGetFabricErrorCounters)
+        self.zesFabricPortGetMultiPortThroughput = _zesFabricPortGetMultiPortThroughput_t(self.__dditable.FabricPort.pfnGetMultiPortThroughput)
+
+        # call driver to get function pointers
+        _Temperature = _zes_temperature_dditable_t()
+        r = ze_result_v(self.__dll.zesGetTemperatureProcAddrTable(version, byref(_Temperature)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.Temperature = _Temperature
+
+        # attach function interface to function address
+        self.zesTemperatureGetProperties = _zesTemperatureGetProperties_t(self.__dditable.Temperature.pfnGetProperties)
+        self.zesTemperatureGetConfig = _zesTemperatureGetConfig_t(self.__dditable.Temperature.pfnGetConfig)
+        self.zesTemperatureSetConfig = _zesTemperatureSetConfig_t(self.__dditable.Temperature.pfnSetConfig)
+        self.zesTemperatureGetState = _zesTemperatureGetState_t(self.__dditable.Temperature.pfnGetState)
+
+        # call driver to get function pointers
+        _Psu = _zes_psu_dditable_t()
+        r = ze_result_v(self.__dll.zesGetPsuProcAddrTable(version, byref(_Psu)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.Psu = _Psu
+
+        # attach function interface to function address
+        self.zesPsuGetProperties = _zesPsuGetProperties_t(self.__dditable.Psu.pfnGetProperties)
+        self.zesPsuGetState = _zesPsuGetState_t(self.__dditable.Psu.pfnGetState)
+
+        # call driver to get function pointers
+        _Fan = _zes_fan_dditable_t()
+        r = ze_result_v(self.__dll.zesGetFanProcAddrTable(version, byref(_Fan)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.Fan = _Fan
+
+        # attach function interface to function address
+        self.zesFanGetProperties = _zesFanGetProperties_t(self.__dditable.Fan.pfnGetProperties)
+        self.zesFanGetConfig = _zesFanGetConfig_t(self.__dditable.Fan.pfnGetConfig)
+        self.zesFanSetDefaultMode = _zesFanSetDefaultMode_t(self.__dditable.Fan.pfnSetDefaultMode)
+        self.zesFanSetFixedSpeedMode = _zesFanSetFixedSpeedMode_t(self.__dditable.Fan.pfnSetFixedSpeedMode)
+        self.zesFanSetSpeedTableMode = _zesFanSetSpeedTableMode_t(self.__dditable.Fan.pfnSetSpeedTableMode)
+        self.zesFanGetState = _zesFanGetState_t(self.__dditable.Fan.pfnGetState)
+
+        # call driver to get function pointers
+        _Led = _zes_led_dditable_t()
+        r = ze_result_v(self.__dll.zesGetLedProcAddrTable(version, byref(_Led)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.Led = _Led
+
+        # attach function interface to function address
+        self.zesLedGetProperties = _zesLedGetProperties_t(self.__dditable.Led.pfnGetProperties)
+        self.zesLedGetState = _zesLedGetState_t(self.__dditable.Led.pfnGetState)
+        self.zesLedSetState = _zesLedSetState_t(self.__dditable.Led.pfnSetState)
+        self.zesLedSetColor = _zesLedSetColor_t(self.__dditable.Led.pfnSetColor)
+
+        # call driver to get function pointers
+        _Ras = _zes_ras_dditable_t()
+        r = ze_result_v(self.__dll.zesGetRasProcAddrTable(version, byref(_Ras)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.Ras = _Ras
+
+        # attach function interface to function address
+        self.zesRasGetProperties = _zesRasGetProperties_t(self.__dditable.Ras.pfnGetProperties)
+        self.zesRasGetConfig = _zesRasGetConfig_t(self.__dditable.Ras.pfnGetConfig)
+        self.zesRasSetConfig = _zesRasSetConfig_t(self.__dditable.Ras.pfnSetConfig)
+        self.zesRasGetState = _zesRasGetState_t(self.__dditable.Ras.pfnGetState)
+
+        # call driver to get function pointers
+        _RasExp = _zes_ras_exp_dditable_t()
+        r = ze_result_v(self.__dll.zesGetRasExpProcAddrTable(version, byref(_RasExp)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.RasExp = _RasExp
+
+        # attach function interface to function address
+        self.zesRasGetStateExp = _zesRasGetStateExp_t(self.__dditable.RasExp.pfnGetStateExp)
+        self.zesRasClearStateExp = _zesRasClearStateExp_t(self.__dditable.RasExp.pfnClearStateExp)
+
+        # call driver to get function pointers
+        _Diagnostics = _zes_diagnostics_dditable_t()
+        r = ze_result_v(self.__dll.zesGetDiagnosticsProcAddrTable(version, byref(_Diagnostics)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.Diagnostics = _Diagnostics
+
+        # attach function interface to function address
+        self.zesDiagnosticsGetProperties = _zesDiagnosticsGetProperties_t(self.__dditable.Diagnostics.pfnGetProperties)
+        self.zesDiagnosticsGetTests = _zesDiagnosticsGetTests_t(self.__dditable.Diagnostics.pfnGetTests)
+        self.zesDiagnosticsRunTests = _zesDiagnosticsRunTests_t(self.__dditable.Diagnostics.pfnRunTests)
+
+        # call driver to get function pointers
+        _VFManagementExp = _zes_vf_management_exp_dditable_t()
+        r = ze_result_v(self.__dll.zesGetVFManagementExpProcAddrTable(version, byref(_VFManagementExp)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.VFManagementExp = _VFManagementExp
+
+        # attach function interface to function address
+        self.zesVFManagementGetVFPropertiesExp = _zesVFManagementGetVFPropertiesExp_t(self.__dditable.VFManagementExp.pfnGetVFPropertiesExp)
+        self.zesVFManagementGetVFMemoryUtilizationExp = _zesVFManagementGetVFMemoryUtilizationExp_t(self.__dditable.VFManagementExp.pfnGetVFMemoryUtilizationExp)
+        self.zesVFManagementGetVFEngineUtilizationExp = _zesVFManagementGetVFEngineUtilizationExp_t(self.__dditable.VFManagementExp.pfnGetVFEngineUtilizationExp)
+        self.zesVFManagementSetVFTelemetryModeExp = _zesVFManagementSetVFTelemetryModeExp_t(self.__dditable.VFManagementExp.pfnSetVFTelemetryModeExp)
+        self.zesVFManagementSetVFTelemetrySamplingIntervalExp = _zesVFManagementSetVFTelemetrySamplingIntervalExp_t(self.__dditable.VFManagementExp.pfnSetVFTelemetrySamplingIntervalExp)
+        self.zesVFManagementGetVFCapabilitiesExp = _zesVFManagementGetVFCapabilitiesExp_t(self.__dditable.VFManagementExp.pfnGetVFCapabilitiesExp)
+        self.zesVFManagementGetVFMemoryUtilizationExp2 = _zesVFManagementGetVFMemoryUtilizationExp2_t(self.__dditable.VFManagementExp.pfnGetVFMemoryUtilizationExp2)
+        self.zesVFManagementGetVFEngineUtilizationExp2 = _zesVFManagementGetVFEngineUtilizationExp2_t(self.__dditable.VFManagementExp.pfnGetVFEngineUtilizationExp2)
+        self.zesVFManagementGetVFCapabilitiesExp2 = _zesVFManagementGetVFCapabilitiesExp2_t(self.__dditable.VFManagementExp.pfnGetVFCapabilitiesExp2)
+
+        # success!

--- a/include/level_zero/zes_api.h
+++ b/include/level_zero/zes_api.h
@@ -1,0 +1,7556 @@
+/*
+ *
+ * Copyright (C) 2019-2021 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file zes_api.h
+ * @version v1.12-r1.12.15
+ *
+ */
+#ifndef _ZES_API_H
+#define _ZES_API_H
+#if defined(__cplusplus)
+#pragma once
+#endif
+
+// 'core' API headers
+#include "ze_api.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+// Intel 'oneAPI' Level-Zero Sysman API common types
+#if !defined(__GNUC__)
+#pragma region common
+#endif
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle to a driver instance
+typedef ze_driver_handle_t zes_driver_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle of device object
+typedef ze_device_handle_t zes_device_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle for a Sysman device scheduler queue
+typedef struct _zes_sched_handle_t *zes_sched_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle for a Sysman device performance factors
+typedef struct _zes_perf_handle_t *zes_perf_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle for a Sysman device power domain
+typedef struct _zes_pwr_handle_t *zes_pwr_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle for a Sysman device frequency domain
+typedef struct _zes_freq_handle_t *zes_freq_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle for a Sysman device engine group
+typedef struct _zes_engine_handle_t *zes_engine_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle for a Sysman device standby control
+typedef struct _zes_standby_handle_t *zes_standby_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle for a Sysman device firmware
+typedef struct _zes_firmware_handle_t *zes_firmware_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle for a Sysman device memory module
+typedef struct _zes_mem_handle_t *zes_mem_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle for a Sysman fabric port
+typedef struct _zes_fabric_port_handle_t *zes_fabric_port_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle for a Sysman device temperature sensor
+typedef struct _zes_temp_handle_t *zes_temp_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle for a Sysman device power supply
+typedef struct _zes_psu_handle_t *zes_psu_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle for a Sysman device fan
+typedef struct _zes_fan_handle_t *zes_fan_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle for a Sysman device LED
+typedef struct _zes_led_handle_t *zes_led_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle for a Sysman device RAS error set
+typedef struct _zes_ras_handle_t *zes_ras_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle for a Sysman device diagnostics test suite
+typedef struct _zes_diag_handle_t *zes_diag_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle for a Sysman device overclock domain
+typedef struct _zes_overclock_handle_t *zes_overclock_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle for a Sysman virtual function management domain
+typedef struct _zes_vf_handle_t *zes_vf_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Defines structure types
+typedef enum _zes_structure_type_t
+{
+    ZES_STRUCTURE_TYPE_DEVICE_PROPERTIES = 0x1,                             ///< ::zes_device_properties_t
+    ZES_STRUCTURE_TYPE_PCI_PROPERTIES = 0x2,                                ///< ::zes_pci_properties_t
+    ZES_STRUCTURE_TYPE_PCI_BAR_PROPERTIES = 0x3,                            ///< ::zes_pci_bar_properties_t
+    ZES_STRUCTURE_TYPE_DIAG_PROPERTIES = 0x4,                               ///< ::zes_diag_properties_t
+    ZES_STRUCTURE_TYPE_ENGINE_PROPERTIES = 0x5,                             ///< ::zes_engine_properties_t
+    ZES_STRUCTURE_TYPE_FABRIC_PORT_PROPERTIES = 0x6,                        ///< ::zes_fabric_port_properties_t
+    ZES_STRUCTURE_TYPE_FAN_PROPERTIES = 0x7,                                ///< ::zes_fan_properties_t
+    ZES_STRUCTURE_TYPE_FIRMWARE_PROPERTIES = 0x8,                           ///< ::zes_firmware_properties_t
+    ZES_STRUCTURE_TYPE_FREQ_PROPERTIES = 0x9,                               ///< ::zes_freq_properties_t
+    ZES_STRUCTURE_TYPE_LED_PROPERTIES = 0xa,                                ///< ::zes_led_properties_t
+    ZES_STRUCTURE_TYPE_MEM_PROPERTIES = 0xb,                                ///< ::zes_mem_properties_t
+    ZES_STRUCTURE_TYPE_PERF_PROPERTIES = 0xc,                               ///< ::zes_perf_properties_t
+    ZES_STRUCTURE_TYPE_POWER_PROPERTIES = 0xd,                              ///< ::zes_power_properties_t
+    ZES_STRUCTURE_TYPE_PSU_PROPERTIES = 0xe,                                ///< ::zes_psu_properties_t
+    ZES_STRUCTURE_TYPE_RAS_PROPERTIES = 0xf,                                ///< ::zes_ras_properties_t
+    ZES_STRUCTURE_TYPE_SCHED_PROPERTIES = 0x10,                             ///< ::zes_sched_properties_t
+    ZES_STRUCTURE_TYPE_SCHED_TIMEOUT_PROPERTIES = 0x11,                     ///< ::zes_sched_timeout_properties_t
+    ZES_STRUCTURE_TYPE_SCHED_TIMESLICE_PROPERTIES = 0x12,                   ///< ::zes_sched_timeslice_properties_t
+    ZES_STRUCTURE_TYPE_STANDBY_PROPERTIES = 0x13,                           ///< ::zes_standby_properties_t
+    ZES_STRUCTURE_TYPE_TEMP_PROPERTIES = 0x14,                              ///< ::zes_temp_properties_t
+    ZES_STRUCTURE_TYPE_DEVICE_STATE = 0x15,                                 ///< ::zes_device_state_t
+    ZES_STRUCTURE_TYPE_PROCESS_STATE = 0x16,                                ///< ::zes_process_state_t
+    ZES_STRUCTURE_TYPE_PCI_STATE = 0x17,                                    ///< ::zes_pci_state_t
+    ZES_STRUCTURE_TYPE_FABRIC_PORT_CONFIG = 0x18,                           ///< ::zes_fabric_port_config_t
+    ZES_STRUCTURE_TYPE_FABRIC_PORT_STATE = 0x19,                            ///< ::zes_fabric_port_state_t
+    ZES_STRUCTURE_TYPE_FAN_CONFIG = 0x1a,                                   ///< ::zes_fan_config_t
+    ZES_STRUCTURE_TYPE_FREQ_STATE = 0x1b,                                   ///< ::zes_freq_state_t
+    ZES_STRUCTURE_TYPE_OC_CAPABILITIES = 0x1c,                              ///< ::zes_oc_capabilities_t
+    ZES_STRUCTURE_TYPE_LED_STATE = 0x1d,                                    ///< ::zes_led_state_t
+    ZES_STRUCTURE_TYPE_MEM_STATE = 0x1e,                                    ///< ::zes_mem_state_t
+    ZES_STRUCTURE_TYPE_PSU_STATE = 0x1f,                                    ///< ::zes_psu_state_t
+    ZES_STRUCTURE_TYPE_BASE_STATE = 0x20,                                   ///< ::zes_base_state_t
+    ZES_STRUCTURE_TYPE_RAS_CONFIG = 0x21,                                   ///< ::zes_ras_config_t
+    ZES_STRUCTURE_TYPE_RAS_STATE = 0x22,                                    ///< ::zes_ras_state_t
+    ZES_STRUCTURE_TYPE_TEMP_CONFIG = 0x23,                                  ///< ::zes_temp_config_t
+    ZES_STRUCTURE_TYPE_PCI_BAR_PROPERTIES_1_2 = 0x24,                       ///< ::zes_pci_bar_properties_1_2_t
+    ZES_STRUCTURE_TYPE_DEVICE_ECC_DESC = 0x25,                              ///< ::zes_device_ecc_desc_t
+    ZES_STRUCTURE_TYPE_DEVICE_ECC_PROPERTIES = 0x26,                        ///< ::zes_device_ecc_properties_t
+    ZES_STRUCTURE_TYPE_POWER_LIMIT_EXT_DESC = 0x27,                         ///< ::zes_power_limit_ext_desc_t
+    ZES_STRUCTURE_TYPE_POWER_EXT_PROPERTIES = 0x28,                         ///< ::zes_power_ext_properties_t
+    ZES_STRUCTURE_TYPE_OVERCLOCK_PROPERTIES = 0x29,                         ///< ::zes_overclock_properties_t
+    ZES_STRUCTURE_TYPE_FABRIC_PORT_ERROR_COUNTERS = 0x2a,                   ///< ::zes_fabric_port_error_counters_t
+    ZES_STRUCTURE_TYPE_ENGINE_EXT_PROPERTIES = 0x2b,                        ///< ::zes_engine_ext_properties_t
+    ZES_STRUCTURE_TYPE_RESET_PROPERTIES = 0x2c,                             ///< ::zes_reset_properties_t
+    ZES_STRUCTURE_TYPE_DEVICE_EXT_PROPERTIES = 0x2d,                        ///< ::zes_device_ext_properties_t
+    ZES_STRUCTURE_TYPE_DEVICE_UUID = 0x2e,                                  ///< ::zes_uuid_t
+    ZES_STRUCTURE_TYPE_POWER_DOMAIN_EXP_PROPERTIES = 0x00020001,            ///< ::zes_power_domain_exp_properties_t
+    ZES_STRUCTURE_TYPE_MEM_BANDWIDTH_COUNTER_BITS_EXP_PROPERTIES = 0x00020002,  ///< ::zes_mem_bandwidth_counter_bits_exp_properties_t
+    ZES_STRUCTURE_TYPE_MEMORY_PAGE_OFFLINE_STATE_EXP = 0x00020003,          ///< ::zes_mem_page_offline_state_exp_t
+    ZES_STRUCTURE_TYPE_SUBDEVICE_EXP_PROPERTIES = 0x00020004,               ///< ::zes_subdevice_exp_properties_t
+    ZES_STRUCTURE_TYPE_VF_EXP_PROPERTIES = 0x00020005,                      ///< ::zes_vf_exp_properties_t
+    ZES_STRUCTURE_TYPE_VF_UTIL_MEM_EXP = 0x00020006,                        ///< ::zes_vf_util_mem_exp_t
+    ZES_STRUCTURE_TYPE_VF_UTIL_ENGINE_EXP = 0x00020007,                     ///< ::zes_vf_util_engine_exp_t
+    ZES_STRUCTURE_TYPE_VF_EXP_CAPABILITIES = 0x00020008,                    ///< ::zes_vf_exp_capabilities_t
+    ZES_STRUCTURE_TYPE_VF_UTIL_MEM_EXP2 = 0x00020009,                       ///< ::zes_vf_util_mem_exp2_t
+    ZES_STRUCTURE_TYPE_VF_UTIL_ENGINE_EXP2 = 0x00020010,                    ///< ::zes_vf_util_engine_exp2_t
+    ZES_STRUCTURE_TYPE_VF_EXP2_CAPABILITIES = 0x00020011,                   ///< ::zes_vf_exp2_capabilities_t
+    ZES_STRUCTURE_TYPE_FORCE_UINT32 = 0x7fffffff
+
+} zes_structure_type_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Base for all properties types
+typedef struct _zes_base_properties_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+
+} zes_base_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Base for all descriptor types
+typedef struct _zes_base_desc_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+
+} zes_base_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Base for all state types
+typedef struct _zes_base_state_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+
+} zes_base_state_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Base for all config types
+typedef struct _zes_base_config_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+
+} zes_base_config_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Base for all capability types
+typedef struct _zes_base_capability_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+
+} zes_base_capability_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_base_properties_t
+typedef struct _zes_base_properties_t zes_base_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_base_desc_t
+typedef struct _zes_base_desc_t zes_base_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_base_state_t
+typedef struct _zes_base_state_t zes_base_state_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_base_config_t
+typedef struct _zes_base_config_t zes_base_config_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_base_capability_t
+typedef struct _zes_base_capability_t zes_base_capability_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_driver_extension_properties_t
+typedef struct _zes_driver_extension_properties_t zes_driver_extension_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_device_state_t
+typedef struct _zes_device_state_t zes_device_state_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_reset_properties_t
+typedef struct _zes_reset_properties_t zes_reset_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_uuid_t
+typedef struct _zes_uuid_t zes_uuid_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_device_properties_t
+typedef struct _zes_device_properties_t zes_device_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_device_ext_properties_t
+typedef struct _zes_device_ext_properties_t zes_device_ext_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_process_state_t
+typedef struct _zes_process_state_t zes_process_state_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_pci_address_t
+typedef struct _zes_pci_address_t zes_pci_address_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_pci_speed_t
+typedef struct _zes_pci_speed_t zes_pci_speed_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_pci_properties_t
+typedef struct _zes_pci_properties_t zes_pci_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_pci_state_t
+typedef struct _zes_pci_state_t zes_pci_state_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_pci_bar_properties_t
+typedef struct _zes_pci_bar_properties_t zes_pci_bar_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_pci_bar_properties_1_2_t
+typedef struct _zes_pci_bar_properties_1_2_t zes_pci_bar_properties_1_2_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_pci_stats_t
+typedef struct _zes_pci_stats_t zes_pci_stats_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_overclock_properties_t
+typedef struct _zes_overclock_properties_t zes_overclock_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_control_property_t
+typedef struct _zes_control_property_t zes_control_property_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_vf_property_t
+typedef struct _zes_vf_property_t zes_vf_property_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_diag_test_t
+typedef struct _zes_diag_test_t zes_diag_test_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_diag_properties_t
+typedef struct _zes_diag_properties_t zes_diag_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_device_ecc_desc_t
+typedef struct _zes_device_ecc_desc_t zes_device_ecc_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_device_ecc_properties_t
+typedef struct _zes_device_ecc_properties_t zes_device_ecc_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_engine_properties_t
+typedef struct _zes_engine_properties_t zes_engine_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_engine_stats_t
+typedef struct _zes_engine_stats_t zes_engine_stats_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_fabric_port_id_t
+typedef struct _zes_fabric_port_id_t zes_fabric_port_id_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_fabric_port_speed_t
+typedef struct _zes_fabric_port_speed_t zes_fabric_port_speed_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_fabric_port_properties_t
+typedef struct _zes_fabric_port_properties_t zes_fabric_port_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_fabric_link_type_t
+typedef struct _zes_fabric_link_type_t zes_fabric_link_type_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_fabric_port_config_t
+typedef struct _zes_fabric_port_config_t zes_fabric_port_config_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_fabric_port_state_t
+typedef struct _zes_fabric_port_state_t zes_fabric_port_state_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_fabric_port_throughput_t
+typedef struct _zes_fabric_port_throughput_t zes_fabric_port_throughput_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_fabric_port_error_counters_t
+typedef struct _zes_fabric_port_error_counters_t zes_fabric_port_error_counters_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_fan_speed_t
+typedef struct _zes_fan_speed_t zes_fan_speed_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_fan_temp_speed_t
+typedef struct _zes_fan_temp_speed_t zes_fan_temp_speed_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_fan_speed_table_t
+typedef struct _zes_fan_speed_table_t zes_fan_speed_table_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_fan_properties_t
+typedef struct _zes_fan_properties_t zes_fan_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_fan_config_t
+typedef struct _zes_fan_config_t zes_fan_config_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_firmware_properties_t
+typedef struct _zes_firmware_properties_t zes_firmware_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_freq_properties_t
+typedef struct _zes_freq_properties_t zes_freq_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_freq_range_t
+typedef struct _zes_freq_range_t zes_freq_range_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_freq_state_t
+typedef struct _zes_freq_state_t zes_freq_state_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_freq_throttle_time_t
+typedef struct _zes_freq_throttle_time_t zes_freq_throttle_time_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_oc_capabilities_t
+typedef struct _zes_oc_capabilities_t zes_oc_capabilities_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_led_properties_t
+typedef struct _zes_led_properties_t zes_led_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_led_color_t
+typedef struct _zes_led_color_t zes_led_color_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_led_state_t
+typedef struct _zes_led_state_t zes_led_state_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_mem_properties_t
+typedef struct _zes_mem_properties_t zes_mem_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_mem_state_t
+typedef struct _zes_mem_state_t zes_mem_state_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_mem_bandwidth_t
+typedef struct _zes_mem_bandwidth_t zes_mem_bandwidth_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_mem_ext_bandwidth_t
+typedef struct _zes_mem_ext_bandwidth_t zes_mem_ext_bandwidth_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_perf_properties_t
+typedef struct _zes_perf_properties_t zes_perf_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_power_properties_t
+typedef struct _zes_power_properties_t zes_power_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_power_energy_counter_t
+typedef struct _zes_power_energy_counter_t zes_power_energy_counter_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_power_sustained_limit_t
+typedef struct _zes_power_sustained_limit_t zes_power_sustained_limit_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_power_burst_limit_t
+typedef struct _zes_power_burst_limit_t zes_power_burst_limit_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_power_peak_limit_t
+typedef struct _zes_power_peak_limit_t zes_power_peak_limit_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_energy_threshold_t
+typedef struct _zes_energy_threshold_t zes_energy_threshold_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_psu_properties_t
+typedef struct _zes_psu_properties_t zes_psu_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_psu_state_t
+typedef struct _zes_psu_state_t zes_psu_state_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_ras_properties_t
+typedef struct _zes_ras_properties_t zes_ras_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_ras_state_t
+typedef struct _zes_ras_state_t zes_ras_state_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_ras_config_t
+typedef struct _zes_ras_config_t zes_ras_config_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_sched_properties_t
+typedef struct _zes_sched_properties_t zes_sched_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_sched_timeout_properties_t
+typedef struct _zes_sched_timeout_properties_t zes_sched_timeout_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_sched_timeslice_properties_t
+typedef struct _zes_sched_timeslice_properties_t zes_sched_timeslice_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_standby_properties_t
+typedef struct _zes_standby_properties_t zes_standby_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_temp_properties_t
+typedef struct _zes_temp_properties_t zes_temp_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_temp_threshold_t
+typedef struct _zes_temp_threshold_t zes_temp_threshold_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_temp_config_t
+typedef struct _zes_temp_config_t zes_temp_config_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_power_limit_ext_desc_t
+typedef struct _zes_power_limit_ext_desc_t zes_power_limit_ext_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_power_ext_properties_t
+typedef struct _zes_power_ext_properties_t zes_power_ext_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_engine_ext_properties_t
+typedef struct _zes_engine_ext_properties_t zes_engine_ext_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_ras_state_exp_t
+typedef struct _zes_ras_state_exp_t zes_ras_state_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_mem_page_offline_state_exp_t
+typedef struct _zes_mem_page_offline_state_exp_t zes_mem_page_offline_state_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_mem_bandwidth_counter_bits_exp_properties_t
+typedef struct _zes_mem_bandwidth_counter_bits_exp_properties_t zes_mem_bandwidth_counter_bits_exp_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_power_domain_exp_properties_t
+typedef struct _zes_power_domain_exp_properties_t zes_power_domain_exp_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_subdevice_exp_properties_t
+typedef struct _zes_subdevice_exp_properties_t zes_subdevice_exp_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_vf_exp_properties_t
+typedef struct _zes_vf_exp_properties_t zes_vf_exp_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_vf_util_mem_exp_t
+typedef struct _zes_vf_util_mem_exp_t zes_vf_util_mem_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_vf_util_engine_exp_t
+typedef struct _zes_vf_util_engine_exp_t zes_vf_util_engine_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_vf_exp_capabilities_t
+typedef struct _zes_vf_exp_capabilities_t zes_vf_exp_capabilities_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_vf_exp2_capabilities_t
+typedef struct _zes_vf_exp2_capabilities_t zes_vf_exp2_capabilities_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_vf_util_mem_exp2_t
+typedef struct _zes_vf_util_mem_exp2_t zes_vf_util_mem_exp2_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zes_vf_util_engine_exp2_t
+typedef struct _zes_vf_util_engine_exp2_t zes_vf_util_engine_exp2_t;
+
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Tool APIs for System Resource Management (Sysman)
+#if !defined(__GNUC__)
+#pragma region driver
+#endif
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported sysman initialization flags
+typedef uint32_t zes_init_flags_t;
+typedef enum _zes_init_flag_t
+{
+    ZES_INIT_FLAG_PLACEHOLDER = ZE_BIT(0),                                  ///< placeholder for future use
+    ZES_INIT_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} zes_init_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Initialize 'oneAPI' System Resource Management (sysman)
+/// 
+/// @details
+///     - The application must call this function or ::zeInit with the
+///       ::ZES_ENABLE_SYSMAN environment variable set before calling any other
+///       sysman function.
+///     - If this function is not called then all other sysman functions will
+///       return ::ZE_RESULT_ERROR_UNINITIALIZED.
+///     - This function will only initialize sysman. To initialize other
+///       functions, call ::zeInit.
+///     - There is no requirement to call this function before or after
+///       ::zeInit.
+///     - Only one instance of sysman will be initialized per process.
+///     - The application must call this function after forking new processes.
+///       Each forked process must call this function.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function must be thread-safe for scenarios
+///       where multiple libraries may initialize sysman simultaneously.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `0x1 < flags`
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesInit(
+    zes_init_flags_t flags                                                  ///< [in] initialization flags.
+                                                                            ///< currently unused, must be 0 (default).
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves sysman driver instances
+/// 
+/// @details
+///     - A sysman driver represents a collection of physical devices.
+///     - Multiple calls to this function will return identical sysman driver
+///       handles, in the same order.
+///     - The application may pass nullptr for pDrivers when only querying the
+///       number of sysman drivers.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDriverGet(
+    uint32_t* pCount,                                                       ///< [in,out] pointer to the number of sysman driver instances.
+                                                                            ///< if count is zero, then the loader shall update the value with the
+                                                                            ///< total number of sysman drivers available.
+                                                                            ///< if count is greater than the number of sysman drivers available, then
+                                                                            ///< the loader shall update the value with the correct number of sysman
+                                                                            ///< drivers available.
+    zes_driver_handle_t* phDrivers                                          ///< [in,out][optional][range(0, *pCount)] array of sysman driver instance handles.
+                                                                            ///< if count is less than the number of sysman drivers available, then the
+                                                                            ///< loader shall only retrieve that number of sysman drivers.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZES_MAX_EXTENSION_NAME
+/// @brief Maximum extension name string size
+#define ZES_MAX_EXTENSION_NAME  256
+#endif // ZES_MAX_EXTENSION_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Extension properties queried using ::zesDriverGetExtensionProperties
+typedef struct _zes_driver_extension_properties_t
+{
+    char name[ZES_MAX_EXTENSION_NAME];                                      ///< [out] extension name
+    uint32_t version;                                                       ///< [out] extension version using ::ZE_MAKE_VERSION
+
+} zes_driver_extension_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves extension properties
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDriver`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDriverGetExtensionProperties(
+    zes_driver_handle_t hDriver,                                            ///< [in] handle of the driver instance
+    uint32_t* pCount,                                                       ///< [in,out] pointer to the number of extension properties.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of extension properties available.
+                                                                            ///< if count is greater than the number of extension properties available,
+                                                                            ///< then the driver shall update the value with the correct number of
+                                                                            ///< extension properties available.
+    zes_driver_extension_properties_t* pExtensionProperties                 ///< [in,out][optional][range(0, *pCount)] array of query results for
+                                                                            ///< extension properties.
+                                                                            ///< if count is less than the number of extension properties available,
+                                                                            ///< then driver shall only retrieve that number of extension properties.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves function pointer for vendor-specific or experimental
+///        extensions
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDriver`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == name`
+///         + `nullptr == ppFunctionAddress`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDriverGetExtensionFunctionAddress(
+    zes_driver_handle_t hDriver,                                            ///< [in] handle of the driver instance
+    const char* name,                                                       ///< [in] extension function name
+    void** ppFunctionAddress                                                ///< [out] pointer to function pointer
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Tool APIs for System Resource Management (Sysman) - Device management
+#if !defined(__GNUC__)
+#pragma region device
+#endif
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves sysman devices within a sysman driver
+/// 
+/// @details
+///     - Multiple calls to this function will return identical sysman device
+///       handles, in the same order.
+///     - The number and order of handles returned from this function is NOT
+///       affected by the ::ZE_AFFINITY_MASK, ::ZE_ENABLE_PCI_ID_DEVICE_ORDER,
+///       or ::ZE_FLAT_DEVICE_HIERARCHY environment variables.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDriver`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDeviceGet(
+    zes_driver_handle_t hDriver,                                            ///< [in] handle of the sysman driver instance
+    uint32_t* pCount,                                                       ///< [in,out] pointer to the number of sysman devices.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of sysman devices available.
+                                                                            ///< if count is greater than the number of sysman devices available, then
+                                                                            ///< the driver shall update the value with the correct number of sysman
+                                                                            ///< devices available.
+    zes_device_handle_t* phDevices                                          ///< [in,out][optional][range(0, *pCount)] array of handle of sysman devices.
+                                                                            ///< if count is less than the number of sysman devices available, then
+                                                                            ///< driver shall only retrieve that number of sysman devices.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZES_STRING_PROPERTY_SIZE
+/// @brief Maximum number of characters in string properties.
+#define ZES_STRING_PROPERTY_SIZE  64
+#endif // ZES_STRING_PROPERTY_SIZE
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZES_MAX_UUID_SIZE
+/// @brief Maximum device universal unique id (UUID) size in bytes.
+#define ZES_MAX_UUID_SIZE  16
+#endif // ZES_MAX_UUID_SIZE
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Types of accelerator engines
+typedef uint32_t zes_engine_type_flags_t;
+typedef enum _zes_engine_type_flag_t
+{
+    ZES_ENGINE_TYPE_FLAG_OTHER = ZE_BIT(0),                                 ///< Undefined types of accelerators.
+    ZES_ENGINE_TYPE_FLAG_COMPUTE = ZE_BIT(1),                               ///< Engines that process compute kernels only (no 3D content).
+    ZES_ENGINE_TYPE_FLAG_3D = ZE_BIT(2),                                    ///< Engines that process 3D content only (no compute kernels).
+    ZES_ENGINE_TYPE_FLAG_MEDIA = ZE_BIT(3),                                 ///< Engines that process media workloads.
+    ZES_ENGINE_TYPE_FLAG_DMA = ZE_BIT(4),                                   ///< Engines that copy blocks of data.
+    ZES_ENGINE_TYPE_FLAG_RENDER = ZE_BIT(5),                                ///< Engines that can process both 3D content and compute kernels.
+    ZES_ENGINE_TYPE_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} zes_engine_type_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Device repair status
+typedef enum _zes_repair_status_t
+{
+    ZES_REPAIR_STATUS_UNSUPPORTED = 0,                                      ///< The device does not support in-field repairs.
+    ZES_REPAIR_STATUS_NOT_PERFORMED = 1,                                    ///< The device has never been repaired.
+    ZES_REPAIR_STATUS_PERFORMED = 2,                                        ///< The device has been repaired.
+    ZES_REPAIR_STATUS_FORCE_UINT32 = 0x7fffffff
+
+} zes_repair_status_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Device reset reasons
+typedef uint32_t zes_reset_reason_flags_t;
+typedef enum _zes_reset_reason_flag_t
+{
+    ZES_RESET_REASON_FLAG_WEDGED = ZE_BIT(0),                               ///< The device needs to be reset because one or more parts of the hardware
+                                                                            ///< is wedged
+    ZES_RESET_REASON_FLAG_REPAIR = ZE_BIT(1),                               ///< The device needs to be reset in order to complete in-field repairs
+    ZES_RESET_REASON_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} zes_reset_reason_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Device reset type
+typedef enum _zes_reset_type_t
+{
+    ZES_RESET_TYPE_WARM = 0,                                                ///< Apply warm reset
+    ZES_RESET_TYPE_COLD = 1,                                                ///< Apply cold reset
+    ZES_RESET_TYPE_FLR = 2,                                                 ///< Apply FLR reset
+    ZES_RESET_TYPE_FORCE_UINT32 = 0x7fffffff
+
+} zes_reset_type_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Device state
+typedef struct _zes_device_state_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    zes_reset_reason_flags_t reset;                                         ///< [out] Indicates if the device needs to be reset and for what reasons.
+                                                                            ///< returns 0 (none) or combination of ::zes_reset_reason_flag_t
+    zes_repair_status_t repaired;                                           ///< [out] Indicates if the device has been repaired
+
+} zes_device_state_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Device reset properties
+typedef struct _zes_reset_properties_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_bool_t force;                                                        ///< [in] If set to true, all applications that are currently using the
+                                                                            ///< device will be forcibly killed.
+    zes_reset_type_t resetType;                                             ///< [in] Type of reset needs to be performed
+
+} zes_reset_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Device universal unique id (UUID)
+typedef struct _zes_uuid_t
+{
+    uint8_t id[ZES_MAX_UUID_SIZE];                                          ///< [out] opaque data representing a device UUID
+
+} zes_uuid_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported device types
+typedef enum _zes_device_type_t
+{
+    ZES_DEVICE_TYPE_GPU = 1,                                                ///< Graphics Processing Unit
+    ZES_DEVICE_TYPE_CPU = 2,                                                ///< Central Processing Unit
+    ZES_DEVICE_TYPE_FPGA = 3,                                               ///< Field Programmable Gate Array
+    ZES_DEVICE_TYPE_MCA = 4,                                                ///< Memory Copy Accelerator
+    ZES_DEVICE_TYPE_VPU = 5,                                                ///< Vision Processing Unit
+    ZES_DEVICE_TYPE_FORCE_UINT32 = 0x7fffffff
+
+} zes_device_type_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported device property flags
+typedef uint32_t zes_device_property_flags_t;
+typedef enum _zes_device_property_flag_t
+{
+    ZES_DEVICE_PROPERTY_FLAG_INTEGRATED = ZE_BIT(0),                        ///< Device is integrated with the Host.
+    ZES_DEVICE_PROPERTY_FLAG_SUBDEVICE = ZE_BIT(1),                         ///< Device handle used for query represents a sub-device.
+    ZES_DEVICE_PROPERTY_FLAG_ECC = ZE_BIT(2),                               ///< Device supports error correction memory access.
+    ZES_DEVICE_PROPERTY_FLAG_ONDEMANDPAGING = ZE_BIT(3),                    ///< Device supports on-demand page-faulting.
+    ZES_DEVICE_PROPERTY_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} zes_device_property_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Device properties
+typedef struct _zes_device_properties_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_device_properties_t core;                                            ///< [out] (Deprecated, use ::zes_uuid_t in the extended structure) Core
+                                                                            ///< device properties
+    uint32_t numSubdevices;                                                 ///< [out] Number of sub-devices. A value of 0 indicates that this device
+                                                                            ///< doesn't have sub-devices.
+    char serialNumber[ZES_STRING_PROPERTY_SIZE];                            ///< [out] Manufacturing serial number (NULL terminated string value). This
+                                                                            ///< value is intended to reflect the Part ID/SoC ID assigned by
+                                                                            ///< manufacturer that is unique for a SoC. Will be set to the string
+                                                                            ///< "unknown" if this cannot be determined for the device.
+    char boardNumber[ZES_STRING_PROPERTY_SIZE];                             ///< [out] Manufacturing board number (NULL terminated string value).
+                                                                            ///< Alternatively "boardSerialNumber", this value is intended to reflect
+                                                                            ///< the string printed on board label by manufacturer. Will be set to the
+                                                                            ///< string "unknown" if this cannot be determined for the device.
+    char brandName[ZES_STRING_PROPERTY_SIZE];                               ///< [out] Brand name of the device (NULL terminated string value). Will be
+                                                                            ///< set to the string "unknown" if this cannot be determined for the
+                                                                            ///< device.
+    char modelName[ZES_STRING_PROPERTY_SIZE];                               ///< [out] Model name of the device (NULL terminated string value). Will be
+                                                                            ///< set to the string "unknown" if this cannot be determined for the
+                                                                            ///< device.
+    char vendorName[ZES_STRING_PROPERTY_SIZE];                              ///< [out] Vendor name of the device (NULL terminated string value). Will
+                                                                            ///< be set to the string "unknown" if this cannot be determined for the
+                                                                            ///< device.
+    char driverVersion[ZES_STRING_PROPERTY_SIZE];                           ///< [out] Installed driver version (NULL terminated string value). Will be
+                                                                            ///< set to the string "unknown" if this cannot be determined for the
+                                                                            ///< device.
+
+} zes_device_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Device properties
+typedef struct _zes_device_ext_properties_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    zes_uuid_t uuid;                                                        ///< [out] universal unique identifier. Note: uuid obtained from Sysman API
+                                                                            ///< is the same as from core API. Subdevices will have their own uuid.
+    zes_device_type_t type;                                                 ///< [out] generic device type
+    zes_device_property_flags_t flags;                                      ///< [out] 0 (none) or a valid combination of ::zes_device_property_flag_t
+
+} zes_device_ext_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get properties about the device
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pProperties`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDeviceGetProperties(
+    zes_device_handle_t hDevice,                                            ///< [in] Sysman handle of the device.
+    zes_device_properties_t* pProperties                                    ///< [in,out] Structure that will contain information about the device.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get information about the state of the device - if a reset is
+///        required, reasons for the reset and if the device has been repaired
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pState`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDeviceGetState(
+    zes_device_handle_t hDevice,                                            ///< [in] Sysman handle of the device.
+    zes_device_state_t* pState                                              ///< [in,out] Structure that will contain information about the device.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Reset device
+/// 
+/// @details
+///     - Performs a PCI bus reset of the device. This will result in all
+///       current device state being lost.
+///     - All applications using the device should be stopped before calling
+///       this function.
+///     - If the force argument is specified, all applications using the device
+///       will be forcibly killed.
+///     - The function will block until the device has restarted or an
+///       implementation defined timeout occurred waiting for the reset to
+///       complete.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS
+///         + User does not have permissions to perform this operation.
+///     - ::ZE_RESULT_ERROR_HANDLE_OBJECT_IN_USE
+///         + Reset cannot be performed because applications are using this device.
+///     - ::ZE_RESULT_ERROR_UNKNOWN
+///         + There were problems unloading the device driver, performing a bus reset or reloading the device driver.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDeviceReset(
+    zes_device_handle_t hDevice,                                            ///< [in] Sysman handle for the device
+    ze_bool_t force                                                         ///< [in] If set to true, all applications that are currently using the
+                                                                            ///< device will be forcibly killed.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Reset device extension
+/// 
+/// @details
+///     - Performs a PCI bus reset of the device. This will result in all
+///       current device state being lost.
+///     - Prior to calling this function, user is responsible for closing
+///       applications using the device unless force argument is specified.
+///     - If the force argument is specified, all applications using the device
+///       will be forcibly killed.
+///     - The function will block until the device has restarted or a
+///       implementation specific timeout occurred waiting for the reset to
+///       complete.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pProperties`
+///     - ::ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS
+///         + User does not have permissions to perform this operation.
+///     - ::ZE_RESULT_ERROR_HANDLE_OBJECT_IN_USE
+///         + Reset cannot be performed because applications are using this device.
+///     - ::ZE_RESULT_ERROR_UNKNOWN
+///         + There were problems unloading the device driver, performing a bus reset or reloading the device driver.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDeviceResetExt(
+    zes_device_handle_t hDevice,                                            ///< [in] Sysman handle for the device
+    zes_reset_properties_t* pProperties                                     ///< [in] Device reset properties to apply
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Contains information about a process that has an open connection with
+///        this device
+/// 
+/// @details
+///     - The application can use the process ID to query the OS for the owner
+///       and the path to the executable.
+typedef struct _zes_process_state_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    uint32_t processId;                                                     ///< [out] Host OS process ID.
+    uint64_t memSize;                                                       ///< [out] Device memory size in bytes allocated by this process (may not
+                                                                            ///< necessarily be resident on the device at the time of reading).
+    uint64_t sharedSize;                                                    ///< [out] The size of shared device memory mapped into this process (may
+                                                                            ///< not necessarily be resident on the device at the time of reading).
+    zes_engine_type_flags_t engines;                                        ///< [out] Bitfield of accelerator engine types being used by this process.
+
+} zes_process_state_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get information about host processes using the device
+/// 
+/// @details
+///     - The number of processes connected to the device is dynamic. This means
+///       that between a call to determine the value of pCount and the
+///       subsequent call, the number of processes may have increased or
+///       decreased. It is recommended that a large array be passed in so as to
+///       avoid receiving the error ::ZE_RESULT_ERROR_INVALID_SIZE. Also, always
+///       check the returned value in pCount since it may be less than the
+///       earlier call to get the required array size.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+///     - ::ZE_RESULT_ERROR_INVALID_SIZE
+///         + The provided value of pCount is not big enough to store information about all the processes currently attached to the device.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDeviceProcessesGetState(
+    zes_device_handle_t hDevice,                                            ///< [in] Sysman handle for the device
+    uint32_t* pCount,                                                       ///< [in,out] pointer to the number of processes.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of processes currently attached to the device.
+                                                                            ///< if count is greater than the number of processes currently attached to
+                                                                            ///< the device, then the driver shall update the value with the correct
+                                                                            ///< number of processes.
+    zes_process_state_t* pProcesses                                         ///< [in,out][optional][range(0, *pCount)] array of process information.
+                                                                            ///< if count is less than the number of processes currently attached to
+                                                                            ///< the device, then the driver shall only retrieve information about that
+                                                                            ///< number of processes. In this case, the return code will ::ZE_RESULT_ERROR_INVALID_SIZE.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief PCI address
+typedef struct _zes_pci_address_t
+{
+    uint32_t domain;                                                        ///< [out] BDF domain
+    uint32_t bus;                                                           ///< [out] BDF bus
+    uint32_t device;                                                        ///< [out] BDF device
+    uint32_t function;                                                      ///< [out] BDF function
+
+} zes_pci_address_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief PCI speed
+typedef struct _zes_pci_speed_t
+{
+    int32_t gen;                                                            ///< [out] The link generation. A value of -1 means that this property is
+                                                                            ///< unknown.
+    int32_t width;                                                          ///< [out] The number of lanes. A value of -1 means that this property is
+                                                                            ///< unknown.
+    int64_t maxBandwidth;                                                   ///< [out] The maximum bandwidth in bytes/sec (sum of all lanes). A value
+                                                                            ///< of -1 means that this property is unknown.
+
+} zes_pci_speed_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Static PCI properties
+typedef struct _zes_pci_properties_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    zes_pci_address_t address;                                              ///< [out] The BDF address
+    zes_pci_speed_t maxSpeed;                                               ///< [out] Fastest port configuration supported by the device (sum of all
+                                                                            ///< lanes)
+    ze_bool_t haveBandwidthCounters;                                        ///< [out] Indicates whether the `rxCounter` and `txCounter` members of
+                                                                            ///< ::zes_pci_stats_t will have valid values
+    ze_bool_t havePacketCounters;                                           ///< [out] Indicates whether the `packetCounter` member of
+                                                                            ///< ::zes_pci_stats_t will have a valid value
+    ze_bool_t haveReplayCounters;                                           ///< [out] Indicates whether the `replayCounter` member of
+                                                                            ///< ::zes_pci_stats_t will have a valid value
+
+} zes_pci_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief PCI link status
+typedef enum _zes_pci_link_status_t
+{
+    ZES_PCI_LINK_STATUS_UNKNOWN = 0,                                        ///< The link status could not be determined
+    ZES_PCI_LINK_STATUS_GOOD = 1,                                           ///< The link is up and operating as expected
+    ZES_PCI_LINK_STATUS_QUALITY_ISSUES = 2,                                 ///< The link is up but has quality and/or bandwidth degradation
+    ZES_PCI_LINK_STATUS_STABILITY_ISSUES = 3,                               ///< The link has stability issues and preventing workloads making forward
+                                                                            ///< progress
+    ZES_PCI_LINK_STATUS_FORCE_UINT32 = 0x7fffffff
+
+} zes_pci_link_status_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief PCI link quality degradation reasons
+typedef uint32_t zes_pci_link_qual_issue_flags_t;
+typedef enum _zes_pci_link_qual_issue_flag_t
+{
+    ZES_PCI_LINK_QUAL_ISSUE_FLAG_REPLAYS = ZE_BIT(0),                       ///< A significant number of replays are occurring
+    ZES_PCI_LINK_QUAL_ISSUE_FLAG_SPEED = ZE_BIT(1),                         ///< There is a degradation in the maximum bandwidth of the link
+    ZES_PCI_LINK_QUAL_ISSUE_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} zes_pci_link_qual_issue_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief PCI link stability issues
+typedef uint32_t zes_pci_link_stab_issue_flags_t;
+typedef enum _zes_pci_link_stab_issue_flag_t
+{
+    ZES_PCI_LINK_STAB_ISSUE_FLAG_RETRAINING = ZE_BIT(0),                    ///< Link retraining has occurred to deal with quality issues
+    ZES_PCI_LINK_STAB_ISSUE_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} zes_pci_link_stab_issue_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Dynamic PCI state
+typedef struct _zes_pci_state_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    zes_pci_link_status_t status;                                           ///< [out] The current status of the port
+    zes_pci_link_qual_issue_flags_t qualityIssues;                          ///< [out] If status is ::ZES_PCI_LINK_STATUS_QUALITY_ISSUES, 
+                                                                            ///< then this gives a combination of ::zes_pci_link_qual_issue_flag_t for
+                                                                            ///< quality issues that have been detected;
+                                                                            ///< otherwise, 0 indicates there are no quality issues with the link at
+                                                                            ///< this time."
+    zes_pci_link_stab_issue_flags_t stabilityIssues;                        ///< [out] If status is ::ZES_PCI_LINK_STATUS_STABILITY_ISSUES, 
+                                                                            ///< then this gives a combination of ::zes_pci_link_stab_issue_flag_t for
+                                                                            ///< reasons for the connection instability;
+                                                                            ///< otherwise, 0 indicates there are no connection stability issues at
+                                                                            ///< this time."
+    zes_pci_speed_t speed;                                                  ///< [out] The current port configure speed
+
+} zes_pci_state_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief PCI bar types
+typedef enum _zes_pci_bar_type_t
+{
+    ZES_PCI_BAR_TYPE_MMIO = 0,                                              ///< MMIO registers
+    ZES_PCI_BAR_TYPE_ROM = 1,                                               ///< ROM aperture
+    ZES_PCI_BAR_TYPE_MEM = 2,                                               ///< Device memory
+    ZES_PCI_BAR_TYPE_FORCE_UINT32 = 0x7fffffff
+
+} zes_pci_bar_type_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Properties of a pci bar
+typedef struct _zes_pci_bar_properties_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    zes_pci_bar_type_t type;                                                ///< [out] The type of bar
+    uint32_t index;                                                         ///< [out] The index of the bar
+    uint64_t base;                                                          ///< [out] Base address of the bar.
+    uint64_t size;                                                          ///< [out] Size of the bar.
+
+} zes_pci_bar_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Properties of a pci bar, including the resizable bar.
+typedef struct _zes_pci_bar_properties_1_2_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    zes_pci_bar_type_t type;                                                ///< [out] The type of bar
+    uint32_t index;                                                         ///< [out] The index of the bar
+    uint64_t base;                                                          ///< [out] Base address of the bar.
+    uint64_t size;                                                          ///< [out] Size of the bar.
+    ze_bool_t resizableBarSupported;                                        ///< [out] Support for Resizable Bar on this device.
+    ze_bool_t resizableBarEnabled;                                          ///< [out] Resizable Bar enabled on this device
+
+} zes_pci_bar_properties_1_2_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief PCI stats counters
+/// 
+/// @details
+///     - Percent replays is calculated by taking two snapshots (s1, s2) and
+///       using the equation: %replay = 10^6 * (s2.replayCounter -
+///       s1.replayCounter) / (s2.maxBandwidth * (s2.timestamp - s1.timestamp))
+///     - Percent throughput is calculated by taking two snapshots (s1, s2) and
+///       using the equation: %bw = 10^6 * ((s2.rxCounter - s1.rxCounter) +
+///       (s2.txCounter - s1.txCounter)) / (s2.maxBandwidth * (s2.timestamp -
+///       s1.timestamp))
+typedef struct _zes_pci_stats_t
+{
+    uint64_t timestamp;                                                     ///< [out] Monotonic timestamp counter in microseconds when the measurement
+                                                                            ///< was made.
+                                                                            ///< This timestamp should only be used to calculate delta time between
+                                                                            ///< snapshots of this structure.
+                                                                            ///< Never take the delta of this timestamp with the timestamp from a
+                                                                            ///< different structure since they are not guaranteed to have the same base.
+                                                                            ///< The absolute value of the timestamp is only valid during within the
+                                                                            ///< application and may be different on the next execution.
+    uint64_t replayCounter;                                                 ///< [out] Monotonic counter for the number of replay packets (sum of all
+                                                                            ///< lanes). Will always be 0 when the `haveReplayCounters` member of
+                                                                            ///< ::zes_pci_properties_t is FALSE.
+    uint64_t packetCounter;                                                 ///< [out] Monotonic counter for the number of packets (sum of all lanes).
+                                                                            ///< Will always be 0 when the `havePacketCounters` member of
+                                                                            ///< ::zes_pci_properties_t is FALSE.
+    uint64_t rxCounter;                                                     ///< [out] Monotonic counter for the number of bytes received (sum of all
+                                                                            ///< lanes). Will always be 0 when the `haveBandwidthCounters` member of
+                                                                            ///< ::zes_pci_properties_t is FALSE.
+    uint64_t txCounter;                                                     ///< [out] Monotonic counter for the number of bytes transmitted (including
+                                                                            ///< replays) (sum of all lanes). Will always be 0 when the
+                                                                            ///< `haveBandwidthCounters` member of ::zes_pci_properties_t is FALSE.
+    zes_pci_speed_t speed;                                                  ///< [out] The current speed of the link (sum of all lanes)
+
+} zes_pci_stats_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get PCI properties - address, max speed
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pProperties`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDevicePciGetProperties(
+    zes_device_handle_t hDevice,                                            ///< [in] Sysman handle of the device.
+    zes_pci_properties_t* pProperties                                       ///< [in,out] Will contain the PCI properties.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get current PCI state - current speed
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pState`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDevicePciGetState(
+    zes_device_handle_t hDevice,                                            ///< [in] Sysman handle of the device.
+    zes_pci_state_t* pState                                                 ///< [in,out] Will contain the PCI properties.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get information about each configured bar
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDevicePciGetBars(
+    zes_device_handle_t hDevice,                                            ///< [in] Sysman handle of the device.
+    uint32_t* pCount,                                                       ///< [in,out] pointer to the number of PCI bars.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of PCI bars that are setup.
+                                                                            ///< if count is greater than the number of PCI bars that are setup, then
+                                                                            ///< the driver shall update the value with the correct number of PCI bars.
+    zes_pci_bar_properties_t* pProperties                                   ///< [in,out][optional][range(0, *pCount)] array of information about setup
+                                                                            ///< PCI bars.
+                                                                            ///< if count is less than the number of PCI bars that are setup, then the
+                                                                            ///< driver shall only retrieve information about that number of PCI bars.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get PCI stats - bandwidth, number of packets, number of replays
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pStats`
+///     - ::ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS
+///         + User does not have permissions to query this telemetry.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDevicePciGetStats(
+    zes_device_handle_t hDevice,                                            ///< [in] Sysman handle of the device.
+    zes_pci_stats_t* pStats                                                 ///< [in,out] Will contain a snapshot of the latest stats.
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Tool APIs for System Resource Management (Sysman) - Overclock controls, VF curve manipulation
+#if !defined(__GNUC__)
+#pragma region Overclock
+#endif
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Overclock domains.
+typedef enum _zes_overclock_domain_t
+{
+    ZES_OVERCLOCK_DOMAIN_CARD = 1,                                          ///< Overclocking card level properties such as temperature limits.
+    ZES_OVERCLOCK_DOMAIN_PACKAGE = 2,                                       ///< Overclocking package level properties such as power limits.
+    ZES_OVERCLOCK_DOMAIN_GPU_ALL = 4,                                       ///< Overclocking a GPU that has all accelerator assets on the same PLL/VR.
+    ZES_OVERCLOCK_DOMAIN_GPU_RENDER_COMPUTE = 8,                            ///< Overclocking a GPU with render and compute assets on the same PLL/VR.
+    ZES_OVERCLOCK_DOMAIN_GPU_RENDER = 16,                                   ///< Overclocking a GPU with render assets on its own PLL/VR.
+    ZES_OVERCLOCK_DOMAIN_GPU_COMPUTE = 32,                                  ///< Overclocking a GPU with compute assets on its own PLL/VR.
+    ZES_OVERCLOCK_DOMAIN_GPU_MEDIA = 64,                                    ///< Overclocking a GPU with media assets on its own PLL/VR.
+    ZES_OVERCLOCK_DOMAIN_VRAM = 128,                                        ///< Overclocking device local memory.
+    ZES_OVERCLOCK_DOMAIN_ADM = 256,                                         ///< Overclocking LLC/L4 cache.
+    ZES_OVERCLOCK_DOMAIN_FORCE_UINT32 = 0x7fffffff
+
+} zes_overclock_domain_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Overclock controls.
+typedef enum _zes_overclock_control_t
+{
+    ZES_OVERCLOCK_CONTROL_VF = 1,                                           ///< This control permits setting a custom V-F curve.
+    ZES_OVERCLOCK_CONTROL_FREQ_OFFSET = 2,                                  ///< The V-F curve of the overclock domain can be shifted up or down using
+                                                                            ///< this control.
+    ZES_OVERCLOCK_CONTROL_VMAX_OFFSET = 4,                                  ///< This control is used to increase the permitted voltage above the
+                                                                            ///< shipped voltage maximum.
+    ZES_OVERCLOCK_CONTROL_FREQ = 8,                                         ///< This control permits direct changes to the operating frequency.
+    ZES_OVERCLOCK_CONTROL_VOLT_LIMIT = 16,                                  ///< This control prevents frequencies that would push the voltage above
+                                                                            ///< this value, typically used by V-F scanners.
+    ZES_OVERCLOCK_CONTROL_POWER_SUSTAINED_LIMIT = 32,                       ///< This control changes the sustained power limit (PL1).
+    ZES_OVERCLOCK_CONTROL_POWER_BURST_LIMIT = 64,                           ///< This control changes the burst power limit (PL2).
+    ZES_OVERCLOCK_CONTROL_POWER_PEAK_LIMIT = 128,                           ///< his control changes the peak power limit (PL4).
+    ZES_OVERCLOCK_CONTROL_ICCMAX_LIMIT = 256,                               ///< This control changes the value of IccMax..
+    ZES_OVERCLOCK_CONTROL_TEMP_LIMIT = 512,                                 ///< This control changes the value of TjMax.
+    ZES_OVERCLOCK_CONTROL_ITD_DISABLE = 1024,                               ///< This control permits disabling the adaptive voltage feature ITD
+    ZES_OVERCLOCK_CONTROL_ACM_DISABLE = 2048,                               ///< This control permits disabling the adaptive voltage feature ACM.
+    ZES_OVERCLOCK_CONTROL_FORCE_UINT32 = 0x7fffffff
+
+} zes_overclock_control_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Overclock modes.
+typedef enum _zes_overclock_mode_t
+{
+    ZES_OVERCLOCK_MODE_MODE_OFF = 0,                                        ///< Overclock mode is off
+    ZES_OVERCLOCK_MODE_MODE_STOCK = 2,                                      ///< Stock (manufacturing settings) are being used.
+    ZES_OVERCLOCK_MODE_MODE_ON = 3,                                         ///< Overclock mode is on.
+    ZES_OVERCLOCK_MODE_MODE_UNAVAILABLE = 4,                                ///< Overclocking is unavailable at this time since the system is running
+                                                                            ///< on battery.
+    ZES_OVERCLOCK_MODE_MODE_DISABLED = 5,                                   ///< Overclock mode is disabled.
+    ZES_OVERCLOCK_MODE_FORCE_UINT32 = 0x7fffffff
+
+} zes_overclock_mode_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Overclock control states.
+typedef enum _zes_control_state_t
+{
+    ZES_CONTROL_STATE_STATE_UNSET = 0,                                      ///< No overclock control has not been changed by the driver since the last
+                                                                            ///< boot/reset.
+    ZES_CONTROL_STATE_STATE_ACTIVE = 2,                                     ///< The overclock control has been set and it is active.
+    ZES_CONTROL_STATE_STATE_DISABLED = 3,                                   ///< The overclock control value has been disabled due to the current power
+                                                                            ///< configuration (typically when running on DC).
+    ZES_CONTROL_STATE_FORCE_UINT32 = 0x7fffffff
+
+} zes_control_state_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Overclock pending actions.
+typedef enum _zes_pending_action_t
+{
+    ZES_PENDING_ACTION_PENDING_NONE = 0,                                    ///< There no pending actions. .
+    ZES_PENDING_ACTION_PENDING_IMMINENT = 1,                                ///< The requested change is in progress and should complete soon.
+    ZES_PENDING_ACTION_PENDING_COLD_RESET = 2,                              ///< The requested change requires a device cold reset (hotplug, system
+                                                                            ///< boot).
+    ZES_PENDING_ACTION_PENDING_WARM_RESET = 3,                              ///< The requested change requires a device warm reset (PCIe FLR).
+    ZES_PENDING_ACTION_FORCE_UINT32 = 0x7fffffff
+
+} zes_pending_action_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Overclock V-F curve programing.
+typedef enum _zes_vf_program_type_t
+{
+    ZES_VF_PROGRAM_TYPE_VF_ARBITRARY = 0,                                   ///< Can program an arbitrary number of V-F points up to the maximum number
+                                                                            ///< and each point can have arbitrary voltage and frequency values within
+                                                                            ///< the min/max/step limits
+    ZES_VF_PROGRAM_TYPE_VF_FREQ_FIXED = 1,                                  ///< Can only program the voltage for the V-F points that it reads back -
+                                                                            ///< the frequency of those points cannot be changed
+    ZES_VF_PROGRAM_TYPE_VF_VOLT_FIXED = 2,                                  ///< Can only program the frequency for the V-F points that is reads back -
+                                                                            ///< the voltage of each point cannot be changed.
+    ZES_VF_PROGRAM_TYPE_FORCE_UINT32 = 0x7fffffff
+
+} zes_vf_program_type_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief VF type
+typedef enum _zes_vf_type_t
+{
+    ZES_VF_TYPE_VOLT = 0,                                                   ///< VF Voltage point
+    ZES_VF_TYPE_FREQ = 1,                                                   ///< VF Frequency point
+    ZES_VF_TYPE_FORCE_UINT32 = 0x7fffffff
+
+} zes_vf_type_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief VF type
+typedef enum _zes_vf_array_type_t
+{
+    ZES_VF_ARRAY_TYPE_USER_VF_ARRAY = 0,                                    ///< User V-F array
+    ZES_VF_ARRAY_TYPE_DEFAULT_VF_ARRAY = 1,                                 ///< Default V-F array
+    ZES_VF_ARRAY_TYPE_LIVE_VF_ARRAY = 2,                                    ///< Live V-F array
+    ZES_VF_ARRAY_TYPE_FORCE_UINT32 = 0x7fffffff
+
+} zes_vf_array_type_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Overclock properties
+/// 
+/// @details
+///     - Information on the overclock domain type and all the contols that are
+///       part of the domain.
+typedef struct _zes_overclock_properties_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    zes_overclock_domain_t domainType;                                      ///< [out] The hardware block that this overclock domain controls (GPU,
+                                                                            ///< VRAM, ...)
+    uint32_t AvailableControls;                                             ///< [out] Returns the overclock controls that are supported (a bit for
+                                                                            ///< each of enum ::zes_overclock_control_t). If no bits are set, the
+                                                                            ///< domain doesn't support overclocking.
+    zes_vf_program_type_t VFProgramType;                                    ///< [out] Type of V-F curve programming that is permitted:.
+    uint32_t NumberOfVFPoints;                                              ///< [out] Number of VF points that can be programmed - max_num_points
+
+} zes_overclock_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Overclock Control properties
+/// 
+/// @details
+///     - Provides all the control capabilities supported by the device for the
+///       overclock domain.
+typedef struct _zes_control_property_t
+{
+    double MinValue;                                                        ///< [out]  This provides information about the limits of the control value
+                                                                            ///< so that the driver can calculate the set of valid values.
+    double MaxValue;                                                        ///< [out]  This provides information about the limits of the control value
+                                                                            ///< so that the driver can calculate the set of valid values.
+    double StepValue;                                                       ///< [out]  This provides information about the limits of the control value
+                                                                            ///< so that the driver can calculate the set of valid values.
+    double RefValue;                                                        ///< [out] The reference value provides the anchor point, UIs can combine
+                                                                            ///< this with the user offset request to show the anticipated improvement.
+    double DefaultValue;                                                    ///< [out] The shipped out-of-box position of this control. Driver can
+                                                                            ///< request this value at any time to return to the out-of-box behavior.
+
+} zes_control_property_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Overclock VF properties
+/// 
+/// @details
+///     - Provides all the VF capabilities supported by the device for the
+///       overclock domain.
+typedef struct _zes_vf_property_t
+{
+    double MinFreq;                                                         ///< [out] Read the minimum frequency that can be be programmed in the
+                                                                            ///< custom V-F point..
+    double MaxFreq;                                                         ///< [out] Read the maximum frequency that can be be programmed in the
+                                                                            ///< custom V-F point..
+    double StepFreq;                                                        ///< [out] Read the frequency step that can be be programmed in the custom
+                                                                            ///< V-F point..
+    double MinVolt;                                                         ///< [out] Read the minimum voltage that can be be programmed in the custom
+                                                                            ///< V-F point..
+    double MaxVolt;                                                         ///< [out] Read the maximum voltage that can be be programmed in the custom
+                                                                            ///< V-F point..
+    double StepVolt;                                                        ///< [out] Read the voltage step that can be be programmed in the custom
+                                                                            ///< V-F point.
+
+} zes_vf_property_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Set the overclock waiver.The overclock waiver setting is persistent
+///        until the next pcode boot
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + This product does not support overclocking
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDeviceSetOverclockWaiver(
+    zes_device_handle_t hDevice                                             ///< [in] Sysman handle of the device.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get the list of supported overclock domains for this device
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pOverclockDomains`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Overclocking is not supported on this control domain
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDeviceGetOverclockDomains(
+    zes_device_handle_t hDevice,                                            ///< [in] Sysman handle of the device.
+    uint32_t* pOverclockDomains                                             ///< [in,out] Returns the overclock domains that are supported (a bit for
+                                                                            ///< each of enum ::zes_overclock_domain_t). If no bits are set, the device
+                                                                            ///< doesn't support overclocking.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get the list of supported overclock controls available for one of the
+///        supported overclock domains on the device
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::ZES_OVERCLOCK_DOMAIN_ADM < domainType`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pAvailableControls`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Overclocking is not supported on this control domain
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDeviceGetOverclockControls(
+    zes_device_handle_t hDevice,                                            ///< [in] Sysman handle of the device.
+    zes_overclock_domain_t domainType,                                      ///< [in] Domain type.
+    uint32_t* pAvailableControls                                            ///< [in,out] Returns the overclock controls that are supported for the
+                                                                            ///< specified overclock domain (a bit for each of enum
+                                                                            ///< ::zes_overclock_control_t).
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Reset all overclock settings to default values (shipped = 1 or
+///        manufacturing =0)
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Overclocking is not supported on this control domain
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDeviceResetOverclockSettings(
+    zes_device_handle_t hDevice,                                            ///< [in] Sysman handle of the device.
+    ze_bool_t onShippedState                                                ///< [in] True will reset to shipped state; false will reset to
+                                                                            ///< manufacturing state
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Determine the state of overclocking
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pOverclockMode`
+///         + `nullptr == pWaiverSetting`
+///         + `nullptr == pOverclockState`
+///         + `nullptr == pPendingAction`
+///         + `nullptr == pPendingReset`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Overclocking is not supported on this control domain
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDeviceReadOverclockState(
+    zes_device_handle_t hDevice,                                            ///< [in] Sysman handle of the device.
+    zes_overclock_mode_t* pOverclockMode,                                   ///< [out] One of overclock mode.
+    ze_bool_t* pWaiverSetting,                                              ///< [out] Waiver setting: 0 = Waiver not set, 1 = waiver has been set.
+    ze_bool_t* pOverclockState,                                             ///< [out] Current settings 0 =manufacturing state, 1= shipped state)..
+    zes_pending_action_t* pPendingAction,                                   ///< [out] This enum is returned when the driver attempts to set an
+                                                                            ///< overclock control or reset overclock settings.
+    ze_bool_t* pPendingReset                                                ///< [out] Pending reset 0 =manufacturing state, 1= shipped state)..
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get handle of overclock domains
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDeviceEnumOverclockDomains(
+    zes_device_handle_t hDevice,                                            ///< [in] Sysman handle of the device.
+    uint32_t* pCount,                                                       ///< [in,out] pointer to the number of components of this type.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of components of this type that are available.
+                                                                            ///< if count is greater than the number of components of this type that
+                                                                            ///< are available, then the driver shall update the value with the correct
+                                                                            ///< number of components.
+    zes_overclock_handle_t* phDomainHandle                                  ///< [in,out][optional][range(0, *pCount)] array of handle of components of
+                                                                            ///< this type.
+                                                                            ///< if count is less than the number of components of this type that are
+                                                                            ///< available, then the driver shall only retrieve that number of
+                                                                            ///< component handles.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get overclock domain control properties
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDomainHandle`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pDomainProperties`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Overclocking is not supported on this control domain
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesOverclockGetDomainProperties(
+    zes_overclock_handle_t hDomainHandle,                                   ///< [in] Handle for the component domain.
+    zes_overclock_properties_t* pDomainProperties                           ///< [in,out] The overclock properties for the specified domain.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Read overclock VF min,max and step values
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDomainHandle`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pVFProperties`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Overclocking is not supported on this control domain
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesOverclockGetDomainVFProperties(
+    zes_overclock_handle_t hDomainHandle,                                   ///< [in] Handle for the component domain.
+    zes_vf_property_t* pVFProperties                                        ///< [in,out] The VF min,max,step for a specified domain.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Read overclock control values - min/max/step/default/ref
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDomainHandle`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::ZES_OVERCLOCK_CONTROL_ACM_DISABLE < DomainControl`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pControlProperties`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Overclocking is not supported on this control domain
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesOverclockGetDomainControlProperties(
+    zes_overclock_handle_t hDomainHandle,                                   ///< [in] Handle for the component domain.
+    zes_overclock_control_t DomainControl,                                  ///< [in] Handle for the component.
+    zes_control_property_t* pControlProperties                              ///< [in,out] overclock control values.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Read the current value for a given overclock control
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDomainHandle`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::ZES_OVERCLOCK_CONTROL_ACM_DISABLE < DomainControl`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pValue`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Overclocking is not supported on this control domain
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesOverclockGetControlCurrentValue(
+    zes_overclock_handle_t hDomainHandle,                                   ///< [in] Handle for the component.
+    zes_overclock_control_t DomainControl,                                  ///< [in] Overclock Control.
+    double* pValue                                                          ///< [in,out] Getting overclock control value for the specified control.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Read the the reset pending value for a given overclock control
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDomainHandle`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::ZES_OVERCLOCK_CONTROL_ACM_DISABLE < DomainControl`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pValue`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Overclocking is not supported on this control domain
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesOverclockGetControlPendingValue(
+    zes_overclock_handle_t hDomainHandle,                                   ///< [in] Handle for the component domain.
+    zes_overclock_control_t DomainControl,                                  ///< [in] Overclock Control.
+    double* pValue                                                          ///< [out] Returns the pending value for a given control. The units and
+                                                                            ///< format of the value depend on the control type.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Set the value for a given overclock control
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDomainHandle`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::ZES_OVERCLOCK_CONTROL_ACM_DISABLE < DomainControl`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pPendingAction`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Overclocking is not supported on this control domain
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesOverclockSetControlUserValue(
+    zes_overclock_handle_t hDomainHandle,                                   ///< [in] Handle for the component domain.
+    zes_overclock_control_t DomainControl,                                  ///< [in] Domain Control.
+    double pValue,                                                          ///< [in] The new value of the control. The units and format of the value
+                                                                            ///< depend on the control type.
+    zes_pending_action_t* pPendingAction                                    ///< [out] Pending overclock setting.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Determine the state of an overclock control
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDomainHandle`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::ZES_OVERCLOCK_CONTROL_ACM_DISABLE < DomainControl`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pControlState`
+///         + `nullptr == pPendingAction`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Overclocking is not supported on this control domain
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesOverclockGetControlState(
+    zes_overclock_handle_t hDomainHandle,                                   ///< [in] Handle for the component domain.
+    zes_overclock_control_t DomainControl,                                  ///< [in] Domain Control.
+    zes_control_state_t* pControlState,                                     ///< [out] Current overclock control state.
+    zes_pending_action_t* pPendingAction                                    ///< [out] Pending overclock setting.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Read the frequency or voltage of a V-F point from the default or
+///        custom V-F curve.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDomainHandle`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::ZES_VF_TYPE_FREQ < VFType`
+///         + `::ZES_VF_ARRAY_TYPE_LIVE_VF_ARRAY < VFArrayType`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == PointValue`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Overclocking is not supported on this control domain
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesOverclockGetVFPointValues(
+    zes_overclock_handle_t hDomainHandle,                                   ///< [in] Handle for the component domain.
+    zes_vf_type_t VFType,                                                   ///< [in] Voltage or Freqency point to read.
+    zes_vf_array_type_t VFArrayType,                                        ///< [in] User,Default or Live VF array to read from
+    uint32_t PointIndex,                                                    ///< [in] Point index - number between (0, max_num_points - 1).
+    uint32_t* PointValue                                                    ///< [out] Returns the frequency in 1kHz units or voltage in millivolt
+                                                                            ///< units from the custom V-F curve at the specified zero-based index 
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Write the frequency or voltage of a V-F point to custom V-F curve.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDomainHandle`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::ZES_VF_TYPE_FREQ < VFType`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Overclocking is not supported on this control domain
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesOverclockSetVFPointValues(
+    zes_overclock_handle_t hDomainHandle,                                   ///< [in] Handle for the component domain.
+    zes_vf_type_t VFType,                                                   ///< [in] Voltage or Freqency point to read.
+    uint32_t PointIndex,                                                    ///< [in] Point index - number between (0, max_num_points - 1).
+    uint32_t PointValue                                                     ///< [in] Writes frequency in 1kHz units or voltage in millivolt units to
+                                                                            ///< custom V-F curve at the specified zero-based index 
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Tool APIs for System Resource Management (Sysman) - Firmware management
+#if !defined(__GNUC__)
+#pragma region diagnostics
+#endif
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Diagnostic results
+typedef enum _zes_diag_result_t
+{
+    ZES_DIAG_RESULT_NO_ERRORS = 0,                                          ///< Diagnostic completed without finding errors to repair
+    ZES_DIAG_RESULT_ABORT = 1,                                              ///< Diagnostic had problems running tests
+    ZES_DIAG_RESULT_FAIL_CANT_REPAIR = 2,                                   ///< Diagnostic had problems setting up repairs
+    ZES_DIAG_RESULT_REBOOT_FOR_REPAIR = 3,                                  ///< Diagnostics found errors, setup for repair and reboot is required to
+                                                                            ///< complete the process
+    ZES_DIAG_RESULT_FORCE_UINT32 = 0x7fffffff
+
+} zes_diag_result_t;
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZES_DIAG_FIRST_TEST_INDEX
+/// @brief Diagnostic test index to use for the very first test.
+#define ZES_DIAG_FIRST_TEST_INDEX  0x0
+#endif // ZES_DIAG_FIRST_TEST_INDEX
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZES_DIAG_LAST_TEST_INDEX
+/// @brief Diagnostic test index to use for the very last test.
+#define ZES_DIAG_LAST_TEST_INDEX  0xFFFFFFFF
+#endif // ZES_DIAG_LAST_TEST_INDEX
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Diagnostic test
+typedef struct _zes_diag_test_t
+{
+    uint32_t index;                                                         ///< [out] Index of the test
+    char name[ZES_STRING_PROPERTY_SIZE];                                    ///< [out] Name of the test
+
+} zes_diag_test_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Diagnostics test suite properties
+typedef struct _zes_diag_properties_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_bool_t onSubdevice;                                                  ///< [out] True if the resource is located on a sub-device; false means
+                                                                            ///< that the resource is on the device of the calling Sysman handle
+    uint32_t subdeviceId;                                                   ///< [out] If onSubdevice is true, this gives the ID of the sub-device
+    char name[ZES_STRING_PROPERTY_SIZE];                                    ///< [out] Name of the diagnostics test suite
+    ze_bool_t haveTests;                                                    ///< [out] Indicates if this test suite has individual tests which can be
+                                                                            ///< run separately (use the function ::zesDiagnosticsGetTests() to get the
+                                                                            ///< list of these tests)
+
+} zes_diag_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get handle of diagnostics test suites
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDeviceEnumDiagnosticTestSuites(
+    zes_device_handle_t hDevice,                                            ///< [in] Sysman handle of the device.
+    uint32_t* pCount,                                                       ///< [in,out] pointer to the number of components of this type.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of components of this type that are available.
+                                                                            ///< if count is greater than the number of components of this type that
+                                                                            ///< are available, then the driver shall update the value with the correct
+                                                                            ///< number of components.
+    zes_diag_handle_t* phDiagnostics                                        ///< [in,out][optional][range(0, *pCount)] array of handle of components of
+                                                                            ///< this type.
+                                                                            ///< if count is less than the number of components of this type that are
+                                                                            ///< available, then the driver shall only retrieve that number of
+                                                                            ///< component handles.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get properties of a diagnostics test suite
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDiagnostics`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pProperties`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDiagnosticsGetProperties(
+    zes_diag_handle_t hDiagnostics,                                         ///< [in] Handle for the component.
+    zes_diag_properties_t* pProperties                                      ///< [in,out] Structure describing the properties of a diagnostics test
+                                                                            ///< suite
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get individual tests that can be run separately. Not all test suites
+///        permit running individual tests, check the `haveTests` member of
+///        ::zes_diag_properties_t.
+/// 
+/// @details
+///     - The list of available tests is returned in order of increasing test
+///       index (see the `index` member of ::zes_diag_test_t).
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDiagnostics`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDiagnosticsGetTests(
+    zes_diag_handle_t hDiagnostics,                                         ///< [in] Handle for the component.
+    uint32_t* pCount,                                                       ///< [in,out] pointer to the number of tests.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of tests that are available.
+                                                                            ///< if count is greater than the number of tests that are available, then
+                                                                            ///< the driver shall update the value with the correct number of tests.
+    zes_diag_test_t* pTests                                                 ///< [in,out][optional][range(0, *pCount)] array of information about
+                                                                            ///< individual tests sorted by increasing value of the `index` member of ::zes_diag_test_t.
+                                                                            ///< if count is less than the number of tests that are available, then the
+                                                                            ///< driver shall only retrieve that number of tests.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Run a diagnostics test suite, either all tests or a subset of tests.
+/// 
+/// @details
+///     - WARNING: Running diagnostics may destroy current device state
+///       information. Gracefully close any running workloads before initiating.
+///     - To run all tests in a test suite, set start =
+///       ::ZES_DIAG_FIRST_TEST_INDEX and end = ::ZES_DIAG_LAST_TEST_INDEX.
+///     - If the test suite permits running individual tests, the `haveTests`
+///       member of ::zes_diag_properties_t will be true. In this case, the
+///       function ::zesDiagnosticsGetTests() can be called to get the list of
+///       tests and corresponding indices that can be supplied to the arguments
+///       start and end in this function.
+///     - This function will block until the diagnostics have completed and
+///       force reset based on result
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDiagnostics`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pResult`
+///     - ::ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS
+///         + User does not have permissions to perform diagnostics.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDiagnosticsRunTests(
+    zes_diag_handle_t hDiagnostics,                                         ///< [in] Handle for the component.
+    uint32_t startIndex,                                                    ///< [in] The index of the first test to run. Set to
+                                                                            ///< ::ZES_DIAG_FIRST_TEST_INDEX to start from the beginning.
+    uint32_t endIndex,                                                      ///< [in] The index of the last test to run. Set to
+                                                                            ///< ::ZES_DIAG_LAST_TEST_INDEX to complete all tests after the start test.
+    zes_diag_result_t* pResult                                              ///< [in,out] The result of the diagnostics
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Tool APIs for System Resource Management (Sysman) - ECC management
+#if !defined(__GNUC__)
+#pragma region ecc
+#endif
+///////////////////////////////////////////////////////////////////////////////
+/// @brief ECC State
+typedef enum _zes_device_ecc_state_t
+{
+    ZES_DEVICE_ECC_STATE_UNAVAILABLE = 0,                                   ///< None
+    ZES_DEVICE_ECC_STATE_ENABLED = 1,                                       ///< ECC enabled.
+    ZES_DEVICE_ECC_STATE_DISABLED = 2,                                      ///< ECC disabled.
+    ZES_DEVICE_ECC_STATE_FORCE_UINT32 = 0x7fffffff
+
+} zes_device_ecc_state_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief State Change Requirements
+typedef enum _zes_device_action_t
+{
+    ZES_DEVICE_ACTION_NONE = 0,                                             ///< No action.
+    ZES_DEVICE_ACTION_WARM_CARD_RESET = 1,                                  ///< Warm reset of the card.
+    ZES_DEVICE_ACTION_COLD_CARD_RESET = 2,                                  ///< Cold reset of the card.
+    ZES_DEVICE_ACTION_COLD_SYSTEM_REBOOT = 3,                               ///< Cold reboot of the system.
+    ZES_DEVICE_ACTION_FORCE_UINT32 = 0x7fffffff
+
+} zes_device_action_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief ECC State Descriptor
+typedef struct _zes_device_ecc_desc_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    zes_device_ecc_state_t state;                                           ///< [out] ECC state
+
+} zes_device_ecc_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief ECC State
+typedef struct _zes_device_ecc_properties_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    zes_device_ecc_state_t currentState;                                    ///< [out] Current ECC state
+    zes_device_ecc_state_t pendingState;                                    ///< [out] Pending ECC state
+    zes_device_action_t pendingAction;                                      ///< [out] Pending action
+
+} zes_device_ecc_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Is ECC functionality available - true or false?
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pAvailable`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDeviceEccAvailable(
+    zes_device_handle_t hDevice,                                            ///< [in] Handle for the component.
+    ze_bool_t* pAvailable                                                   ///< [out] ECC functionality is available (true)/unavailable (false).
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Is ECC support configurable - true or false?
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pConfigurable`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDeviceEccConfigurable(
+    zes_device_handle_t hDevice,                                            ///< [in] Handle for the component.
+    ze_bool_t* pConfigurable                                                ///< [out] ECC can be enabled/disabled (true)/enabled/disabled (false).
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get current ECC state, pending state, and pending action
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pState`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDeviceGetEccState(
+    zes_device_handle_t hDevice,                                            ///< [in] Handle for the component.
+    zes_device_ecc_properties_t* pState                                     ///< [out] ECC state, pending state, and pending action for state change.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Set new ECC state
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+///     - ::zesDeviceGetState should be called to determine pending action
+///       required to implement state change.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == newState`
+///         + `nullptr == pState`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::ZES_DEVICE_ECC_STATE_DISABLED < newState->state`
+///     - ::ZE_RESULT_WARNING_ACTION_REQUIRED
+///         + User must look at the pendingAction attribute of pState & perform the action required to complete the ECC state change.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDeviceSetEccState(
+    zes_device_handle_t hDevice,                                            ///< [in] Handle for the component.
+    const zes_device_ecc_desc_t* newState,                                  ///< [in] Pointer to desired ECC state.
+    zes_device_ecc_properties_t* pState                                     ///< [out] ECC state, pending state, and pending action for state change.
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Tool APIs for System Resource Management (Sysman) - Engine groups
+#if !defined(__GNUC__)
+#pragma region engine
+#endif
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Accelerator engine groups
+typedef enum _zes_engine_group_t
+{
+    ZES_ENGINE_GROUP_ALL = 0,                                               ///< Access information about all engines combined.
+    ZES_ENGINE_GROUP_COMPUTE_ALL = 1,                                       ///< Access information about all compute engines combined. Compute engines
+                                                                            ///< can only process compute kernels (no 3D content).
+    ZES_ENGINE_GROUP_MEDIA_ALL = 2,                                         ///< Access information about all media engines combined.
+    ZES_ENGINE_GROUP_COPY_ALL = 3,                                          ///< Access information about all copy (blitter) engines combined.
+    ZES_ENGINE_GROUP_COMPUTE_SINGLE = 4,                                    ///< Access information about a single compute engine - this is an engine
+                                                                            ///< that can process compute kernels. Note that single engines may share
+                                                                            ///< the same underlying accelerator resources as other engines so activity
+                                                                            ///< of such an engine may not be indicative of the underlying resource
+                                                                            ///< utilization - use ::ZES_ENGINE_GROUP_3D_RENDER_COMPUTE_ALL for that.
+    ZES_ENGINE_GROUP_RENDER_SINGLE = 5,                                     ///< Access information about a single render engine - this is an engine
+                                                                            ///< that can process both 3D content and compute kernels. Note that single
+                                                                            ///< engines may share the same underlying accelerator resources as other
+                                                                            ///< engines so activity of such an engine may not be indicative of the
+                                                                            ///< underlying resource utilization - use
+                                                                            ///< ::ZES_ENGINE_GROUP_3D_RENDER_COMPUTE_ALL for that.
+    ZES_ENGINE_GROUP_MEDIA_DECODE_SINGLE = 6,                               ///< [DEPRECATED] No longer supported.
+    ZES_ENGINE_GROUP_MEDIA_ENCODE_SINGLE = 7,                               ///< [DEPRECATED] No longer supported.
+    ZES_ENGINE_GROUP_COPY_SINGLE = 8,                                       ///< Access information about a single media encode engine. Note that
+                                                                            ///< single engines may share the same underlying accelerator resources as
+                                                                            ///< other engines so activity of such an engine may not be indicative of
+                                                                            ///< the underlying resource utilization - use ::ZES_ENGINE_GROUP_COPY_ALL
+                                                                            ///< for that.
+    ZES_ENGINE_GROUP_MEDIA_ENHANCEMENT_SINGLE = 9,                          ///< Access information about a single media enhancement engine. Note that
+                                                                            ///< single engines may share the same underlying accelerator resources as
+                                                                            ///< other engines so activity of such an engine may not be indicative of
+                                                                            ///< the underlying resource utilization - use ::ZES_ENGINE_GROUP_MEDIA_ALL
+                                                                            ///< for that.
+    ZES_ENGINE_GROUP_3D_SINGLE = 10,                                        ///< [DEPRECATED] No longer supported.
+    ZES_ENGINE_GROUP_3D_RENDER_COMPUTE_ALL = 11,                            ///< [DEPRECATED] No longer supported.
+    ZES_ENGINE_GROUP_RENDER_ALL = 12,                                       ///< Access information about all render engines combined. Render engines
+                                                                            ///< are those than process both 3D content and compute kernels.
+    ZES_ENGINE_GROUP_3D_ALL = 13,                                           ///< [DEPRECATED] No longer supported.
+    ZES_ENGINE_GROUP_MEDIA_CODEC_SINGLE = 14,                               ///< Access information about a single media engine. Note that single
+                                                                            ///< engines may share the same underlying accelerator resources as other
+                                                                            ///< engines so activity of such an engine may not be indicative of the
+                                                                            ///< underlying resource utilization - use ::ZES_ENGINE_GROUP_MEDIA_ALL for
+                                                                            ///< that.
+    ZES_ENGINE_GROUP_FORCE_UINT32 = 0x7fffffff
+
+} zes_engine_group_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Engine group properties
+typedef struct _zes_engine_properties_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    zes_engine_group_t type;                                                ///< [out] The engine group
+    ze_bool_t onSubdevice;                                                  ///< [out] True if this resource is located on a sub-device; false means
+                                                                            ///< that the resource is on the device of the calling Sysman handle
+    uint32_t subdeviceId;                                                   ///< [out] If onSubdevice is true, this gives the ID of the sub-device
+
+} zes_engine_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Engine activity counters
+/// 
+/// @details
+///     - Percent utilization is calculated by taking two snapshots (s1, s2) and
+///       using the equation: %util = (s2.activeTime - s1.activeTime) /
+///       (s2.timestamp - s1.timestamp)
+///     - The `activeTime` time units are implementation-specific since the
+///       value is only intended to be used for calculating utilization
+///       percentage.
+///     - The `timestamp` should only be used to calculate delta between
+///       snapshots of this structure.
+///     - The application should never take the delta of `timestamp` with the
+///       timestamp from a different structure since they are not guaranteed to
+///       have the same base.
+///     - When taking the delta, the difference between `timestamp` samples
+///       could be `0`, if the frequency of sampling the snapshots is higher
+///       than the frequency of the timestamp update.
+///     - The absolute value of `timestamp` is only valid during within the
+///       application and may be different on the next execution.
+typedef struct _zes_engine_stats_t
+{
+    uint64_t activeTime;                                                    ///< [out] Monotonic counter where the resource is actively running
+                                                                            ///< workloads.
+    uint64_t timestamp;                                                     ///< [out] Monotonic counter when activeTime counter was sampled.
+
+} zes_engine_stats_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get handle of engine groups
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDeviceEnumEngineGroups(
+    zes_device_handle_t hDevice,                                            ///< [in] Sysman handle of the device.
+    uint32_t* pCount,                                                       ///< [in,out] pointer to the number of components of this type.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of components of this type that are available.
+                                                                            ///< if count is greater than the number of components of this type that
+                                                                            ///< are available, then the driver shall update the value with the correct
+                                                                            ///< number of components.
+    zes_engine_handle_t* phEngine                                           ///< [in,out][optional][range(0, *pCount)] array of handle of components of
+                                                                            ///< this type.
+                                                                            ///< if count is less than the number of components of this type that are
+                                                                            ///< available, then the driver shall only retrieve that number of
+                                                                            ///< component handles.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get engine group properties
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hEngine`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pProperties`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesEngineGetProperties(
+    zes_engine_handle_t hEngine,                                            ///< [in] Handle for the component.
+    zes_engine_properties_t* pProperties                                    ///< [in,out] The properties for the specified engine group.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get the activity stats for an engine group.
+/// 
+/// @details
+///     - This function also returns the engine activity inside a Virtual
+///       Machine (VM), in the presence of hardware virtualization (SRIOV)
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hEngine`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pStats`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesEngineGetActivity(
+    zes_engine_handle_t hEngine,                                            ///< [in] Handle for the component.
+    zes_engine_stats_t* pStats                                              ///< [in,out] Will contain a snapshot of the engine group activity
+                                                                            ///< counters.
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Tool APIs for System Resource Management (Sysman) - Event management
+#if !defined(__GNUC__)
+#pragma region events
+#endif
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Event types
+typedef uint32_t zes_event_type_flags_t;
+typedef enum _zes_event_type_flag_t
+{
+    ZES_EVENT_TYPE_FLAG_DEVICE_DETACH = ZE_BIT(0),                          ///< Event is triggered when the device is no longer available (due to a
+                                                                            ///< reset or being disabled).
+    ZES_EVENT_TYPE_FLAG_DEVICE_ATTACH = ZE_BIT(1),                          ///< Event is triggered after the device is available again.
+    ZES_EVENT_TYPE_FLAG_DEVICE_SLEEP_STATE_ENTER = ZE_BIT(2),               ///< Event is triggered when the driver is about to put the device into a
+                                                                            ///< deep sleep state
+    ZES_EVENT_TYPE_FLAG_DEVICE_SLEEP_STATE_EXIT = ZE_BIT(3),                ///< Event is triggered when the driver is waking the device up from a deep
+                                                                            ///< sleep state
+    ZES_EVENT_TYPE_FLAG_FREQ_THROTTLED = ZE_BIT(4),                         ///< Event is triggered when the frequency starts being throttled
+    ZES_EVENT_TYPE_FLAG_ENERGY_THRESHOLD_CROSSED = ZE_BIT(5),               ///< Event is triggered when the energy consumption threshold is reached
+                                                                            ///< (use ::zesPowerSetEnergyThreshold() to configure).
+    ZES_EVENT_TYPE_FLAG_TEMP_CRITICAL = ZE_BIT(6),                          ///< Event is triggered when the critical temperature is reached (use
+                                                                            ///< ::zesTemperatureSetConfig() to configure - disabled by default).
+    ZES_EVENT_TYPE_FLAG_TEMP_THRESHOLD1 = ZE_BIT(7),                        ///< Event is triggered when the temperature crosses threshold 1 (use
+                                                                            ///< ::zesTemperatureSetConfig() to configure - disabled by default).
+    ZES_EVENT_TYPE_FLAG_TEMP_THRESHOLD2 = ZE_BIT(8),                        ///< Event is triggered when the temperature crosses threshold 2 (use
+                                                                            ///< ::zesTemperatureSetConfig() to configure - disabled by default).
+    ZES_EVENT_TYPE_FLAG_MEM_HEALTH = ZE_BIT(9),                             ///< Event is triggered when the health of device memory changes.
+    ZES_EVENT_TYPE_FLAG_FABRIC_PORT_HEALTH = ZE_BIT(10),                    ///< Event is triggered when the health of fabric ports change.
+    ZES_EVENT_TYPE_FLAG_PCI_LINK_HEALTH = ZE_BIT(11),                       ///< Event is triggered when the health of the PCI link changes.
+    ZES_EVENT_TYPE_FLAG_RAS_CORRECTABLE_ERRORS = ZE_BIT(12),                ///< Event is triggered when accelerator RAS correctable errors cross
+                                                                            ///< thresholds (use ::zesRasSetConfig() to configure - disabled by
+                                                                            ///< default).
+    ZES_EVENT_TYPE_FLAG_RAS_UNCORRECTABLE_ERRORS = ZE_BIT(13),              ///< Event is triggered when accelerator RAS uncorrectable errors cross
+                                                                            ///< thresholds (use ::zesRasSetConfig() to configure - disabled by
+                                                                            ///< default).
+    ZES_EVENT_TYPE_FLAG_DEVICE_RESET_REQUIRED = ZE_BIT(14),                 ///< Event is triggered when the device needs to be reset (use
+                                                                            ///< ::zesDeviceGetState() to determine the reasons for the reset).
+    ZES_EVENT_TYPE_FLAG_SURVIVABILITY_MODE_DETECTED = ZE_BIT(15),           ///< Event is triggered when graphics driver encounter an error condition.
+    ZES_EVENT_TYPE_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} zes_event_type_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Specify the list of events to listen to for a given device
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `0xffff < events`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDeviceEventRegister(
+    zes_device_handle_t hDevice,                                            ///< [in] The device handle.
+    zes_event_type_flags_t events                                           ///< [in] List of events to listen to.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Wait for events to be received from a one or more devices.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDriver`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == phDevices`
+///         + `nullptr == pNumDeviceEvents`
+///         + `nullptr == pEvents`
+///     - ::ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS
+///         + User does not have permissions to listen to events.
+///     - ::ZE_RESULT_ERROR_INVALID_ARGUMENT
+///         + One or more of the supplied device handles belongs to a different driver.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDriverEventListen(
+    ze_driver_handle_t hDriver,                                             ///< [in] handle of the driver instance
+    uint32_t timeout,                                                       ///< [in] if non-zero, then indicates the maximum time (in milliseconds) to
+                                                                            ///< yield before returning ::ZE_RESULT_SUCCESS or ::ZE_RESULT_NOT_READY;
+                                                                            ///< if zero, then will check status and return immediately;
+                                                                            ///< if `UINT32_MAX`, then function will not return until events arrive.
+    uint32_t count,                                                         ///< [in] Number of device handles in phDevices.
+    zes_device_handle_t* phDevices,                                         ///< [in][range(0, count)] Device handles to listen to for events. Only
+                                                                            ///< devices from the provided driver handle can be specified in this list.
+    uint32_t* pNumDeviceEvents,                                             ///< [in,out] Will contain the actual number of devices in phDevices that
+                                                                            ///< generated events. If non-zero, check pEvents to determine the devices
+                                                                            ///< and events that were received.
+    zes_event_type_flags_t* pEvents                                         ///< [in,out] An array that will continue the list of events for each
+                                                                            ///< device listened in phDevices.
+                                                                            ///< This array must be at least as big as count.
+                                                                            ///< For every device handle in phDevices, this will provide the events
+                                                                            ///< that occurred for that device at the same position in this array. If
+                                                                            ///< no event was received for a given device, the corresponding array
+                                                                            ///< entry will be zero.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Wait for events to be received from a one or more devices.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDriver`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == phDevices`
+///         + `nullptr == pNumDeviceEvents`
+///         + `nullptr == pEvents`
+///     - ::ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS
+///         + User does not have permissions to listen to events.
+///     - ::ZE_RESULT_ERROR_INVALID_ARGUMENT
+///         + One or more of the supplied device handles belongs to a different driver.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDriverEventListenEx(
+    ze_driver_handle_t hDriver,                                             ///< [in] handle of the driver instance
+    uint64_t timeout,                                                       ///< [in] if non-zero, then indicates the maximum time (in milliseconds) to
+                                                                            ///< yield before returning ::ZE_RESULT_SUCCESS or ::ZE_RESULT_NOT_READY;
+                                                                            ///< if zero, then will check status and return immediately;
+                                                                            ///< if `UINT64_MAX`, then function will not return until events arrive.
+    uint32_t count,                                                         ///< [in] Number of device handles in phDevices.
+    zes_device_handle_t* phDevices,                                         ///< [in][range(0, count)] Device handles to listen to for events. Only
+                                                                            ///< devices from the provided driver handle can be specified in this list.
+    uint32_t* pNumDeviceEvents,                                             ///< [in,out] Will contain the actual number of devices in phDevices that
+                                                                            ///< generated events. If non-zero, check pEvents to determine the devices
+                                                                            ///< and events that were received.
+    zes_event_type_flags_t* pEvents                                         ///< [in,out] An array that will continue the list of events for each
+                                                                            ///< device listened in phDevices.
+                                                                            ///< This array must be at least as big as count.
+                                                                            ///< For every device handle in phDevices, this will provide the events
+                                                                            ///< that occurred for that device at the same position in this array. If
+                                                                            ///< no event was received for a given device, the corresponding array
+                                                                            ///< entry will be zero.
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Tool APIs for System Resource Management (Sysman) - Firmware management
+#if !defined(__GNUC__)
+#pragma region fabric
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZES_MAX_FABRIC_PORT_MODEL_SIZE
+/// @brief Maximum Fabric port model string size
+#define ZES_MAX_FABRIC_PORT_MODEL_SIZE  256
+#endif // ZES_MAX_FABRIC_PORT_MODEL_SIZE
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZES_MAX_FABRIC_LINK_TYPE_SIZE
+/// @brief Maximum size of the buffer that will return information about link
+///        types
+#define ZES_MAX_FABRIC_LINK_TYPE_SIZE  256
+#endif // ZES_MAX_FABRIC_LINK_TYPE_SIZE
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Fabric port status
+typedef enum _zes_fabric_port_status_t
+{
+    ZES_FABRIC_PORT_STATUS_UNKNOWN = 0,                                     ///< The port status cannot be determined
+    ZES_FABRIC_PORT_STATUS_HEALTHY = 1,                                     ///< The port is up and operating as expected
+    ZES_FABRIC_PORT_STATUS_DEGRADED = 2,                                    ///< The port is up but has quality and/or speed degradation
+    ZES_FABRIC_PORT_STATUS_FAILED = 3,                                      ///< Port connection instabilities are preventing workloads making forward
+                                                                            ///< progress
+    ZES_FABRIC_PORT_STATUS_DISABLED = 4,                                    ///< The port is configured down
+    ZES_FABRIC_PORT_STATUS_FORCE_UINT32 = 0x7fffffff
+
+} zes_fabric_port_status_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Fabric port quality degradation reasons
+typedef uint32_t zes_fabric_port_qual_issue_flags_t;
+typedef enum _zes_fabric_port_qual_issue_flag_t
+{
+    ZES_FABRIC_PORT_QUAL_ISSUE_FLAG_LINK_ERRORS = ZE_BIT(0),                ///< Excessive link errors are occurring
+    ZES_FABRIC_PORT_QUAL_ISSUE_FLAG_SPEED = ZE_BIT(1),                      ///< There is a degradation in the bitrate and/or width of the link
+    ZES_FABRIC_PORT_QUAL_ISSUE_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} zes_fabric_port_qual_issue_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Fabric port failure reasons
+typedef uint32_t zes_fabric_port_failure_flags_t;
+typedef enum _zes_fabric_port_failure_flag_t
+{
+    ZES_FABRIC_PORT_FAILURE_FLAG_FAILED = ZE_BIT(0),                        ///< A previously operating link has failed. Hardware will automatically
+                                                                            ///< retrain this port. This state will persist until either the physical
+                                                                            ///< connection is removed or the link trains successfully.
+    ZES_FABRIC_PORT_FAILURE_FLAG_TRAINING_TIMEOUT = ZE_BIT(1),              ///< A connection has not been established within an expected time.
+                                                                            ///< Hardware will continue to attempt port training. This status will
+                                                                            ///< persist until either the physical connection is removed or the link
+                                                                            ///< successfully trains.
+    ZES_FABRIC_PORT_FAILURE_FLAG_FLAPPING = ZE_BIT(2),                      ///< Port has excessively trained and then transitioned down for some
+                                                                            ///< period of time. Driver will allow port to continue to train, but will
+                                                                            ///< not enable the port for use until the port has been disabled and
+                                                                            ///< subsequently re-enabled using ::zesFabricPortSetConfig().
+    ZES_FABRIC_PORT_FAILURE_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} zes_fabric_port_failure_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Unique identifier for a fabric port
+/// 
+/// @details
+///     - This not a universal identifier. The identified is garanteed to be
+///       unique for the current hardware configuration of the system. Changes
+///       in the hardware may result in a different identifier for a given port.
+///     - The main purpose of this identifier to build up an instantaneous
+///       topology map of system connectivity. An application should enumerate
+///       all fabric ports and match the `remotePortId` member of
+///       ::zes_fabric_port_state_t to the `portId` member of
+///       ::zes_fabric_port_properties_t.
+typedef struct _zes_fabric_port_id_t
+{
+    uint32_t fabricId;                                                      ///< [out] Unique identifier for the fabric end-point
+    uint32_t attachId;                                                      ///< [out] Unique identifier for the device attachment point
+    uint8_t portNumber;                                                     ///< [out] The logical port number (this is typically marked somewhere on
+                                                                            ///< the physical device)
+
+} zes_fabric_port_id_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Fabric port speed in one direction
+typedef struct _zes_fabric_port_speed_t
+{
+    int64_t bitRate;                                                        ///< [out] Bits/sec that the link is operating at. A value of -1 means that
+                                                                            ///< this property is unknown.
+    int32_t width;                                                          ///< [out] The number of lanes. A value of -1 means that this property is
+                                                                            ///< unknown.
+
+} zes_fabric_port_speed_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Fabric port properties
+typedef struct _zes_fabric_port_properties_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    char model[ZES_MAX_FABRIC_PORT_MODEL_SIZE];                             ///< [out] Description of port technology. Will be set to the string
+                                                                            ///< "unkown" if this cannot be determined for this port.
+    ze_bool_t onSubdevice;                                                  ///< [out] True if the port is located on a sub-device; false means that
+                                                                            ///< the port is on the device of the calling Sysman handle
+    uint32_t subdeviceId;                                                   ///< [out] If onSubdevice is true, this gives the ID of the sub-device
+    zes_fabric_port_id_t portId;                                            ///< [out] The unique port identifier
+    zes_fabric_port_speed_t maxRxSpeed;                                     ///< [out] Maximum speed supported by the receive side of the port (sum of
+                                                                            ///< all lanes)
+    zes_fabric_port_speed_t maxTxSpeed;                                     ///< [out] Maximum speed supported by the transmit side of the port (sum of
+                                                                            ///< all lanes)
+
+} zes_fabric_port_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Provides information about the fabric link attached to a port
+typedef struct _zes_fabric_link_type_t
+{
+    char desc[ZES_MAX_FABRIC_LINK_TYPE_SIZE];                               ///< [out] Description of link technology. Will be set to the string
+                                                                            ///< "unkown" if this cannot be determined for this link.
+
+} zes_fabric_link_type_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Fabric port configuration
+typedef struct _zes_fabric_port_config_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_bool_t enabled;                                                      ///< [in,out] Port is configured up/down
+    ze_bool_t beaconing;                                                    ///< [in,out] Beaconing is configured on/off
+
+} zes_fabric_port_config_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Fabric port state
+typedef struct _zes_fabric_port_state_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    zes_fabric_port_status_t status;                                        ///< [out] The current status of the port
+    zes_fabric_port_qual_issue_flags_t qualityIssues;                       ///< [out] If status is ::ZES_FABRIC_PORT_STATUS_DEGRADED,
+                                                                            ///< then this gives a combination of ::zes_fabric_port_qual_issue_flag_t
+                                                                            ///< for quality issues that have been detected;
+                                                                            ///< otherwise, 0 indicates there are no quality issues with the link at
+                                                                            ///< this time.
+    zes_fabric_port_failure_flags_t failureReasons;                         ///< [out] If status is ::ZES_FABRIC_PORT_STATUS_FAILED,
+                                                                            ///< then this gives a combination of ::zes_fabric_port_failure_flag_t for
+                                                                            ///< reasons for the connection instability;
+                                                                            ///< otherwise, 0 indicates there are no connection stability issues at
+                                                                            ///< this time.
+    zes_fabric_port_id_t remotePortId;                                      ///< [out] The unique port identifier for the remote connection point if
+                                                                            ///< status is ::ZES_FABRIC_PORT_STATUS_HEALTHY,
+                                                                            ///< ::ZES_FABRIC_PORT_STATUS_DEGRADED or ::ZES_FABRIC_PORT_STATUS_FAILED
+    zes_fabric_port_speed_t rxSpeed;                                        ///< [out] Current maximum receive speed (sum of all lanes)
+    zes_fabric_port_speed_t txSpeed;                                        ///< [out] Current maximum transmit speed (sum of all lanes)
+
+} zes_fabric_port_state_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Fabric port throughput.
+typedef struct _zes_fabric_port_throughput_t
+{
+    uint64_t timestamp;                                                     ///< [out] Monotonic timestamp counter in microseconds when the measurement
+                                                                            ///< was made.
+                                                                            ///< This timestamp should only be used to calculate delta time between
+                                                                            ///< snapshots of this structure.
+                                                                            ///< Never take the delta of this timestamp with the timestamp from a
+                                                                            ///< different structure since they are not guaranteed to have the same base.
+                                                                            ///< The absolute value of the timestamp is only valid during within the
+                                                                            ///< application and may be different on the next execution.
+    uint64_t rxCounter;                                                     ///< [out] Monotonic counter for the number of bytes received (sum of all
+                                                                            ///< lanes). This includes all protocol overhead, not only the GPU traffic.
+    uint64_t txCounter;                                                     ///< [out] Monotonic counter for the number of bytes transmitted (sum of
+                                                                            ///< all lanes). This includes all protocol overhead, not only the GPU
+                                                                            ///< traffic.
+
+} zes_fabric_port_throughput_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Fabric Port Error Counters
+typedef struct _zes_fabric_port_error_counters_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    uint64_t linkFailureCount;                                              ///< [out] Link Failure Error Count reported per port
+    uint64_t fwCommErrorCount;                                              ///< [out] Firmware Communication Error Count reported per device
+    uint64_t fwErrorCount;                                                  ///< [out] Firmware reported Error Count reported per device
+    uint64_t linkDegradeCount;                                              ///< [out] Link Degrade Error Count reported per port
+
+} zes_fabric_port_error_counters_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get handle of Fabric ports in a device
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDeviceEnumFabricPorts(
+    zes_device_handle_t hDevice,                                            ///< [in] Sysman handle of the device.
+    uint32_t* pCount,                                                       ///< [in,out] pointer to the number of components of this type.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of components of this type that are available.
+                                                                            ///< if count is greater than the number of components of this type that
+                                                                            ///< are available, then the driver shall update the value with the correct
+                                                                            ///< number of components.
+    zes_fabric_port_handle_t* phPort                                        ///< [in,out][optional][range(0, *pCount)] array of handle of components of
+                                                                            ///< this type.
+                                                                            ///< if count is less than the number of components of this type that are
+                                                                            ///< available, then the driver shall only retrieve that number of
+                                                                            ///< component handles.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get Fabric port properties
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hPort`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pProperties`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesFabricPortGetProperties(
+    zes_fabric_port_handle_t hPort,                                         ///< [in] Handle for the component.
+    zes_fabric_port_properties_t* pProperties                               ///< [in,out] Will contain properties of the Fabric Port.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get Fabric port link type
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hPort`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pLinkType`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesFabricPortGetLinkType(
+    zes_fabric_port_handle_t hPort,                                         ///< [in] Handle for the component.
+    zes_fabric_link_type_t* pLinkType                                       ///< [in,out] Will contain details about the link attached to the Fabric
+                                                                            ///< port.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get Fabric port configuration
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hPort`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pConfig`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesFabricPortGetConfig(
+    zes_fabric_port_handle_t hPort,                                         ///< [in] Handle for the component.
+    zes_fabric_port_config_t* pConfig                                       ///< [in,out] Will contain configuration of the Fabric Port.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Set Fabric port configuration
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hPort`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pConfig`
+///     - ::ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS
+///         + User does not have permissions to make these modifications.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesFabricPortSetConfig(
+    zes_fabric_port_handle_t hPort,                                         ///< [in] Handle for the component.
+    const zes_fabric_port_config_t* pConfig                                 ///< [in] Contains new configuration of the Fabric Port.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get Fabric port state - status (health/degraded/failed/disabled),
+///        reasons for link degradation or instability, current rx/tx speed
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hPort`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pState`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesFabricPortGetState(
+    zes_fabric_port_handle_t hPort,                                         ///< [in] Handle for the component.
+    zes_fabric_port_state_t* pState                                         ///< [in,out] Will contain the current state of the Fabric Port
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get Fabric port throughput
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hPort`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pThroughput`
+///     - ::ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS
+///         + User does not have permissions to query this telemetry.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesFabricPortGetThroughput(
+    zes_fabric_port_handle_t hPort,                                         ///< [in] Handle for the component.
+    zes_fabric_port_throughput_t* pThroughput                               ///< [in,out] Will contain the Fabric port throughput counters.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get Fabric Port Error Counters
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+///     - The memory backing the arrays for phPorts and ppThroughputs must be
+///       allocated in system memory by the user who is also responsible for
+///       releasing them when they are no longer needed.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hPort`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pErrors`
+///     - ::ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS
+///         + User does not have permissions to query this telemetry.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesFabricPortGetFabricErrorCounters(
+    zes_fabric_port_handle_t hPort,                                         ///< [in] Handle for the component.
+    zes_fabric_port_error_counters_t* pErrors                               ///< [in,out] Will contain the Fabric port Error counters.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get Fabric port throughput from multiple ports in a single call
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == phPort`
+///         + `nullptr == pThroughput`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesFabricPortGetMultiPortThroughput(
+    zes_device_handle_t hDevice,                                            ///< [in] Sysman handle of the device.
+    uint32_t numPorts,                                                      ///< [in] Number of ports enumerated in function ::zesDeviceEnumFabricPorts
+    zes_fabric_port_handle_t* phPort,                                       ///< [in][range(0, numPorts)] array of fabric port handles provided by user
+                                                                            ///< to gather throughput values. 
+    zes_fabric_port_throughput_t** pThroughput                              ///< [out][range(0, numPorts)] array of fabric port throughput counters
+                                                                            ///< from multiple ports of type ::zes_fabric_port_throughput_t.
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Tool APIs for System Resource Management (Sysman) - Firmware management
+#if !defined(__GNUC__)
+#pragma region fan
+#endif
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Fan resource speed mode
+typedef enum _zes_fan_speed_mode_t
+{
+    ZES_FAN_SPEED_MODE_DEFAULT = 0,                                         ///< The fan speed is operating using the hardware default settings
+    ZES_FAN_SPEED_MODE_FIXED = 1,                                           ///< The fan speed is currently set to a fixed value
+    ZES_FAN_SPEED_MODE_TABLE = 2,                                           ///< The fan speed is currently controlled dynamically by hardware based on
+                                                                            ///< a temp/speed table
+    ZES_FAN_SPEED_MODE_FORCE_UINT32 = 0x7fffffff
+
+} zes_fan_speed_mode_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Fan speed units
+typedef enum _zes_fan_speed_units_t
+{
+    ZES_FAN_SPEED_UNITS_RPM = 0,                                            ///< The fan speed is in units of revolutions per minute (rpm)
+    ZES_FAN_SPEED_UNITS_PERCENT = 1,                                        ///< The fan speed is a percentage of the maximum speed of the fan
+    ZES_FAN_SPEED_UNITS_FORCE_UINT32 = 0x7fffffff
+
+} zes_fan_speed_units_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Fan speed
+typedef struct _zes_fan_speed_t
+{
+    int32_t speed;                                                          ///< [in,out] The speed of the fan. On output, a value of -1 indicates that
+                                                                            ///< there is no fixed fan speed setting.
+    zes_fan_speed_units_t units;                                            ///< [in,out] The units that the fan speed is expressed in. On output, if
+                                                                            ///< fan speed is -1 then units should be ignored.
+
+} zes_fan_speed_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Fan temperature/speed pair
+typedef struct _zes_fan_temp_speed_t
+{
+    uint32_t temperature;                                                   ///< [in,out] Temperature in degrees Celsius.
+    zes_fan_speed_t speed;                                                  ///< [in,out] The speed of the fan
+
+} zes_fan_temp_speed_t;
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZES_FAN_TEMP_SPEED_PAIR_COUNT
+/// @brief Maximum number of fan temperature/speed pairs in the fan speed table.
+#define ZES_FAN_TEMP_SPEED_PAIR_COUNT  32
+#endif // ZES_FAN_TEMP_SPEED_PAIR_COUNT
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Fan speed table
+typedef struct _zes_fan_speed_table_t
+{
+    int32_t numPoints;                                                      ///< [in,out] The number of valid points in the fan speed table. 0 means
+                                                                            ///< that there is no fan speed table configured. -1 means that a fan speed
+                                                                            ///< table is not supported by the hardware.
+    zes_fan_temp_speed_t table[ZES_FAN_TEMP_SPEED_PAIR_COUNT];              ///< [in,out] Array of temperature/fan speed pairs. The table is ordered
+                                                                            ///< based on temperature from lowest to highest.
+
+} zes_fan_speed_table_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Fan properties
+typedef struct _zes_fan_properties_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_bool_t onSubdevice;                                                  ///< [out] True if the resource is located on a sub-device; false means
+                                                                            ///< that the resource is on the device of the calling Sysman handle
+    uint32_t subdeviceId;                                                   ///< [out] If onSubdevice is true, this gives the ID of the sub-device
+    ze_bool_t canControl;                                                   ///< [out] Indicates if software can control the fan speed assuming the
+                                                                            ///< user has permissions
+    uint32_t supportedModes;                                                ///< [out] Bitfield of supported fan configuration modes
+                                                                            ///< (1<<::zes_fan_speed_mode_t)
+    uint32_t supportedUnits;                                                ///< [out] Bitfield of supported fan speed units
+                                                                            ///< (1<<::zes_fan_speed_units_t)
+    int32_t maxRPM;                                                         ///< [out] The maximum RPM of the fan. A value of -1 means that this
+                                                                            ///< property is unknown. 
+    int32_t maxPoints;                                                      ///< [out] The maximum number of points in the fan temp/speed table. A
+                                                                            ///< value of -1 means that this fan doesn't support providing a temp/speed
+                                                                            ///< table.
+
+} zes_fan_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Fan configuration
+typedef struct _zes_fan_config_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    zes_fan_speed_mode_t mode;                                              ///< [in,out] The fan speed mode (fixed, temp-speed table)
+    zes_fan_speed_t speedFixed;                                             ///< [in,out] The current fixed fan speed setting
+    zes_fan_speed_table_t speedTable;                                       ///< [out] A table containing temperature/speed pairs
+
+} zes_fan_config_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get handle of fans
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDeviceEnumFans(
+    zes_device_handle_t hDevice,                                            ///< [in] Sysman handle of the device.
+    uint32_t* pCount,                                                       ///< [in,out] pointer to the number of components of this type.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of components of this type that are available.
+                                                                            ///< if count is greater than the number of components of this type that
+                                                                            ///< are available, then the driver shall update the value with the correct
+                                                                            ///< number of components.
+    zes_fan_handle_t* phFan                                                 ///< [in,out][optional][range(0, *pCount)] array of handle of components of
+                                                                            ///< this type.
+                                                                            ///< if count is less than the number of components of this type that are
+                                                                            ///< available, then the driver shall only retrieve that number of
+                                                                            ///< component handles.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get fan properties
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hFan`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pProperties`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesFanGetProperties(
+    zes_fan_handle_t hFan,                                                  ///< [in] Handle for the component.
+    zes_fan_properties_t* pProperties                                       ///< [in,out] Will contain the properties of the fan.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get fan configurations and the current fan speed mode (default, fixed,
+///        temp-speed table)
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hFan`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pConfig`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesFanGetConfig(
+    zes_fan_handle_t hFan,                                                  ///< [in] Handle for the component.
+    zes_fan_config_t* pConfig                                               ///< [in,out] Will contain the current configuration of the fan.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Configure the fan to run with hardware factory settings (set mode to
+///        ::ZES_FAN_SPEED_MODE_DEFAULT)
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hFan`
+///     - ::ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS
+///         + User does not have permissions to make these modifications.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesFanSetDefaultMode(
+    zes_fan_handle_t hFan                                                   ///< [in] Handle for the component.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Configure the fan to rotate at a fixed speed (set mode to
+///        ::ZES_FAN_SPEED_MODE_FIXED)
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hFan`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == speed`
+///     - ::ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS
+///         + User does not have permissions to make these modifications.
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Fixing the fan speed not supported by the hardware or the fan speed units are not supported. See the `supportedModes` and `supportedUnits` members of ::zes_fan_properties_t.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesFanSetFixedSpeedMode(
+    zes_fan_handle_t hFan,                                                  ///< [in] Handle for the component.
+    const zes_fan_speed_t* speed                                            ///< [in] The fixed fan speed setting
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Configure the fan to adjust speed based on a temperature/speed table
+///        (set mode to ::ZES_FAN_SPEED_MODE_TABLE)
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hFan`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == speedTable`
+///     - ::ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS
+///         + User does not have permissions to make these modifications.
+///     - ::ZE_RESULT_ERROR_INVALID_ARGUMENT
+///         + The temperature/speed pairs in the array are not sorted on temperature from lowest to highest.
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Fan speed table not supported by the hardware or the fan speed units are not supported. See the `supportedModes` and `supportedUnits` members of ::zes_fan_properties_t.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesFanSetSpeedTableMode(
+    zes_fan_handle_t hFan,                                                  ///< [in] Handle for the component.
+    const zes_fan_speed_table_t* speedTable                                 ///< [in] A table containing temperature/speed pairs.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get current state of a fan - current mode and speed
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hFan`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::ZES_FAN_SPEED_UNITS_PERCENT < units`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pSpeed`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + The requested fan speed units are not supported. See the `supportedUnits` member of ::zes_fan_properties_t.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesFanGetState(
+    zes_fan_handle_t hFan,                                                  ///< [in] Handle for the component.
+    zes_fan_speed_units_t units,                                            ///< [in] The units in which the fan speed should be returned.
+    int32_t* pSpeed                                                         ///< [in,out] Will contain the current speed of the fan in the units
+                                                                            ///< requested. A value of -1 indicates that the fan speed cannot be
+                                                                            ///< measured.
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Tool APIs for System Resource Management (Sysman) - Firmware management
+#if !defined(__GNUC__)
+#pragma region firmware
+#endif
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Firmware properties
+typedef struct _zes_firmware_properties_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_bool_t onSubdevice;                                                  ///< [out] True if the resource is located on a sub-device; false means
+                                                                            ///< that the resource is on the device of the calling Sysman handle
+    uint32_t subdeviceId;                                                   ///< [out] If onSubdevice is true, this gives the ID of the sub-device
+    ze_bool_t canControl;                                                   ///< [out] Indicates if software can flash the firmware assuming the user
+                                                                            ///< has permissions
+    char name[ZES_STRING_PROPERTY_SIZE];                                    ///< [out] NULL terminated string value. The string "unknown" will be
+                                                                            ///< returned if this property cannot be determined.
+    char version[ZES_STRING_PROPERTY_SIZE];                                 ///< [out] NULL terminated string value. The string "unknown" will be
+                                                                            ///< returned if this property cannot be determined.
+
+} zes_firmware_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get handle of firmwares
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDeviceEnumFirmwares(
+    zes_device_handle_t hDevice,                                            ///< [in] Sysman handle of the device.
+    uint32_t* pCount,                                                       ///< [in,out] pointer to the number of components of this type.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of components of this type that are available.
+                                                                            ///< if count is greater than the number of components of this type that
+                                                                            ///< are available, then the driver shall update the value with the correct
+                                                                            ///< number of components.
+    zes_firmware_handle_t* phFirmware                                       ///< [in,out][optional][range(0, *pCount)] array of handle of components of
+                                                                            ///< this type.
+                                                                            ///< if count is less than the number of components of this type that are
+                                                                            ///< available, then the driver shall only retrieve that number of
+                                                                            ///< component handles.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get firmware properties
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hFirmware`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pProperties`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesFirmwareGetProperties(
+    zes_firmware_handle_t hFirmware,                                        ///< [in] Handle for the component.
+    zes_firmware_properties_t* pProperties                                  ///< [in,out] Pointer to an array that will hold the properties of the
+                                                                            ///< firmware
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Flash a new firmware image
+/// 
+/// @details
+///     - Any running workload must be gracefully closed before invoking this
+///       function.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+///     - This is a non-blocking call. Application may call
+///       ::zesFirmwareGetFlashProgress to get completion status.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hFirmware`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pImage`
+///     - ::ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS
+///         + User does not have permissions to perform this operation.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesFirmwareFlash(
+    zes_firmware_handle_t hFirmware,                                        ///< [in] Handle for the component.
+    void* pImage,                                                           ///< [in] Image of the new firmware to flash.
+    uint32_t size                                                           ///< [in] Size of the flash image.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get Firmware Flash Progress
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hFirmware`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCompletionPercent`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesFirmwareGetFlashProgress(
+    zes_firmware_handle_t hFirmware,                                        ///< [in] Handle for the component.
+    uint32_t* pCompletionPercent                                            ///< [in,out] Pointer to the Completion Percentage of Firmware Update
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get Firmware Console Logs
+/// 
+/// @details
+///     - The caller may pass nullptr for pFirmwareLog and set pSize to zero
+///       when querying only for size.
+///     - The caller must provide memory for Firmware log.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hFirmware`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pSize`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesFirmwareGetConsoleLogs(
+    zes_firmware_handle_t hFirmware,                                        ///< [in] Handle for the component.
+    size_t* pSize,                                                          ///< [in,out] size of firmware log
+    char* pFirmwareLog                                                      ///< [in,out][optional] pointer to null-terminated string of the log.
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Tool APIs for System Resource Management (Sysman) - Frequency domains
+#if !defined(__GNUC__)
+#pragma region frequency
+#endif
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Frequency domains.
+typedef enum _zes_freq_domain_t
+{
+    ZES_FREQ_DOMAIN_GPU = 0,                                                ///< GPU Core Domain.
+    ZES_FREQ_DOMAIN_MEMORY = 1,                                             ///< Local Memory Domain.
+    ZES_FREQ_DOMAIN_MEDIA = 2,                                              ///< GPU Media Domain.
+    ZES_FREQ_DOMAIN_FORCE_UINT32 = 0x7fffffff
+
+} zes_freq_domain_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Frequency properties
+/// 
+/// @details
+///     - Indicates if this frequency domain can be overclocked (if true,
+///       functions such as ::zesFrequencyOcSetFrequencyTarget() are supported).
+///     - The min/max hardware frequencies are specified for non-overclock
+///       configurations. For overclock configurations, use
+///       ::zesFrequencyOcGetFrequencyTarget() to determine the maximum
+///       frequency that can be requested.
+typedef struct _zes_freq_properties_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    zes_freq_domain_t type;                                                 ///< [out] The hardware block that this frequency domain controls (GPU,
+                                                                            ///< memory, ...)
+    ze_bool_t onSubdevice;                                                  ///< [out] True if this resource is located on a sub-device; false means
+                                                                            ///< that the resource is on the device of the calling Sysman handle
+    uint32_t subdeviceId;                                                   ///< [out] If onSubdevice is true, this gives the ID of the sub-device
+    ze_bool_t canControl;                                                   ///< [out] Indicates if software can control the frequency of this domain
+                                                                            ///< assuming the user has permissions
+    ze_bool_t isThrottleEventSupported;                                     ///< [out] Indicates if software can register to receive event
+                                                                            ///< ::ZES_EVENT_TYPE_FLAG_FREQ_THROTTLED
+    double min;                                                             ///< [out] The minimum hardware clock frequency in units of MHz.
+    double max;                                                             ///< [out] The maximum non-overclock hardware clock frequency in units of
+                                                                            ///< MHz.
+
+} zes_freq_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Frequency range between which the hardware can operate.
+/// 
+/// @details
+///     - When setting limits, they will be clamped to the hardware limits.
+///     - When setting limits, ensure that the max frequency is greater than or
+///       equal to the min frequency specified.
+///     - When setting limits to return to factory settings, specify -1 for both
+///       the min and max limit.
+typedef struct _zes_freq_range_t
+{
+    double min;                                                             ///< [in,out] The min frequency in MHz below which hardware frequency
+                                                                            ///< management will not request frequencies. On input, setting to 0 will
+                                                                            ///< permit the frequency to go down to the hardware minimum while setting
+                                                                            ///< to -1 will return the min frequency limit to the factory value (can be
+                                                                            ///< larger than the hardware min). On output, a negative value indicates
+                                                                            ///< that no external minimum frequency limit is in effect.
+    double max;                                                             ///< [in,out] The max frequency in MHz above which hardware frequency
+                                                                            ///< management will not request frequencies. On input, setting to 0 or a
+                                                                            ///< very big number will permit the frequency to go all the way up to the
+                                                                            ///< hardware maximum while setting to -1 will return the max frequency to
+                                                                            ///< the factory value (which can be less than the hardware max). On
+                                                                            ///< output, a negative number indicates that no external maximum frequency
+                                                                            ///< limit is in effect.
+
+} zes_freq_range_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Frequency throttle reasons
+typedef uint32_t zes_freq_throttle_reason_flags_t;
+typedef enum _zes_freq_throttle_reason_flag_t
+{
+    ZES_FREQ_THROTTLE_REASON_FLAG_AVE_PWR_CAP = ZE_BIT(0),                  ///< frequency throttled due to average power excursion (PL1)
+    ZES_FREQ_THROTTLE_REASON_FLAG_BURST_PWR_CAP = ZE_BIT(1),                ///< frequency throttled due to burst power excursion (PL2)
+    ZES_FREQ_THROTTLE_REASON_FLAG_CURRENT_LIMIT = ZE_BIT(2),                ///< frequency throttled due to current excursion (PL4)
+    ZES_FREQ_THROTTLE_REASON_FLAG_THERMAL_LIMIT = ZE_BIT(3),                ///< frequency throttled due to thermal excursion (T > TjMax)
+    ZES_FREQ_THROTTLE_REASON_FLAG_PSU_ALERT = ZE_BIT(4),                    ///< frequency throttled due to power supply assertion
+    ZES_FREQ_THROTTLE_REASON_FLAG_SW_RANGE = ZE_BIT(5),                     ///< frequency throttled due to software supplied frequency range
+    ZES_FREQ_THROTTLE_REASON_FLAG_HW_RANGE = ZE_BIT(6),                     ///< frequency throttled due to a sub block that has a lower frequency
+                                                                            ///< range when it receives clocks
+    ZES_FREQ_THROTTLE_REASON_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} zes_freq_throttle_reason_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Frequency state
+typedef struct _zes_freq_state_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    double currentVoltage;                                                  ///< [out] Current voltage in Volts. A negative value indicates that this
+                                                                            ///< property is not known.
+    double request;                                                         ///< [out] The current frequency request in MHz. A negative value indicates
+                                                                            ///< that this property is not known.
+    double tdp;                                                             ///< [out] The maximum frequency in MHz supported under the current TDP
+                                                                            ///< conditions. This fluctuates dynamically based on the power and thermal
+                                                                            ///< limits of the part. A negative value indicates that this property is
+                                                                            ///< not known.
+    double efficient;                                                       ///< [out] The efficient minimum frequency in MHz. A negative value
+                                                                            ///< indicates that this property is not known.
+    double actual;                                                          ///< [out] The resolved frequency in MHz. A negative value indicates that
+                                                                            ///< this property is not known.
+    zes_freq_throttle_reason_flags_t throttleReasons;                       ///< [out] The reasons that the frequency is being limited by the hardware.
+                                                                            ///< Returns 0 (frequency not throttled) or a combination of ::zes_freq_throttle_reason_flag_t.
+
+} zes_freq_state_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Frequency throttle time snapshot
+/// 
+/// @details
+///     - Percent time throttled is calculated by taking two snapshots (s1, s2)
+///       and using the equation: %throttled = (s2.throttleTime -
+///       s1.throttleTime) / (s2.timestamp - s1.timestamp)
+typedef struct _zes_freq_throttle_time_t
+{
+    uint64_t throttleTime;                                                  ///< [out] The monotonic counter of time in microseconds that the frequency
+                                                                            ///< has been limited by the hardware.
+    uint64_t timestamp;                                                     ///< [out] Microsecond timestamp when throttleTime was captured.
+                                                                            ///< This timestamp should only be used to calculate delta time between
+                                                                            ///< snapshots of this structure.
+                                                                            ///< Never take the delta of this timestamp with the timestamp from a
+                                                                            ///< different structure since they are not guaranteed to have the same base.
+                                                                            ///< The absolute value of the timestamp is only valid during within the
+                                                                            ///< application and may be different on the next execution.
+
+} zes_freq_throttle_time_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Overclocking modes
+/// 
+/// @details
+///     - [DEPRECATED] No longer supported.
+typedef enum _zes_oc_mode_t
+{
+    ZES_OC_MODE_OFF = 0,                                                    ///< Overclocking if off - hardware is running using factory default
+                                                                            ///< voltages/frequencies.
+    ZES_OC_MODE_OVERRIDE = 1,                                               ///< Overclock override mode - In this mode, a fixed user-supplied voltage
+                                                                            ///< is applied independent of the frequency request. The maximum permitted
+                                                                            ///< frequency can also be increased. This mode disables INTERPOLATIVE and
+                                                                            ///< FIXED modes.
+    ZES_OC_MODE_INTERPOLATIVE = 2,                                          ///< Overclock interpolative mode - In this mode, the voltage/frequency
+                                                                            ///< curve can be extended with a new voltage/frequency point that will be
+                                                                            ///< interpolated. The existing voltage/frequency points can also be offset
+                                                                            ///< (up or down) by a fixed voltage. This mode disables FIXED and OVERRIDE
+                                                                            ///< modes.
+    ZES_OC_MODE_FIXED = 3,                                                  ///< Overclocking fixed Mode - In this mode, hardware will disable most
+                                                                            ///< frequency throttling and lock the frequency and voltage at the
+                                                                            ///< specified overclock values. This mode disables OVERRIDE and
+                                                                            ///< INTERPOLATIVE modes. This mode can damage the part, most of the
+                                                                            ///< protections are disabled on this mode.
+    ZES_OC_MODE_FORCE_UINT32 = 0x7fffffff
+
+} zes_oc_mode_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Overclocking properties
+/// 
+/// @details
+///     - Provides all the overclocking capabilities and properties supported by
+///       the device for the frequency domain.
+///     - [DEPRECATED] No longer supported.
+typedef struct _zes_oc_capabilities_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_bool_t isOcSupported;                                                ///< [out] Indicates if any overclocking features are supported on this
+                                                                            ///< frequency domain.
+    double maxFactoryDefaultFrequency;                                      ///< [out] Factory default non-overclock maximum frequency in Mhz.
+    double maxFactoryDefaultVoltage;                                        ///< [out] Factory default voltage used for the non-overclock maximum
+                                                                            ///< frequency in MHz.
+    double maxOcFrequency;                                                  ///< [out] Maximum hardware overclocking frequency limit in Mhz.
+    double minOcVoltageOffset;                                              ///< [out] The minimum voltage offset that can be applied to the
+                                                                            ///< voltage/frequency curve. Note that this number can be negative.
+    double maxOcVoltageOffset;                                              ///< [out] The maximum voltage offset that can be applied to the
+                                                                            ///< voltage/frequency curve.
+    double maxOcVoltage;                                                    ///< [out] The maximum overclock voltage that hardware supports.
+    ze_bool_t isTjMaxSupported;                                             ///< [out] Indicates if the maximum temperature limit (TjMax) can be
+                                                                            ///< changed for this frequency domain.
+    ze_bool_t isIccMaxSupported;                                            ///< [out] Indicates if the maximum current (IccMax) can be changed for
+                                                                            ///< this frequency domain.
+    ze_bool_t isHighVoltModeCapable;                                        ///< [out] Indicates if this frequency domains supports a feature to set
+                                                                            ///< very high voltages.
+    ze_bool_t isHighVoltModeEnabled;                                        ///< [out] Indicates if very high voltages are permitted on this frequency
+                                                                            ///< domain.
+    ze_bool_t isExtendedModeSupported;                                      ///< [out] Indicates if the extended overclocking features are supported.
+                                                                            ///< If this is supported, increments are on 1 Mhz basis.
+    ze_bool_t isFixedModeSupported;                                         ///< [out] Indicates if the fixed mode is supported. In this mode, hardware
+                                                                            ///< will disable most frequency throttling and lock the frequency and
+                                                                            ///< voltage at the specified overclock values.
+
+} zes_oc_capabilities_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get handle of frequency domains
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDeviceEnumFrequencyDomains(
+    zes_device_handle_t hDevice,                                            ///< [in] Sysman handle of the device.
+    uint32_t* pCount,                                                       ///< [in,out] pointer to the number of components of this type.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of components of this type that are available.
+                                                                            ///< if count is greater than the number of components of this type that
+                                                                            ///< are available, then the driver shall update the value with the correct
+                                                                            ///< number of components.
+    zes_freq_handle_t* phFrequency                                          ///< [in,out][optional][range(0, *pCount)] array of handle of components of
+                                                                            ///< this type.
+                                                                            ///< if count is less than the number of components of this type that are
+                                                                            ///< available, then the driver shall only retrieve that number of
+                                                                            ///< component handles.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get frequency properties - available frequencies
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hFrequency`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pProperties`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesFrequencyGetProperties(
+    zes_freq_handle_t hFrequency,                                           ///< [in] Handle for the component.
+    zes_freq_properties_t* pProperties                                      ///< [in,out] The frequency properties for the specified domain.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get available non-overclocked hardware clock frequencies for the
+///        frequency domain
+/// 
+/// @details
+///     - The list of available frequencies is returned in order of slowest to
+///       fastest.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hFrequency`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesFrequencyGetAvailableClocks(
+    zes_freq_handle_t hFrequency,                                           ///< [in] Sysman handle of the device.
+    uint32_t* pCount,                                                       ///< [in,out] pointer to the number of frequencies.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of frequencies that are available.
+                                                                            ///< if count is greater than the number of frequencies that are available,
+                                                                            ///< then the driver shall update the value with the correct number of frequencies.
+    double* phFrequency                                                     ///< [in,out][optional][range(0, *pCount)] array of frequencies in units of
+                                                                            ///< MHz and sorted from slowest to fastest.
+                                                                            ///< if count is less than the number of frequencies that are available,
+                                                                            ///< then the driver shall only retrieve that number of frequencies.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get current frequency limits
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hFrequency`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pLimits`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesFrequencyGetRange(
+    zes_freq_handle_t hFrequency,                                           ///< [in] Handle for the component.
+    zes_freq_range_t* pLimits                                               ///< [in,out] The range between which the hardware can operate for the
+                                                                            ///< specified domain.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Set frequency range between which the hardware can operate.
+/// 
+/// @details
+///     - The application may call this function with the frequency range min
+///       and max values set to `-1` to request the frequency be (re)set to the
+///       default values.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hFrequency`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pLimits`
+///     - ::ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS
+///         + User does not have permissions to make these modifications.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesFrequencySetRange(
+    zes_freq_handle_t hFrequency,                                           ///< [in] Handle for the component.
+    const zes_freq_range_t* pLimits                                         ///< [in] The limits between which the hardware can operate for the
+                                                                            ///< specified domain.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get current frequency state - frequency request, actual frequency, TDP
+///        limits
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hFrequency`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pState`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesFrequencyGetState(
+    zes_freq_handle_t hFrequency,                                           ///< [in] Handle for the component.
+    zes_freq_state_t* pState                                                ///< [in,out] Frequency state for the specified domain.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get frequency throttle time
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hFrequency`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pThrottleTime`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesFrequencyGetThrottleTime(
+    zes_freq_handle_t hFrequency,                                           ///< [in] Handle for the component.
+    zes_freq_throttle_time_t* pThrottleTime                                 ///< [in,out] Will contain a snapshot of the throttle time counters for the
+                                                                            ///< specified domain.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get the overclocking capabilities.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+///     - [DEPRECATED] No longer supported.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hFrequency`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pOcCapabilities`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesFrequencyOcGetCapabilities(
+    zes_freq_handle_t hFrequency,                                           ///< [in] Handle for the component.
+    zes_oc_capabilities_t* pOcCapabilities                                  ///< [in,out] Pointer to the capabilities structure.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get the current overclocking frequency target, if extended moded is
+///        supported, will returned in 1 Mhz granularity.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+///     - [DEPRECATED] No longer supported.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hFrequency`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCurrentOcFrequency`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Overclocking is not supported on this frequency domain (see the `isOcSupported` member of ::zes_oc_capabilities_t).
+///         + The specified voltage and/or frequency overclock settings exceed the hardware values (see the `maxOcFrequency`, `maxOcVoltage`, `minOcVoltageOffset` and `maxOcVoltageOffset` members of ::zes_oc_capabilities_t).
+///         + Requested voltage overclock is very high but the `isHighVoltModeEnabled` member of ::zes_oc_capabilities_t is not enabled for the device.
+///     - ::ZE_RESULT_ERROR_NOT_AVAILABLE
+///         + Overclocking feature is locked on this frequency domain.
+///     - ::ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS
+///         + User does not have permissions to make these modifications.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesFrequencyOcGetFrequencyTarget(
+    zes_freq_handle_t hFrequency,                                           ///< [in] Handle for the component.
+    double* pCurrentOcFrequency                                             ///< [out] Overclocking Frequency in MHz, if extended moded is supported,
+                                                                            ///< will returned in 1 Mhz granularity, else, in multiples of 50 Mhz. This
+                                                                            ///< cannot be greater than the `maxOcFrequency` member of
+                                                                            ///< ::zes_oc_capabilities_t.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Set the current overclocking frequency target, if extended moded is
+///        supported, can be set in 1 Mhz granularity.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+///     - [DEPRECATED] No longer supported.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hFrequency`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Overclocking is not supported on this frequency domain (see the `isOcSupported` member of ::zes_oc_capabilities_t).
+///         + The specified voltage and/or frequency overclock settings exceed the hardware values (see the `maxOcFrequency`, `maxOcVoltage`, `minOcVoltageOffset` and `maxOcVoltageOffset` members of ::zes_oc_capabilities_t).
+///         + Requested voltage overclock is very high but the `isHighVoltModeEnabled` member of ::zes_oc_capabilities_t is not enabled for the device.
+///     - ::ZE_RESULT_ERROR_NOT_AVAILABLE
+///         + Overclocking feature is locked on this frequency domain.
+///     - ::ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS
+///         + User does not have permissions to make these modifications.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesFrequencyOcSetFrequencyTarget(
+    zes_freq_handle_t hFrequency,                                           ///< [in] Handle for the component.
+    double CurrentOcFrequency                                               ///< [in] Overclocking Frequency in MHz, if extended moded is supported, it
+                                                                            ///< could be set in 1 Mhz granularity, else, in multiples of 50 Mhz. This
+                                                                            ///< cannot be greater than the `maxOcFrequency` member of
+                                                                            ///< ::zes_oc_capabilities_t.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get the current overclocking voltage settings.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+///     - [DEPRECATED] No longer supported.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hFrequency`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCurrentVoltageTarget`
+///         + `nullptr == pCurrentVoltageOffset`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Overclocking is not supported on this frequency domain (see the `isOcSupported` member of ::zes_oc_capabilities_t).
+///         + The specified voltage and/or frequency overclock settings exceed the hardware values (see the `maxOcFrequency`, `maxOcVoltage`, `minOcVoltageOffset` and `maxOcVoltageOffset` members of ::zes_oc_capabilities_t).
+///         + Requested voltage overclock is very high but the `isHighVoltModeEnabled` member of ::zes_oc_capabilities_t is not enabled for the device.
+///     - ::ZE_RESULT_ERROR_NOT_AVAILABLE
+///         + Overclocking feature is locked on this frequency domain.
+///     - ::ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS
+///         + User does not have permissions to make these modifications.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesFrequencyOcGetVoltageTarget(
+    zes_freq_handle_t hFrequency,                                           ///< [in] Handle for the component.
+    double* pCurrentVoltageTarget,                                          ///< [out] Overclock voltage in Volts. This cannot be greater than the
+                                                                            ///< `maxOcVoltage` member of ::zes_oc_capabilities_t.
+    double* pCurrentVoltageOffset                                           ///< [out] This voltage offset is applied to all points on the
+                                                                            ///< voltage/frequency curve, including the new overclock voltageTarget.
+                                                                            ///< Valid range is between the `minOcVoltageOffset` and
+                                                                            ///< `maxOcVoltageOffset` members of ::zes_oc_capabilities_t.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Set the current overclocking voltage settings.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+///     - [DEPRECATED] No longer supported.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hFrequency`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Overclocking is not supported on this frequency domain (see the `isOcSupported` member of ::zes_oc_capabilities_t).
+///         + The specified voltage and/or frequency overclock settings exceed the hardware values (see the `maxOcFrequency`, `maxOcVoltage`, `minOcVoltageOffset` and `maxOcVoltageOffset` members of ::zes_oc_capabilities_t).
+///         + Requested voltage overclock is very high but the `isHighVoltModeEnabled` member of ::zes_oc_capabilities_t is not enabled for the device.
+///     - ::ZE_RESULT_ERROR_NOT_AVAILABLE
+///         + Overclocking feature is locked on this frequency domain.
+///     - ::ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS
+///         + User does not have permissions to make these modifications.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesFrequencyOcSetVoltageTarget(
+    zes_freq_handle_t hFrequency,                                           ///< [in] Handle for the component.
+    double CurrentVoltageTarget,                                            ///< [in] Overclock voltage in Volts. This cannot be greater than the
+                                                                            ///< `maxOcVoltage` member of ::zes_oc_capabilities_t.
+    double CurrentVoltageOffset                                             ///< [in] This voltage offset is applied to all points on the
+                                                                            ///< voltage/frequency curve, include the new overclock voltageTarget.
+                                                                            ///< Valid range is between the `minOcVoltageOffset` and
+                                                                            ///< `maxOcVoltageOffset` members of ::zes_oc_capabilities_t.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Set the current overclocking mode.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+///     - [DEPRECATED] No longer supported.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hFrequency`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::ZES_OC_MODE_FIXED < CurrentOcMode`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Overclocking is not supported on this frequency domain (see the `isOcSupported` member of ::zes_oc_capabilities_t).
+///         + The specified voltage and/or frequency overclock settings exceed the hardware values (see the `maxOcFrequency`, `maxOcVoltage`, `minOcVoltageOffset` and `maxOcVoltageOffset` members of ::zes_oc_capabilities_t).
+///         + Requested voltage overclock is very high but the `isHighVoltModeEnabled` member of ::zes_oc_capabilities_t is not enabled for the device.
+///     - ::ZE_RESULT_ERROR_NOT_AVAILABLE
+///         + Overclocking feature is locked on this frequency domain.
+///     - ::ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS
+///         + User does not have permissions to make these modifications.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesFrequencyOcSetMode(
+    zes_freq_handle_t hFrequency,                                           ///< [in] Handle for the component.
+    zes_oc_mode_t CurrentOcMode                                             ///< [in] Current Overclocking Mode ::zes_oc_mode_t.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get the current overclocking mode.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+///     - [DEPRECATED] No longer supported.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hFrequency`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCurrentOcMode`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Overclocking is not supported on this frequency domain (see the `isOcSupported` member of ::zes_oc_capabilities_t).
+///         + The specified voltage and/or frequency overclock settings exceed the hardware values (see the `maxOcFrequency`, `maxOcVoltage`, `minOcVoltageOffset` and `maxOcVoltageOffset` members of ::zes_oc_capabilities_t).
+///         + Requested voltage overclock is very high but the `isHighVoltModeEnabled` member of ::zes_oc_capabilities_t is not enabled for the device.
+///     - ::ZE_RESULT_ERROR_NOT_AVAILABLE
+///         + Overclocking feature is locked on this frequency domain.
+///     - ::ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS
+///         + User does not have permissions to make these modifications.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesFrequencyOcGetMode(
+    zes_freq_handle_t hFrequency,                                           ///< [in] Handle for the component.
+    zes_oc_mode_t* pCurrentOcMode                                           ///< [out] Current Overclocking Mode ::zes_oc_mode_t.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get the maximum current limit setting.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+///     - [DEPRECATED] No longer supported.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hFrequency`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pOcIccMax`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Overclocking is not supported on this frequency domain (see the `isOcSupported` member of ::zes_oc_capabilities_t).
+///         + Capability the `isIccMaxSupported` member of ::zes_oc_capabilities_t is false for this frequency domain.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesFrequencyOcGetIccMax(
+    zes_freq_handle_t hFrequency,                                           ///< [in] Handle for the component.
+    double* pOcIccMax                                                       ///< [in,out] Will contain the maximum current limit in Amperes on
+                                                                            ///< successful return.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Change the maximum current limit setting.
+/// 
+/// @details
+///     - Setting ocIccMax to 0.0 will return the value to the factory default.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+///     - [DEPRECATED] No longer supported.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hFrequency`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Overclocking is not supported on this frequency domain (see the `isOcSupported` member of ::zes_oc_capabilities_t).
+///         + The `isIccMaxSupported` member of ::zes_oc_capabilities_t is false for this frequency domain.
+///     - ::ZE_RESULT_ERROR_NOT_AVAILABLE
+///         + Overclocking feature is locked on this frequency domain.
+///     - ::ZE_RESULT_ERROR_INVALID_ARGUMENT
+///         + The specified current limit is too low or too high.
+///     - ::ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS
+///         + User does not have permissions to make these modifications.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesFrequencyOcSetIccMax(
+    zes_freq_handle_t hFrequency,                                           ///< [in] Handle for the component.
+    double ocIccMax                                                         ///< [in] The new maximum current limit in Amperes.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get the maximum temperature limit setting.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+///     - [DEPRECATED] No longer supported.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hFrequency`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pOcTjMax`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Overclocking is not supported on this frequency domain (see the `isOcSupported` member of ::zes_oc_capabilities_t).
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesFrequencyOcGetTjMax(
+    zes_freq_handle_t hFrequency,                                           ///< [in] Handle for the component.
+    double* pOcTjMax                                                        ///< [in,out] Will contain the maximum temperature limit in degrees Celsius
+                                                                            ///< on successful return.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Change the maximum temperature limit setting.
+/// 
+/// @details
+///     - Setting ocTjMax to 0.0 will return the value to the factory default.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+///     - [DEPRECATED] No longer supported.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hFrequency`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Overclocking is not supported on this frequency domain (see the `isOcSupported` member of ::zes_oc_capabilities_t).
+///         + The `isTjMaxSupported` member of ::zes_oc_capabilities_t is false for this frequency domain.
+///     - ::ZE_RESULT_ERROR_NOT_AVAILABLE
+///         + Overclocking feature is locked on this frequency domain.
+///     - ::ZE_RESULT_ERROR_INVALID_ARGUMENT
+///         + The specified temperature limit is too high.
+///     - ::ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS
+///         + User does not have permissions to make these modifications.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesFrequencyOcSetTjMax(
+    zes_freq_handle_t hFrequency,                                           ///< [in] Handle for the component.
+    double ocTjMax                                                          ///< [in] The new maximum temperature limit in degrees Celsius.
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Tool APIs for System Resource Management (Sysman) - Firmware management
+#if !defined(__GNUC__)
+#pragma region led
+#endif
+///////////////////////////////////////////////////////////////////////////////
+/// @brief LED properties
+typedef struct _zes_led_properties_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_bool_t onSubdevice;                                                  ///< [out] True if the resource is located on a sub-device; false means
+                                                                            ///< that the resource is on the device of the calling Sysman handle
+    uint32_t subdeviceId;                                                   ///< [out] If onSubdevice is true, this gives the ID of the sub-device
+    ze_bool_t canControl;                                                   ///< [out] Indicates if software can control the LED assuming the user has
+                                                                            ///< permissions
+    ze_bool_t haveRGB;                                                      ///< [out] Indicates if the LED is RGB capable
+
+} zes_led_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief LED color
+typedef struct _zes_led_color_t
+{
+    double red;                                                             ///< [in,out][range(0.0, 1.0)] The LED red value. On output, a value less
+                                                                            ///< than 0.0 indicates that the color is not known.
+    double green;                                                           ///< [in,out][range(0.0, 1.0)] The LED green value. On output, a value less
+                                                                            ///< than 0.0 indicates that the color is not known.
+    double blue;                                                            ///< [in,out][range(0.0, 1.0)] The LED blue value. On output, a value less
+                                                                            ///< than 0.0 indicates that the color is not known.
+
+} zes_led_color_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief LED state
+typedef struct _zes_led_state_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_bool_t isOn;                                                         ///< [out] Indicates if the LED is on or off
+    zes_led_color_t color;                                                  ///< [out] Color of the LED
+
+} zes_led_state_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get handle of LEDs
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDeviceEnumLeds(
+    zes_device_handle_t hDevice,                                            ///< [in] Sysman handle of the device.
+    uint32_t* pCount,                                                       ///< [in,out] pointer to the number of components of this type.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of components of this type that are available.
+                                                                            ///< if count is greater than the number of components of this type that
+                                                                            ///< are available, then the driver shall update the value with the correct
+                                                                            ///< number of components.
+    zes_led_handle_t* phLed                                                 ///< [in,out][optional][range(0, *pCount)] array of handle of components of
+                                                                            ///< this type.
+                                                                            ///< if count is less than the number of components of this type that are
+                                                                            ///< available, then the driver shall only retrieve that number of
+                                                                            ///< component handles.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get LED properties
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hLed`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pProperties`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesLedGetProperties(
+    zes_led_handle_t hLed,                                                  ///< [in] Handle for the component.
+    zes_led_properties_t* pProperties                                       ///< [in,out] Will contain the properties of the LED.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get current state of a LED - on/off, color
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hLed`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pState`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesLedGetState(
+    zes_led_handle_t hLed,                                                  ///< [in] Handle for the component.
+    zes_led_state_t* pState                                                 ///< [in,out] Will contain the current state of the LED.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Turn the LED on/off
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hLed`
+///     - ::ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS
+///         + User does not have permissions to make these modifications.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesLedSetState(
+    zes_led_handle_t hLed,                                                  ///< [in] Handle for the component.
+    ze_bool_t enable                                                        ///< [in] Set to TRUE to turn the LED on, FALSE to turn off.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Set the color of the LED
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hLed`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pColor`
+///     - ::ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS
+///         + User does not have permissions to make these modifications.
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + This LED doesn't not support color changes. See the `haveRGB` member of ::zes_led_properties_t.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesLedSetColor(
+    zes_led_handle_t hLed,                                                  ///< [in] Handle for the component.
+    const zes_led_color_t* pColor                                           ///< [in] New color of the LED.
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Tool APIs for System Resource Management (Sysman) - Memory management
+#if !defined(__GNUC__)
+#pragma region memory
+#endif
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Memory module types
+typedef enum _zes_mem_type_t
+{
+    ZES_MEM_TYPE_HBM = 0,                                                   ///< HBM memory
+    ZES_MEM_TYPE_DDR = 1,                                                   ///< DDR memory
+    ZES_MEM_TYPE_DDR3 = 2,                                                  ///< DDR3 memory
+    ZES_MEM_TYPE_DDR4 = 3,                                                  ///< DDR4 memory
+    ZES_MEM_TYPE_DDR5 = 4,                                                  ///< DDR5 memory
+    ZES_MEM_TYPE_LPDDR = 5,                                                 ///< LPDDR memory
+    ZES_MEM_TYPE_LPDDR3 = 6,                                                ///< LPDDR3 memory
+    ZES_MEM_TYPE_LPDDR4 = 7,                                                ///< LPDDR4 memory
+    ZES_MEM_TYPE_LPDDR5 = 8,                                                ///< LPDDR5 memory
+    ZES_MEM_TYPE_SRAM = 9,                                                  ///< SRAM memory
+    ZES_MEM_TYPE_L1 = 10,                                                   ///< L1 cache
+    ZES_MEM_TYPE_L3 = 11,                                                   ///< L3 cache
+    ZES_MEM_TYPE_GRF = 12,                                                  ///< Execution unit register file
+    ZES_MEM_TYPE_SLM = 13,                                                  ///< Execution unit shared local memory
+    ZES_MEM_TYPE_GDDR4 = 14,                                                ///< GDDR4 memory
+    ZES_MEM_TYPE_GDDR5 = 15,                                                ///< GDDR5 memory
+    ZES_MEM_TYPE_GDDR5X = 16,                                               ///< GDDR5X memory
+    ZES_MEM_TYPE_GDDR6 = 17,                                                ///< GDDR6 memory
+    ZES_MEM_TYPE_GDDR6X = 18,                                               ///< GDDR6X memory
+    ZES_MEM_TYPE_GDDR7 = 19,                                                ///< GDDR7 memory
+    ZES_MEM_TYPE_FORCE_UINT32 = 0x7fffffff
+
+} zes_mem_type_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Memory module location
+typedef enum _zes_mem_loc_t
+{
+    ZES_MEM_LOC_SYSTEM = 0,                                                 ///< System memory
+    ZES_MEM_LOC_DEVICE = 1,                                                 ///< On board local device memory
+    ZES_MEM_LOC_FORCE_UINT32 = 0x7fffffff
+
+} zes_mem_loc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Memory health
+typedef enum _zes_mem_health_t
+{
+    ZES_MEM_HEALTH_UNKNOWN = 0,                                             ///< The memory health cannot be determined.
+    ZES_MEM_HEALTH_OK = 1,                                                  ///< All memory channels are healthy.
+    ZES_MEM_HEALTH_DEGRADED = 2,                                            ///< Excessive correctable errors have been detected on one or more
+                                                                            ///< channels. Device should be reset.
+    ZES_MEM_HEALTH_CRITICAL = 3,                                            ///< Operating with reduced memory to cover banks with too many
+                                                                            ///< uncorrectable errors.
+    ZES_MEM_HEALTH_REPLACE = 4,                                             ///< Device should be replaced due to excessive uncorrectable errors.
+    ZES_MEM_HEALTH_FORCE_UINT32 = 0x7fffffff
+
+} zes_mem_health_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Memory properties
+typedef struct _zes_mem_properties_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    zes_mem_type_t type;                                                    ///< [out] The memory type
+    ze_bool_t onSubdevice;                                                  ///< [out] True if this resource is located on a sub-device; false means
+                                                                            ///< that the resource is on the device of the calling Sysman handle
+    uint32_t subdeviceId;                                                   ///< [out] If onSubdevice is true, this gives the ID of the sub-device
+    zes_mem_loc_t location;                                                 ///< [out] Location of this memory (system, device)
+    uint64_t physicalSize;                                                  ///< [out] Physical memory size in bytes. A value of 0 indicates that this
+                                                                            ///< property is not known. However, a call to ::zesMemoryGetState() will
+                                                                            ///< correctly return the total size of usable memory.
+    int32_t busWidth;                                                       ///< [out] Width of the memory bus. A value of -1 means that this property
+                                                                            ///< is unknown.
+    int32_t numChannels;                                                    ///< [out] The number of memory channels. A value of -1 means that this
+                                                                            ///< property is unknown.
+
+} zes_mem_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Memory state - health, allocated
+/// 
+/// @details
+///     - Percent allocation is given by 100 * (size - free / size.
+///     - Percent free is given by 100 * free / size.
+typedef struct _zes_mem_state_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    zes_mem_health_t health;                                                ///< [out] Indicates the health of the memory
+    uint64_t free;                                                          ///< [out] The free memory in bytes
+    uint64_t size;                                                          ///< [out] The total allocatable memory in bytes (can be less than the
+                                                                            ///< `physicalSize` member of ::zes_mem_properties_t)
+
+} zes_mem_state_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Memory bandwidth
+/// 
+/// @details
+///     - Percent bandwidth is calculated by taking two snapshots (s1, s2) and
+///       using the equation: %bw = 10^6 * ((s2.readCounter - s1.readCounter) +
+///       (s2.writeCounter - s1.writeCounter)) / (s2.maxBandwidth *
+///       (s2.timestamp - s1.timestamp))
+///     - Counter can roll over and rollover needs to be handled by comparing
+///       the current read against the previous read
+///     - Counter is a 32 byte transaction count, which means the calculated
+///       delta (delta = current_value - previous_value or delta = 2^32 -
+///       previous_value + current_value in case of rollover) needs to be
+///       multiplied by 32 to get delta between samples in actual byte count
+typedef struct _zes_mem_bandwidth_t
+{
+    uint64_t readCounter;                                                   ///< [out] Total bytes read from memory
+    uint64_t writeCounter;                                                  ///< [out] Total bytes written to memory
+    uint64_t maxBandwidth;                                                  ///< [out] Current maximum bandwidth in units of bytes/sec
+    uint64_t timestamp;                                                     ///< [out] The timestamp in microseconds when these measurements were sampled.
+                                                                            ///< This timestamp should only be used to calculate delta time between
+                                                                            ///< snapshots of this structure.
+                                                                            ///< Never take the delta of this timestamp with the timestamp from a
+                                                                            ///< different structure since they are not guaranteed to have the same base.
+                                                                            ///< The absolute value of the timestamp is only valid during within the
+                                                                            ///< application and may be different on the next execution.
+
+} zes_mem_bandwidth_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Extension properties for Memory bandwidth
+/// 
+/// @details
+///     - Number of counter bits
+///     - [DEPRECATED] No longer supported.
+typedef struct _zes_mem_ext_bandwidth_t
+{
+    uint32_t memoryTimestampValidBits;                                      ///< [out] Returns the number of valid bits in the timestamp values
+
+} zes_mem_ext_bandwidth_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get handle of memory modules
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDeviceEnumMemoryModules(
+    zes_device_handle_t hDevice,                                            ///< [in] Sysman handle of the device.
+    uint32_t* pCount,                                                       ///< [in,out] pointer to the number of components of this type.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of components of this type that are available.
+                                                                            ///< if count is greater than the number of components of this type that
+                                                                            ///< are available, then the driver shall update the value with the correct
+                                                                            ///< number of components.
+    zes_mem_handle_t* phMemory                                              ///< [in,out][optional][range(0, *pCount)] array of handle of components of
+                                                                            ///< this type.
+                                                                            ///< if count is less than the number of components of this type that are
+                                                                            ///< available, then the driver shall only retrieve that number of
+                                                                            ///< component handles.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get memory properties
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hMemory`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pProperties`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesMemoryGetProperties(
+    zes_mem_handle_t hMemory,                                               ///< [in] Handle for the component.
+    zes_mem_properties_t* pProperties                                       ///< [in,out] Will contain memory properties.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get memory state - health, allocated
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hMemory`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pState`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesMemoryGetState(
+    zes_mem_handle_t hMemory,                                               ///< [in] Handle for the component.
+    zes_mem_state_t* pState                                                 ///< [in,out] Will contain the current health and allocated memory.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get memory bandwidth
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hMemory`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pBandwidth`
+///     - ::ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS
+///         + User does not have permissions to query this telemetry.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesMemoryGetBandwidth(
+    zes_mem_handle_t hMemory,                                               ///< [in] Handle for the component.
+    zes_mem_bandwidth_t* pBandwidth                                         ///< [in,out] Will contain the total number of bytes read from and written
+                                                                            ///< to memory, as well as the current maximum bandwidth.
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Tool APIs for System Resource Management (Sysman) - Performance factor
+#if !defined(__GNUC__)
+#pragma region performance
+#endif
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Static information about a Performance Factor domain
+typedef struct _zes_perf_properties_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_bool_t onSubdevice;                                                  ///< [out] True if this Performance Factor affects accelerators located on
+                                                                            ///< a sub-device
+    uint32_t subdeviceId;                                                   ///< [out] If onSubdevice is true, this gives the ID of the sub-device
+    zes_engine_type_flags_t engines;                                        ///< [out] Bitfield of accelerator engine types that are affected by this
+                                                                            ///< Performance Factor.
+
+} zes_perf_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get handles to accelerator domains whose performance can be optimized
+///        via a Performance Factor
+/// 
+/// @details
+///     - A Performance Factor should be tuned for each workload.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDeviceEnumPerformanceFactorDomains(
+    zes_device_handle_t hDevice,                                            ///< [in] Sysman handle of the device.
+    uint32_t* pCount,                                                       ///< [in,out] pointer to the number of components of this type.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of components of this type that are available.
+                                                                            ///< if count is greater than the number of components of this type that
+                                                                            ///< are available, then the driver shall update the value with the correct
+                                                                            ///< number of components.
+    zes_perf_handle_t* phPerf                                               ///< [in,out][optional][range(0, *pCount)] array of handle of components of
+                                                                            ///< this type.
+                                                                            ///< if count is less than the number of components of this type that are
+                                                                            ///< available, then the driver shall only retrieve that number of
+                                                                            ///< component handles.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get properties about a Performance Factor domain
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hPerf`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pProperties`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesPerformanceFactorGetProperties(
+    zes_perf_handle_t hPerf,                                                ///< [in] Handle for the Performance Factor domain.
+    zes_perf_properties_t* pProperties                                      ///< [in,out] Will contain information about the specified Performance
+                                                                            ///< Factor domain.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get current Performance Factor for a given domain
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hPerf`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pFactor`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesPerformanceFactorGetConfig(
+    zes_perf_handle_t hPerf,                                                ///< [in] Handle for the Performance Factor domain.
+    double* pFactor                                                         ///< [in,out] Will contain the actual Performance Factor being used by the
+                                                                            ///< hardware (may not be the same as the requested Performance Factor).
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Change the performance factor for a domain
+/// 
+/// @details
+///     - The Performance Factor is a number between 0 and 100.
+///     - A Performance Factor is a hint to the hardware. Depending on the
+///       hardware, the request may not be granted. Follow up this function with
+///       a call to ::zesPerformanceFactorGetConfig() to determine the actual
+///       factor being used by the hardware.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hPerf`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesPerformanceFactorSetConfig(
+    zes_perf_handle_t hPerf,                                                ///< [in] Handle for the Performance Factor domain.
+    double factor                                                           ///< [in] The new Performance Factor.
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Tool APIs for System Resource Management (Sysman) - Scheduler management
+#if !defined(__GNUC__)
+#pragma region power
+#endif
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Power Domain
+typedef enum _zes_power_domain_t
+{
+    ZES_POWER_DOMAIN_UNKNOWN = 0,                                           ///< The PUnit power domain level cannot be determined.
+    ZES_POWER_DOMAIN_CARD = 1,                                              ///< The PUnit power domain is a card-level power domain.
+    ZES_POWER_DOMAIN_PACKAGE = 2,                                           ///< The PUnit power domain is a package-level power domain.
+    ZES_POWER_DOMAIN_STACK = 3,                                             ///< The PUnit power domain is a stack-level power domain.
+    ZES_POWER_DOMAIN_MEMORY = 4,                                            ///< The PUnit power domain is a memory-level power domain.
+    ZES_POWER_DOMAIN_GPU = 5,                                               ///< The PUnit power domain is a GPU-level power domain.
+    ZES_POWER_DOMAIN_FORCE_UINT32 = 0x7fffffff
+
+} zes_power_domain_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Power Level Type
+typedef enum _zes_power_level_t
+{
+    ZES_POWER_LEVEL_UNKNOWN = 0,                                            ///< The PUnit power monitoring duration cannot be determined.
+    ZES_POWER_LEVEL_SUSTAINED = 1,                                          ///< The PUnit determines effective power draw by computing a moving
+                                                                            ///< average of the actual power draw over a time interval (longer than
+                                                                            ///< BURST).
+    ZES_POWER_LEVEL_BURST = 2,                                              ///< The PUnit determines effective power draw by computing a moving
+                                                                            ///< average of the actual power draw over a time interval (longer than
+                                                                            ///< PEAK).
+    ZES_POWER_LEVEL_PEAK = 3,                                               ///< The PUnit determines effective power draw by computing a moving
+                                                                            ///< average of the actual power draw over a very short time interval.
+    ZES_POWER_LEVEL_INSTANTANEOUS = 4,                                      ///< The PUnit predicts effective power draw using the current device
+                                                                            ///< configuration (frequency, voltage, etc...) & throttles proactively to
+                                                                            ///< stay within the specified limit.
+    ZES_POWER_LEVEL_FORCE_UINT32 = 0x7fffffff
+
+} zes_power_level_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Power Source Type
+typedef enum _zes_power_source_t
+{
+    ZES_POWER_SOURCE_ANY = 0,                                               ///< Limit active no matter whether the power source is mains powered or
+                                                                            ///< battery powered.
+    ZES_POWER_SOURCE_MAINS = 1,                                             ///< Limit active only when the device is mains powered.
+    ZES_POWER_SOURCE_BATTERY = 2,                                           ///< Limit active only when the device is battery powered.
+    ZES_POWER_SOURCE_FORCE_UINT32 = 0x7fffffff
+
+} zes_power_source_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Limit Unit
+typedef enum _zes_limit_unit_t
+{
+    ZES_LIMIT_UNIT_UNKNOWN = 0,                                             ///< The PUnit power monitoring unit cannot be determined.
+    ZES_LIMIT_UNIT_CURRENT = 1,                                             ///< The limit is specified in milliamperes of current drawn.
+    ZES_LIMIT_UNIT_POWER = 2,                                               ///< The limit is specified in milliwatts of power generated.
+    ZES_LIMIT_UNIT_FORCE_UINT32 = 0x7fffffff
+
+} zes_limit_unit_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Properties related to device power settings
+typedef struct _zes_power_properties_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_bool_t onSubdevice;                                                  ///< [out] True if this resource is located on a sub-device; false means
+                                                                            ///< that the resource is on the device of the calling Sysman handle
+    uint32_t subdeviceId;                                                   ///< [out] If onSubdevice is true, this gives the ID of the sub-device
+    ze_bool_t canControl;                                                   ///< [out] Software can change the power limits of this domain assuming the
+                                                                            ///< user has permissions.
+    ze_bool_t isEnergyThresholdSupported;                                   ///< [out] Indicates if this power domain supports the energy threshold
+                                                                            ///< event (::ZES_EVENT_TYPE_FLAG_ENERGY_THRESHOLD_CROSSED).
+    int32_t defaultLimit;                                                   ///< [out] (Deprecated) The factory default TDP power limit of the part in
+                                                                            ///< milliwatts. A value of -1 means that this is not known.
+    int32_t minLimit;                                                       ///< [out] (Deprecated) The minimum power limit in milliwatts that can be
+                                                                            ///< requested. A value of -1 means that this is not known.
+    int32_t maxLimit;                                                       ///< [out] (Deprecated) The maximum power limit in milliwatts that can be
+                                                                            ///< requested. A value of -1 means that this is not known.
+
+} zes_power_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Energy counter snapshot
+/// 
+/// @details
+///     - Average power is calculated by taking two snapshots (s1, s2) and using
+///       the equation: PowerWatts = (s2.energy - s1.energy) / (s2.timestamp -
+///       s1.timestamp)
+typedef struct _zes_power_energy_counter_t
+{
+    uint64_t energy;                                                        ///< [out] The monotonic energy counter in microjoules.
+    uint64_t timestamp;                                                     ///< [out] Microsecond timestamp when energy was captured.
+                                                                            ///< This timestamp should only be used to calculate delta time between
+                                                                            ///< snapshots of this structure.
+                                                                            ///< Never take the delta of this timestamp with the timestamp from a
+                                                                            ///< different structure since they are not guaranteed to have the same base.
+                                                                            ///< The absolute value of the timestamp is only valid during within the
+                                                                            ///< application and may be different on the next execution.
+
+} zes_power_energy_counter_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Sustained power limits
+/// 
+/// @details
+///     - The power controller (Punit) will throttle the operating frequency if
+///       the power averaged over a window (typically seconds) exceeds this
+///       limit.
+///     - [DEPRECATED] No longer supported.
+typedef struct _zes_power_sustained_limit_t
+{
+    ze_bool_t enabled;                                                      ///< [in,out] indicates if the limit is enabled (true) or ignored (false)
+    int32_t power;                                                          ///< [in,out] power limit in milliwatts
+    int32_t interval;                                                       ///< [in,out] power averaging window (Tau) in milliseconds
+
+} zes_power_sustained_limit_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Burst power limit
+/// 
+/// @details
+///     - The power controller (Punit) will throttle the operating frequency of
+///       the device if the power averaged over a few milliseconds exceeds a
+///       limit known as PL2. Typically PL2 > PL1 so that it permits the
+///       frequency to burst higher for short periods than would be otherwise
+///       permitted by PL1.
+///     - [DEPRECATED] No longer supported.
+typedef struct _zes_power_burst_limit_t
+{
+    ze_bool_t enabled;                                                      ///< [in,out] indicates if the limit is enabled (true) or ignored (false)
+    int32_t power;                                                          ///< [in,out] power limit in milliwatts
+
+} zes_power_burst_limit_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Peak power limit
+/// 
+/// @details
+///     - The power controller (Punit) will reactively/proactively throttle the
+///       operating frequency of the device when the instantaneous/100usec power
+///       exceeds this limit. The limit is known as PL4 or Psys. It expresses
+///       the maximum power that can be drawn from the power supply.
+///     - If this power limit is removed or set too high, the power supply will
+///       generate an interrupt when it detects an overcurrent condition and the
+///       power controller will throttle the device frequencies down to min. It
+///       is thus better to tune the PL4 value in order to avoid such
+///       excursions.
+///     - [DEPRECATED] No longer supported.
+typedef struct _zes_power_peak_limit_t
+{
+    int32_t powerAC;                                                        ///< [in,out] power limit in milliwatts for the AC power source.
+    int32_t powerDC;                                                        ///< [in,out] power limit in milliwatts for the DC power source. On input,
+                                                                            ///< this is ignored if the product does not have a battery. On output,
+                                                                            ///< this will be -1 if the product does not have a battery.
+
+} zes_power_peak_limit_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Energy threshold
+/// 
+/// @details
+///     - .
+typedef struct _zes_energy_threshold_t
+{
+    ze_bool_t enable;                                                       ///< [in,out] Indicates if the energy threshold is enabled.
+    double threshold;                                                       ///< [in,out] The energy threshold in Joules. Will be 0.0 if no threshold
+                                                                            ///< has been set.
+    uint32_t processId;                                                     ///< [in,out] The host process ID that set the energy threshold. Will be
+                                                                            ///< 0xFFFFFFFF if no threshold has been set.
+
+} zes_energy_threshold_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get handle of power domains
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDeviceEnumPowerDomains(
+    zes_device_handle_t hDevice,                                            ///< [in] Sysman handle of the device.
+    uint32_t* pCount,                                                       ///< [in,out] pointer to the number of components of this type.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of components of this type that are available.
+                                                                            ///< if count is greater than the number of components of this type that
+                                                                            ///< are available, then the driver shall update the value with the correct
+                                                                            ///< number of components.
+    zes_pwr_handle_t* phPower                                               ///< [in,out][optional][range(0, *pCount)] array of handle of components of
+                                                                            ///< this type.
+                                                                            ///< if count is less than the number of components of this type that are
+                                                                            ///< available, then the driver shall only retrieve that number of
+                                                                            ///< component handles.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get handle of the PCIe card-level power
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+///     - [DEPRECATED] No longer supported.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == phPower`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + The device does not provide access to card level power controls or telemetry. An invalid power domain handle will be returned in phPower.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDeviceGetCardPowerDomain(
+    zes_device_handle_t hDevice,                                            ///< [in] Sysman handle of the device.
+    zes_pwr_handle_t* phPower                                               ///< [in,out] power domain handle for the entire PCIe card.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get properties related to a power domain
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hPower`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pProperties`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesPowerGetProperties(
+    zes_pwr_handle_t hPower,                                                ///< [in] Handle for the component.
+    zes_power_properties_t* pProperties                                     ///< [in,out] Structure that will contain property data.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get energy counter
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hPower`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pEnergy`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesPowerGetEnergyCounter(
+    zes_pwr_handle_t hPower,                                                ///< [in] Handle for the component.
+    zes_power_energy_counter_t* pEnergy                                     ///< [in,out] Will contain the latest snapshot of the energy counter and
+                                                                            ///< timestamp when the last counter value was measured.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get power limits
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+///     - [DEPRECATED] Use ::zesPowerGetLimitsExt.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hPower`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesPowerGetLimits(
+    zes_pwr_handle_t hPower,                                                ///< [in] Handle for the component.
+    zes_power_sustained_limit_t* pSustained,                                ///< [in,out][optional] The sustained power limit. If this is null, the
+                                                                            ///< current sustained power limits will not be returned.
+    zes_power_burst_limit_t* pBurst,                                        ///< [in,out][optional] The burst power limit. If this is null, the current
+                                                                            ///< peak power limits will not be returned.
+    zes_power_peak_limit_t* pPeak                                           ///< [in,out][optional] The peak power limit. If this is null, the peak
+                                                                            ///< power limits will not be returned.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Set power limits
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+///     - [DEPRECATED] Use ::zesPowerSetLimitsExt.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hPower`
+///     - ::ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS
+///         + User does not have permissions to make these modifications.
+///     - ::ZE_RESULT_ERROR_NOT_AVAILABLE
+///         + The device is in use, meaning that the GPU is under Over clocking, applying power limits under overclocking is not supported.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesPowerSetLimits(
+    zes_pwr_handle_t hPower,                                                ///< [in] Handle for the component.
+    const zes_power_sustained_limit_t* pSustained,                          ///< [in][optional] The sustained power limit. If this is null, no changes
+                                                                            ///< will be made to the sustained power limits.
+    const zes_power_burst_limit_t* pBurst,                                  ///< [in][optional] The burst power limit. If this is null, no changes will
+                                                                            ///< be made to the burst power limits.
+    const zes_power_peak_limit_t* pPeak                                     ///< [in][optional] The peak power limit. If this is null, no changes will
+                                                                            ///< be made to the peak power limits.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get energy threshold
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hPower`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pThreshold`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Energy threshold not supported on this power domain (check the `isEnergyThresholdSupported` member of ::zes_power_properties_t).
+///     - ::ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS
+///         + User does not have permissions to request this feature.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesPowerGetEnergyThreshold(
+    zes_pwr_handle_t hPower,                                                ///< [in] Handle for the component.
+    zes_energy_threshold_t* pThreshold                                      ///< [in,out] Returns information about the energy threshold setting -
+                                                                            ///< enabled/energy threshold/process ID.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Set energy threshold
+/// 
+/// @details
+///     - An event ::ZES_EVENT_TYPE_FLAG_ENERGY_THRESHOLD_CROSSED will be
+///       generated when the delta energy consumed starting from this call
+///       exceeds the specified threshold. Use the function
+///       ::zesDeviceEventRegister() to start receiving the event.
+///     - Only one running process can control the energy threshold at a given
+///       time. If another process attempts to change the energy threshold, the
+///       error ::ZE_RESULT_ERROR_NOT_AVAILABLE will be returned. The function
+///       ::zesPowerGetEnergyThreshold() to determine the process ID currently
+///       controlling this setting.
+///     - Calling this function will remove any pending energy thresholds and
+///       start counting from the time of this call.
+///     - Once the energy threshold has been reached and the event generated,
+///       the threshold is automatically removed. It is up to the application to
+///       request a new threshold.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hPower`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Energy threshold not supported on this power domain (check the `isEnergyThresholdSupported` member of ::zes_power_properties_t).
+///     - ::ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS
+///         + User does not have permissions to request this feature.
+///     - ::ZE_RESULT_ERROR_NOT_AVAILABLE
+///         + Another running process has set the energy threshold.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesPowerSetEnergyThreshold(
+    zes_pwr_handle_t hPower,                                                ///< [in] Handle for the component.
+    double threshold                                                        ///< [in] The energy threshold to be set in joules.
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Tool APIs for System Resource Management (Sysman) - Firmware management
+#if !defined(__GNUC__)
+#pragma region psu
+#endif
+///////////////////////////////////////////////////////////////////////////////
+/// @brief PSU voltage status
+typedef enum _zes_psu_voltage_status_t
+{
+    ZES_PSU_VOLTAGE_STATUS_UNKNOWN = 0,                                     ///< The status of the power supply voltage controllers cannot be
+                                                                            ///< determined
+    ZES_PSU_VOLTAGE_STATUS_NORMAL = 1,                                      ///< No unusual voltages have been detected
+    ZES_PSU_VOLTAGE_STATUS_OVER = 2,                                        ///< Over-voltage has occurred
+    ZES_PSU_VOLTAGE_STATUS_UNDER = 3,                                       ///< Under-voltage has occurred
+    ZES_PSU_VOLTAGE_STATUS_FORCE_UINT32 = 0x7fffffff
+
+} zes_psu_voltage_status_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Static properties of the power supply
+typedef struct _zes_psu_properties_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_bool_t onSubdevice;                                                  ///< [out] True if the resource is located on a sub-device; false means
+                                                                            ///< that the resource is on the device of the calling Sysman handle
+    uint32_t subdeviceId;                                                   ///< [out] If onSubdevice is true, this gives the ID of the sub-device
+    ze_bool_t haveFan;                                                      ///< [out] True if the power supply has a fan
+    int32_t ampLimit;                                                       ///< [out] The maximum electrical current in milliamperes that can be
+                                                                            ///< drawn. A value of -1 indicates that this property cannot be
+                                                                            ///< determined.
+
+} zes_psu_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Dynamic state of the power supply
+typedef struct _zes_psu_state_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    zes_psu_voltage_status_t voltStatus;                                    ///< [out] The current PSU voltage status
+    ze_bool_t fanFailed;                                                    ///< [out] Indicates if the fan has failed
+    int32_t temperature;                                                    ///< [out] Read the current heatsink temperature in degrees Celsius. A
+                                                                            ///< value of -1 indicates that this property cannot be determined.
+    int32_t current;                                                        ///< [out] The amps being drawn in milliamperes. A value of -1 indicates
+                                                                            ///< that this property cannot be determined.
+
+} zes_psu_state_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get handle of power supplies
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDeviceEnumPsus(
+    zes_device_handle_t hDevice,                                            ///< [in] Sysman handle of the device.
+    uint32_t* pCount,                                                       ///< [in,out] pointer to the number of components of this type.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of components of this type that are available.
+                                                                            ///< if count is greater than the number of components of this type that
+                                                                            ///< are available, then the driver shall update the value with the correct
+                                                                            ///< number of components.
+    zes_psu_handle_t* phPsu                                                 ///< [in,out][optional][range(0, *pCount)] array of handle of components of
+                                                                            ///< this type.
+                                                                            ///< if count is less than the number of components of this type that are
+                                                                            ///< available, then the driver shall only retrieve that number of
+                                                                            ///< component handles.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get power supply properties
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hPsu`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pProperties`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesPsuGetProperties(
+    zes_psu_handle_t hPsu,                                                  ///< [in] Handle for the component.
+    zes_psu_properties_t* pProperties                                       ///< [in,out] Will contain the properties of the power supply.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get current power supply state
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hPsu`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pState`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesPsuGetState(
+    zes_psu_handle_t hPsu,                                                  ///< [in] Handle for the component.
+    zes_psu_state_t* pState                                                 ///< [in,out] Will contain the current state of the power supply.
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Tool APIs for System Resource Management (Sysman) - Firmware management
+#if !defined(__GNUC__)
+#pragma region ras
+#endif
+///////////////////////////////////////////////////////////////////////////////
+/// @brief RAS error type
+typedef enum _zes_ras_error_type_t
+{
+    ZES_RAS_ERROR_TYPE_CORRECTABLE = 0,                                     ///< Errors were corrected by hardware
+    ZES_RAS_ERROR_TYPE_UNCORRECTABLE = 1,                                   ///< Error were not corrected
+    ZES_RAS_ERROR_TYPE_FORCE_UINT32 = 0x7fffffff
+
+} zes_ras_error_type_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief RAS error categories
+typedef enum _zes_ras_error_cat_t
+{
+    ZES_RAS_ERROR_CAT_RESET = 0,                                            ///< The number of accelerator engine resets attempted by the driver
+    ZES_RAS_ERROR_CAT_PROGRAMMING_ERRORS = 1,                               ///< The number of hardware exceptions generated by the way workloads have
+                                                                            ///< programmed the hardware
+    ZES_RAS_ERROR_CAT_DRIVER_ERRORS = 2,                                    ///< The number of low level driver communication errors have occurred
+    ZES_RAS_ERROR_CAT_COMPUTE_ERRORS = 3,                                   ///< The number of errors that have occurred in the compute accelerator
+                                                                            ///< hardware
+    ZES_RAS_ERROR_CAT_NON_COMPUTE_ERRORS = 4,                               ///< The number of errors that have occurred in the fixed-function
+                                                                            ///< accelerator hardware
+    ZES_RAS_ERROR_CAT_CACHE_ERRORS = 5,                                     ///< The number of errors that have occurred in caches (L1/L3/register
+                                                                            ///< file/shared local memory/sampler)
+    ZES_RAS_ERROR_CAT_DISPLAY_ERRORS = 6,                                   ///< The number of errors that have occurred in the display
+    ZES_RAS_ERROR_CAT_FORCE_UINT32 = 0x7fffffff
+
+} zes_ras_error_cat_t;
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZES_MAX_RAS_ERROR_CATEGORY_COUNT
+/// @brief The maximum number of categories
+#define ZES_MAX_RAS_ERROR_CATEGORY_COUNT  7
+#endif // ZES_MAX_RAS_ERROR_CATEGORY_COUNT
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief RAS properties
+typedef struct _zes_ras_properties_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    zes_ras_error_type_t type;                                              ///< [out] The type of RAS error
+    ze_bool_t onSubdevice;                                                  ///< [out] True if the resource is located on a sub-device; false means
+                                                                            ///< that the resource is on the device of the calling Sysman handle
+    uint32_t subdeviceId;                                                   ///< [out] If onSubdevice is true, this gives the ID of the sub-device
+
+} zes_ras_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief RAS error details
+typedef struct _zes_ras_state_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    uint64_t category[ZES_MAX_RAS_ERROR_CATEGORY_COUNT];                    ///< [in][out] Breakdown of error by category
+
+} zes_ras_state_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief RAS error configuration - thresholds used for triggering RAS events
+///        (::ZES_EVENT_TYPE_FLAG_RAS_CORRECTABLE_ERRORS,
+///        ::ZES_EVENT_TYPE_FLAG_RAS_UNCORRECTABLE_ERRORS)
+/// 
+/// @details
+///     - The driver maintains a total counter which is updated every time a
+///       hardware block covered by the corresponding RAS error set notifies
+///       that an error has occurred. When this total count goes above the
+///       totalThreshold specified below, a RAS event is triggered.
+///     - The driver also maintains a counter for each category of RAS error
+///       (see ::zes_ras_state_t for a breakdown). Each time a hardware block of
+///       that category notifies that an error has occurred, that corresponding
+///       category counter is updated. When it goes above the threshold
+///       specified in detailedThresholds, a RAS event is triggered.
+typedef struct _zes_ras_config_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    uint64_t totalThreshold;                                                ///< [in,out] If the total RAS errors exceeds this threshold, the event
+                                                                            ///< will be triggered. A value of 0ULL disables triggering the event based
+                                                                            ///< on the total counter.
+    zes_ras_state_t detailedThresholds;                                     ///< [in,out] If the RAS errors for each category exceed the threshold for
+                                                                            ///< that category, the event will be triggered. A value of 0ULL will
+                                                                            ///< disable an event being triggered for that category.
+
+} zes_ras_config_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get handle of all RAS error sets on a device
+/// 
+/// @details
+///     - A RAS error set is a collection of RAS error counters of a given type
+///       (correctable/uncorrectable) from hardware blocks contained within a
+///       sub-device or within the device.
+///     - A device without sub-devices will typically return two handles, one
+///       for correctable errors sets and one for uncorrectable error sets.
+///     - A device with sub-devices will return RAS error sets for each
+///       sub-device and possibly RAS error sets for hardware blocks outside the
+///       sub-devices.
+///     - If the function completes successfully but pCount is set to 0, RAS
+///       features are not available/enabled on this device.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDeviceEnumRasErrorSets(
+    zes_device_handle_t hDevice,                                            ///< [in] Sysman handle of the device.
+    uint32_t* pCount,                                                       ///< [in,out] pointer to the number of components of this type.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of components of this type that are available.
+                                                                            ///< if count is greater than the number of components of this type that
+                                                                            ///< are available, then the driver shall update the value with the correct
+                                                                            ///< number of components.
+    zes_ras_handle_t* phRas                                                 ///< [in,out][optional][range(0, *pCount)] array of handle of components of
+                                                                            ///< this type.
+                                                                            ///< if count is less than the number of components of this type that are
+                                                                            ///< available, then the driver shall only retrieve that number of
+                                                                            ///< component handles.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get RAS properties of a given RAS error set - this enables discovery
+///        of the type of RAS error set (correctable/uncorrectable) and if
+///        located on a sub-device
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hRas`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pProperties`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesRasGetProperties(
+    zes_ras_handle_t hRas,                                                  ///< [in] Handle for the component.
+    zes_ras_properties_t* pProperties                                       ///< [in,out] Structure describing RAS properties
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get RAS error thresholds that control when RAS events are generated
+/// 
+/// @details
+///     - The driver maintains counters for all RAS error sets and error
+///       categories. Events are generated when errors occur. The configuration
+///       enables setting thresholds to limit when events are sent.
+///     - When a particular RAS correctable error counter exceeds the configured
+///       threshold, the event ::ZES_EVENT_TYPE_FLAG_RAS_CORRECTABLE_ERRORS will
+///       be triggered.
+///     - When a particular RAS uncorrectable error counter exceeds the
+///       configured threshold, the event
+///       ::ZES_EVENT_TYPE_FLAG_RAS_UNCORRECTABLE_ERRORS will be triggered.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hRas`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pConfig`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesRasGetConfig(
+    zes_ras_handle_t hRas,                                                  ///< [in] Handle for the component.
+    zes_ras_config_t* pConfig                                               ///< [in,out] Will be populed with the current RAS configuration -
+                                                                            ///< thresholds used to trigger events
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Set RAS error thresholds that control when RAS events are generated
+/// 
+/// @details
+///     - The driver maintains counters for all RAS error sets and error
+///       categories. Events are generated when errors occur. The configuration
+///       enables setting thresholds to limit when events are sent.
+///     - When a particular RAS correctable error counter exceeds the specified
+///       threshold, the event ::ZES_EVENT_TYPE_FLAG_RAS_CORRECTABLE_ERRORS will
+///       be generated.
+///     - When a particular RAS uncorrectable error counter exceeds the
+///       specified threshold, the event
+///       ::ZES_EVENT_TYPE_FLAG_RAS_UNCORRECTABLE_ERRORS will be generated.
+///     - Call ::zesRasGetState() and set the clear flag to true to restart
+///       event generation once counters have exceeded thresholds.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hRas`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pConfig`
+///     - ::ZE_RESULT_ERROR_NOT_AVAILABLE
+///         + Another running process is controlling these settings.
+///     - ::ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS
+///         + Don't have permissions to set thresholds.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesRasSetConfig(
+    zes_ras_handle_t hRas,                                                  ///< [in] Handle for the component.
+    const zes_ras_config_t* pConfig                                         ///< [in] Change the RAS configuration - thresholds used to trigger events
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get the current value of RAS error counters for a particular error set
+/// 
+/// @details
+///     - Clearing errors will affect other threads/applications - the counter
+///       values will start from zero.
+///     - Clearing errors requires write permissions.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hRas`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pState`
+///     - ::ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS
+///         + Don't have permissions to clear error counters.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesRasGetState(
+    zes_ras_handle_t hRas,                                                  ///< [in] Handle for the component.
+    ze_bool_t clear,                                                        ///< [in] Set to 1 to clear the counters of this type
+    zes_ras_state_t* pState                                                 ///< [in,out] Breakdown of where errors have occurred
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Tool APIs for System Resource Management (Sysman) - Scheduler management
+#if !defined(__GNUC__)
+#pragma region scheduler
+#endif
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Scheduler mode
+typedef enum _zes_sched_mode_t
+{
+    ZES_SCHED_MODE_TIMEOUT = 0,                                             ///< Multiple applications or contexts are submitting work to the hardware.
+                                                                            ///< When higher priority work arrives, the scheduler attempts to pause the
+                                                                            ///< current executing work within some timeout interval, then submits the
+                                                                            ///< other work.
+    ZES_SCHED_MODE_TIMESLICE = 1,                                           ///< The scheduler attempts to fairly timeslice hardware execution time
+                                                                            ///< between multiple contexts submitting work to the hardware
+                                                                            ///< concurrently.
+    ZES_SCHED_MODE_EXCLUSIVE = 2,                                           ///< Any application or context can run indefinitely on the hardware
+                                                                            ///< without being preempted or terminated. All pending work for other
+                                                                            ///< contexts must wait until the running context completes with no further
+                                                                            ///< submitted work.
+    ZES_SCHED_MODE_COMPUTE_UNIT_DEBUG = 3,                                  ///< [DEPRECATED] No longer supported.
+    ZES_SCHED_MODE_FORCE_UINT32 = 0x7fffffff
+
+} zes_sched_mode_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Properties related to scheduler component
+typedef struct _zes_sched_properties_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_bool_t onSubdevice;                                                  ///< [out] True if this resource is located on a sub-device; false means
+                                                                            ///< that the resource is on the device of the calling Sysman handle
+    uint32_t subdeviceId;                                                   ///< [out] If onSubdevice is true, this gives the ID of the sub-device
+    ze_bool_t canControl;                                                   ///< [out] Software can change the scheduler component configuration
+                                                                            ///< assuming the user has permissions.
+    zes_engine_type_flags_t engines;                                        ///< [out] Bitfield of accelerator engine types that are managed by this
+                                                                            ///< scheduler component. Note that there can be more than one scheduler
+                                                                            ///< component for the same type of accelerator engine.
+    uint32_t supportedModes;                                                ///< [out] Bitfield of scheduler modes that can be configured for this
+                                                                            ///< scheduler component (bitfield of 1<<::zes_sched_mode_t).
+
+} zes_sched_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZES_SCHED_WATCHDOG_DISABLE
+/// @brief Disable forward progress guard timeout.
+#define ZES_SCHED_WATCHDOG_DISABLE  (~(0ULL))
+#endif // ZES_SCHED_WATCHDOG_DISABLE
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Configuration for timeout scheduler mode (::ZES_SCHED_MODE_TIMEOUT)
+typedef struct _zes_sched_timeout_properties_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    uint64_t watchdogTimeout;                                               ///< [in,out] The maximum time in microseconds that the scheduler will wait
+                                                                            ///< for a batch of work submitted to a hardware engine to complete or to
+                                                                            ///< be preempted so as to run another context.
+                                                                            ///< If this time is exceeded, the hardware engine is reset and the context terminated.
+                                                                            ///< If set to ::ZES_SCHED_WATCHDOG_DISABLE, a running workload can run as
+                                                                            ///< long as it wants without being terminated, but preemption attempts to
+                                                                            ///< run other contexts are permitted but not enforced.
+
+} zes_sched_timeout_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Configuration for timeslice scheduler mode
+///        (::ZES_SCHED_MODE_TIMESLICE)
+typedef struct _zes_sched_timeslice_properties_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    uint64_t interval;                                                      ///< [in,out] The average interval in microseconds that a submission for a
+                                                                            ///< context will run on a hardware engine before being preempted out to
+                                                                            ///< run a pending submission for another context.
+    uint64_t yieldTimeout;                                                  ///< [in,out] The maximum time in microseconds that the scheduler will wait
+                                                                            ///< to preempt a workload running on an engine before deciding to reset
+                                                                            ///< the hardware engine and terminating the associated context.
+
+} zes_sched_timeslice_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Returns handles to scheduler components.
+/// 
+/// @details
+///     - Each scheduler component manages the distribution of work across one
+///       or more accelerator engines.
+///     - If an application wishes to change the scheduler behavior for all
+///       accelerator engines of a specific type (e.g. compute), it should
+///       select all the handles where the `engines` member
+///       ::zes_sched_properties_t contains that type.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDeviceEnumSchedulers(
+    zes_device_handle_t hDevice,                                            ///< [in] Sysman handle of the device.
+    uint32_t* pCount,                                                       ///< [in,out] pointer to the number of components of this type.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of components of this type that are available.
+                                                                            ///< if count is greater than the number of components of this type that
+                                                                            ///< are available, then the driver shall update the value with the correct
+                                                                            ///< number of components.
+    zes_sched_handle_t* phScheduler                                         ///< [in,out][optional][range(0, *pCount)] array of handle of components of
+                                                                            ///< this type.
+                                                                            ///< if count is less than the number of components of this type that are
+                                                                            ///< available, then the driver shall only retrieve that number of
+                                                                            ///< component handles.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get properties related to a scheduler component
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hScheduler`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pProperties`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesSchedulerGetProperties(
+    zes_sched_handle_t hScheduler,                                          ///< [in] Handle for the component.
+    zes_sched_properties_t* pProperties                                     ///< [in,out] Structure that will contain property data.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get current scheduling mode in effect on a scheduler component.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hScheduler`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pMode`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + This scheduler component does not support scheduler modes.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesSchedulerGetCurrentMode(
+    zes_sched_handle_t hScheduler,                                          ///< [in] Sysman handle for the component.
+    zes_sched_mode_t* pMode                                                 ///< [in,out] Will contain the current scheduler mode.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get scheduler config for mode ::ZES_SCHED_MODE_TIMEOUT
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hScheduler`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pConfig`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + This scheduler component does not support scheduler modes.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesSchedulerGetTimeoutModeProperties(
+    zes_sched_handle_t hScheduler,                                          ///< [in] Sysman handle for the component.
+    ze_bool_t getDefaults,                                                  ///< [in] If TRUE, the driver will return the system default properties for
+                                                                            ///< this mode, otherwise it will return the current properties.
+    zes_sched_timeout_properties_t* pConfig                                 ///< [in,out] Will contain the current parameters for this mode.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get scheduler config for mode ::ZES_SCHED_MODE_TIMESLICE
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hScheduler`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pConfig`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + This scheduler component does not support scheduler modes.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesSchedulerGetTimesliceModeProperties(
+    zes_sched_handle_t hScheduler,                                          ///< [in] Sysman handle for the component.
+    ze_bool_t getDefaults,                                                  ///< [in] If TRUE, the driver will return the system default properties for
+                                                                            ///< this mode, otherwise it will return the current properties.
+    zes_sched_timeslice_properties_t* pConfig                               ///< [in,out] Will contain the current parameters for this mode.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Change scheduler mode to ::ZES_SCHED_MODE_TIMEOUT or update scheduler
+///        mode parameters if already running in this mode.
+/// 
+/// @details
+///     - This mode is optimized for multiple applications or contexts
+///       submitting work to the hardware. When higher priority work arrives,
+///       the scheduler attempts to pause the current executing work within some
+///       timeout interval, then submits the other work.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hScheduler`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pProperties`
+///         + `nullptr == pNeedReload`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + This scheduler component does not support scheduler modes.
+///     - ::ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS
+///         + User does not have permissions to make this modification.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesSchedulerSetTimeoutMode(
+    zes_sched_handle_t hScheduler,                                          ///< [in] Sysman handle for the component.
+    zes_sched_timeout_properties_t* pProperties,                            ///< [in] The properties to use when configurating this mode.
+    ze_bool_t* pNeedReload                                                  ///< [in,out] Will be set to TRUE if a device driver reload is needed to
+                                                                            ///< apply the new scheduler mode.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Change scheduler mode to ::ZES_SCHED_MODE_TIMESLICE or update
+///        scheduler mode parameters if already running in this mode.
+/// 
+/// @details
+///     - This mode is optimized to provide fair sharing of hardware execution
+///       time between multiple contexts submitting work to the hardware
+///       concurrently.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hScheduler`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pProperties`
+///         + `nullptr == pNeedReload`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + This scheduler component does not support scheduler modes.
+///     - ::ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS
+///         + User does not have permissions to make this modification.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesSchedulerSetTimesliceMode(
+    zes_sched_handle_t hScheduler,                                          ///< [in] Sysman handle for the component.
+    zes_sched_timeslice_properties_t* pProperties,                          ///< [in] The properties to use when configurating this mode.
+    ze_bool_t* pNeedReload                                                  ///< [in,out] Will be set to TRUE if a device driver reload is needed to
+                                                                            ///< apply the new scheduler mode.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Change scheduler mode to ::ZES_SCHED_MODE_EXCLUSIVE
+/// 
+/// @details
+///     - This mode is optimized for single application/context use-cases. It
+///       permits a context to run indefinitely on the hardware without being
+///       preempted or terminated. All pending work for other contexts must wait
+///       until the running context completes with no further submitted work.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hScheduler`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pNeedReload`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + This scheduler component does not support scheduler modes.
+///     - ::ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS
+///         + User does not have permissions to make this modification.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesSchedulerSetExclusiveMode(
+    zes_sched_handle_t hScheduler,                                          ///< [in] Sysman handle for the component.
+    ze_bool_t* pNeedReload                                                  ///< [in,out] Will be set to TRUE if a device driver reload is needed to
+                                                                            ///< apply the new scheduler mode.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Change scheduler mode to ::ZES_SCHED_MODE_COMPUTE_UNIT_DEBUG
+/// 
+/// @details
+///     - This is a special mode that must ben enabled when debugging an
+///       application that uses this device e.g. using the Level0 Debug API.
+///     - It ensures that only one command queue can execute work on the
+///       hardware at a given time. Work is permitted to run as long as needed
+///       without enforcing any scheduler fairness policies.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+///     - [DEPRECATED] No longer supported.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hScheduler`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pNeedReload`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + This scheduler component does not support scheduler modes.
+///     - ::ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS
+///         + User does not have permissions to make this modification.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesSchedulerSetComputeUnitDebugMode(
+    zes_sched_handle_t hScheduler,                                          ///< [in] Sysman handle for the component.
+    ze_bool_t* pNeedReload                                                  ///< [in,out] Will be set to TRUE if a device driver reload is needed to
+                                                                            ///< apply the new scheduler mode.
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Tool APIs for System Resource Management (Sysman) - Standby domains
+#if !defined(__GNUC__)
+#pragma region standby
+#endif
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Standby hardware components
+typedef enum _zes_standby_type_t
+{
+    ZES_STANDBY_TYPE_GLOBAL = 0,                                            ///< Control the overall standby policy of the device/sub-device
+    ZES_STANDBY_TYPE_FORCE_UINT32 = 0x7fffffff
+
+} zes_standby_type_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Standby hardware component properties
+typedef struct _zes_standby_properties_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    zes_standby_type_t type;                                                ///< [out] Which standby hardware component this controls
+    ze_bool_t onSubdevice;                                                  ///< [out] True if the resource is located on a sub-device; false means
+                                                                            ///< that the resource is on the device of the calling Sysman handle
+    uint32_t subdeviceId;                                                   ///< [out] If onSubdevice is true, this gives the ID of the sub-device
+
+} zes_standby_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Standby promotion modes
+typedef enum _zes_standby_promo_mode_t
+{
+    ZES_STANDBY_PROMO_MODE_DEFAULT = 0,                                     ///< Best compromise between performance and energy savings.
+    ZES_STANDBY_PROMO_MODE_NEVER = 1,                                       ///< The device/component will never shutdown. This can improve performance
+                                                                            ///< but uses more energy.
+    ZES_STANDBY_PROMO_MODE_FORCE_UINT32 = 0x7fffffff
+
+} zes_standby_promo_mode_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get handle of standby controls
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDeviceEnumStandbyDomains(
+    zes_device_handle_t hDevice,                                            ///< [in] Sysman handle of the device.
+    uint32_t* pCount,                                                       ///< [in,out] pointer to the number of components of this type.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of components of this type that are available.
+                                                                            ///< if count is greater than the number of components of this type that
+                                                                            ///< are available, then the driver shall update the value with the correct
+                                                                            ///< number of components.
+    zes_standby_handle_t* phStandby                                         ///< [in,out][optional][range(0, *pCount)] array of handle of components of
+                                                                            ///< this type.
+                                                                            ///< if count is less than the number of components of this type that are
+                                                                            ///< available, then the driver shall only retrieve that number of
+                                                                            ///< component handles.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get standby hardware component properties
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hStandby`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pProperties`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesStandbyGetProperties(
+    zes_standby_handle_t hStandby,                                          ///< [in] Handle for the component.
+    zes_standby_properties_t* pProperties                                   ///< [in,out] Will contain the standby hardware properties.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get the current standby promotion mode
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hStandby`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pMode`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesStandbyGetMode(
+    zes_standby_handle_t hStandby,                                          ///< [in] Handle for the component.
+    zes_standby_promo_mode_t* pMode                                         ///< [in,out] Will contain the current standby mode.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Set standby promotion mode
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hStandby`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::ZES_STANDBY_PROMO_MODE_NEVER < mode`
+///     - ::ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS
+///         + User does not have permissions to make these modifications.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesStandbySetMode(
+    zes_standby_handle_t hStandby,                                          ///< [in] Handle for the component.
+    zes_standby_promo_mode_t mode                                           ///< [in] New standby mode.
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Tool APIs for System Resource Management (Sysman) - Firmware management
+#if !defined(__GNUC__)
+#pragma region temperature
+#endif
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Temperature sensors
+typedef enum _zes_temp_sensors_t
+{
+    ZES_TEMP_SENSORS_GLOBAL = 0,                                            ///< The maximum temperature across all device sensors
+    ZES_TEMP_SENSORS_GPU = 1,                                               ///< The maximum temperature across all sensors in the GPU
+    ZES_TEMP_SENSORS_MEMORY = 2,                                            ///< The maximum temperature across all sensors in the local memory
+    ZES_TEMP_SENSORS_GLOBAL_MIN = 3,                                        ///< The minimum temperature across all device sensors
+    ZES_TEMP_SENSORS_GPU_MIN = 4,                                           ///< The minimum temperature across all sensors in the GPU
+    ZES_TEMP_SENSORS_MEMORY_MIN = 5,                                        ///< The minimum temperature across all sensors in the local device memory
+    ZES_TEMP_SENSORS_GPU_BOARD = 6,                                         ///< The maximum temperature across all sensors in the GPU Board
+    ZES_TEMP_SENSORS_GPU_BOARD_MIN = 7,                                     ///< The minimum temperature across all sensors in the GPU Board
+    ZES_TEMP_SENSORS_VOLTAGE_REGULATOR = 8,                                 ///< The maximum temperature across all sensors in the Voltage Regulator
+    ZES_TEMP_SENSORS_FORCE_UINT32 = 0x7fffffff
+
+} zes_temp_sensors_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Temperature sensor properties
+typedef struct _zes_temp_properties_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    zes_temp_sensors_t type;                                                ///< [out] Which part of the device the temperature sensor measures
+    ze_bool_t onSubdevice;                                                  ///< [out] True if the resource is located on a sub-device; false means
+                                                                            ///< that the resource is on the device of the calling Sysman handle
+    uint32_t subdeviceId;                                                   ///< [out] If onSubdevice is true, this gives the ID of the sub-device
+    double maxTemperature;                                                  ///< [out] Will contain the maximum temperature for the specific device in
+                                                                            ///< degrees Celsius.
+    ze_bool_t isCriticalTempSupported;                                      ///< [out] Indicates if the critical temperature event
+                                                                            ///< ::ZES_EVENT_TYPE_FLAG_TEMP_CRITICAL is supported
+    ze_bool_t isThreshold1Supported;                                        ///< [out] Indicates if the temperature threshold 1 event
+                                                                            ///< ::ZES_EVENT_TYPE_FLAG_TEMP_THRESHOLD1 is supported
+    ze_bool_t isThreshold2Supported;                                        ///< [out] Indicates if the temperature threshold 2 event
+                                                                            ///< ::ZES_EVENT_TYPE_FLAG_TEMP_THRESHOLD2 is supported
+
+} zes_temp_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Temperature sensor threshold
+typedef struct _zes_temp_threshold_t
+{
+    ze_bool_t enableLowToHigh;                                              ///< [in,out] Trigger an event when the temperature crosses from below the
+                                                                            ///< threshold to above.
+    ze_bool_t enableHighToLow;                                              ///< [in,out] Trigger an event when the temperature crosses from above the
+                                                                            ///< threshold to below.
+    double threshold;                                                       ///< [in,out] The threshold in degrees Celsius.
+
+} zes_temp_threshold_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Temperature configuration - which events should be triggered and the
+///        trigger conditions.
+typedef struct _zes_temp_config_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    ze_bool_t enableCritical;                                               ///< [in,out] Indicates if event ::ZES_EVENT_TYPE_FLAG_TEMP_CRITICAL should
+                                                                            ///< be triggered by the driver.
+    zes_temp_threshold_t threshold1;                                        ///< [in,out] Configuration controlling if and when event
+                                                                            ///< ::ZES_EVENT_TYPE_FLAG_TEMP_THRESHOLD1 should be triggered by the
+                                                                            ///< driver.
+    zes_temp_threshold_t threshold2;                                        ///< [in,out] Configuration controlling if and when event
+                                                                            ///< ::ZES_EVENT_TYPE_FLAG_TEMP_THRESHOLD2 should be triggered by the
+                                                                            ///< driver.
+
+} zes_temp_config_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get handle of temperature sensors
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDeviceEnumTemperatureSensors(
+    zes_device_handle_t hDevice,                                            ///< [in] Sysman handle of the device.
+    uint32_t* pCount,                                                       ///< [in,out] pointer to the number of components of this type.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of components of this type that are available.
+                                                                            ///< if count is greater than the number of components of this type that
+                                                                            ///< are available, then the driver shall update the value with the correct
+                                                                            ///< number of components.
+    zes_temp_handle_t* phTemperature                                        ///< [in,out][optional][range(0, *pCount)] array of handle of components of
+                                                                            ///< this type.
+                                                                            ///< if count is less than the number of components of this type that are
+                                                                            ///< available, then the driver shall only retrieve that number of
+                                                                            ///< component handles.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get temperature sensor properties
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hTemperature`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pProperties`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesTemperatureGetProperties(
+    zes_temp_handle_t hTemperature,                                         ///< [in] Handle for the component.
+    zes_temp_properties_t* pProperties                                      ///< [in,out] Will contain the temperature sensor properties.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get temperature configuration for this sensor - which events are
+///        triggered and the trigger conditions
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hTemperature`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pConfig`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Temperature thresholds are not supported on this temperature sensor. Generally this is only supported for temperature sensor ::ZES_TEMP_SENSORS_GLOBAL.
+///         + One or both of the thresholds is not supported. Check the `isThreshold1Supported` and `isThreshold2Supported` members of ::zes_temp_properties_t.
+///     - ::ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS
+///         + User does not have permissions to request this feature.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesTemperatureGetConfig(
+    zes_temp_handle_t hTemperature,                                         ///< [in] Handle for the component.
+    zes_temp_config_t* pConfig                                              ///< [in,out] Returns current configuration.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Set temperature configuration for this sensor - indicates which events
+///        are triggered and the trigger conditions
+/// 
+/// @details
+///     - Events ::ZES_EVENT_TYPE_FLAG_TEMP_CRITICAL will be triggered when
+///       temperature reaches the critical range. Use the function
+///       ::zesDeviceEventRegister() to start receiving this event.
+///     - Events ::ZES_EVENT_TYPE_FLAG_TEMP_THRESHOLD1 and
+///       ::ZES_EVENT_TYPE_FLAG_TEMP_THRESHOLD2 will be generated when
+///       temperature cross the thresholds set using this function. Use the
+///       function ::zesDeviceEventRegister() to start receiving these events.
+///     - Only one running process can set the temperature configuration at a
+///       time. If another process attempts to change the configuration, the
+///       error ::ZE_RESULT_ERROR_NOT_AVAILABLE will be returned. The function
+///       ::zesTemperatureGetConfig() will return the process ID currently
+///       controlling these settings.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hTemperature`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pConfig`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + Temperature thresholds are not supported on this temperature sensor. Generally they are only supported for temperature sensor ::ZES_TEMP_SENSORS_GLOBAL.
+///         + Enabling the critical temperature event is not supported. Check the `isCriticalTempSupported` member of ::zes_temp_properties_t.
+///         + One or both of the thresholds is not supported. Check the `isThreshold1Supported` and `isThreshold2Supported` members of ::zes_temp_properties_t.
+///     - ::ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS
+///         + User does not have permissions to request this feature.
+///     - ::ZE_RESULT_ERROR_NOT_AVAILABLE
+///         + Another running process is controlling these settings.
+///     - ::ZE_RESULT_ERROR_INVALID_ARGUMENT
+///         + One or both the thresholds is above TjMax (see ::zesFrequencyOcGetTjMax()). Temperature thresholds must be below this value.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesTemperatureSetConfig(
+    zes_temp_handle_t hTemperature,                                         ///< [in] Handle for the component.
+    const zes_temp_config_t* pConfig                                        ///< [in] New configuration.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get the temperature from a specified sensor
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hTemperature`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pTemperature`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesTemperatureGetState(
+    zes_temp_handle_t hTemperature,                                         ///< [in] Handle for the component.
+    double* pTemperature                                                    ///< [in,out] Will contain the temperature read from the specified sensor
+                                                                            ///< in degrees Celsius.
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Sysman Extension APIs for Power Limits
+#if !defined(__GNUC__)
+#pragma region powerLimits
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZES_POWER_LIMITS_EXT_NAME
+/// @brief Power Limits Extension Name
+#define ZES_POWER_LIMITS_EXT_NAME  "ZES_extension_power_limits"
+#endif // ZES_POWER_LIMITS_EXT_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Power Limits Extension Version(s)
+typedef enum _zes_power_limits_ext_version_t
+{
+    ZES_POWER_LIMITS_EXT_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),             ///< version 1.0
+    ZES_POWER_LIMITS_EXT_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),         ///< latest known version
+    ZES_POWER_LIMITS_EXT_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} zes_power_limits_ext_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Device power/current limit descriptor.
+typedef struct _zes_power_limit_ext_desc_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    zes_power_level_t level;                                                ///< [in,out] duration type over which the power draw is measured, i.e.
+                                                                            ///< sustained, burst, peak, or critical.
+    zes_power_source_t source;                                              ///< [out] source of power used by the system, i.e. AC or DC.
+    zes_limit_unit_t limitUnit;                                             ///< [out] unit used for specifying limit, i.e. current units (milliamps)
+                                                                            ///< or power units (milliwatts).
+    ze_bool_t enabledStateLocked;                                           ///< [out] indicates if the power limit state (enabled/ignored) can be set
+                                                                            ///< (false) or is locked (true).
+    ze_bool_t enabled;                                                      ///< [in,out] indicates if the limit is enabled (true) or ignored (false).
+                                                                            ///< If enabledStateIsLocked is True, this value is ignored.
+    ze_bool_t intervalValueLocked;                                          ///< [out] indicates if the interval can be modified (false) or is fixed
+                                                                            ///< (true).
+    int32_t interval;                                                       ///< [in,out] power averaging window in milliseconds. If
+                                                                            ///< intervalValueLocked is true, this value is ignored.
+    ze_bool_t limitValueLocked;                                             ///< [out] indicates if the limit can be set (false) or if the limit is
+                                                                            ///< fixed (true).
+    int32_t limit;                                                          ///< [in,out] limit value. If limitValueLocked is true, this value is
+                                                                            ///< ignored. The value should be provided in the unit specified by
+                                                                            ///< limitUnit.
+
+} zes_power_limit_ext_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Extension properties related to device power settings
+/// 
+/// @details
+///     - This structure may be returned from ::zesPowerGetProperties via the
+///       `pNext` member of ::zes_power_properties_t.
+///     - This structure may also be returned from ::zesPowerGetProperties via
+///       the `pNext` member of ::zes_power_ext_properties_t
+///     - Used for determining the power domain level, i.e. card-level v/s
+///       package-level v/s stack-level & the factory default power limits.
+typedef struct _zes_power_ext_properties_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    zes_power_domain_t domain;                                              ///< [out] domain that the power limit belongs to.
+    zes_power_limit_ext_desc_t* defaultLimit;                               ///< [out] the factory default limit of the part.
+
+} zes_power_ext_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get power limits
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+///     - This function returns all the power limits associated with the
+///       supplied power domain.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hPower`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesPowerGetLimitsExt(
+    zes_pwr_handle_t hPower,                                                ///< [in] Power domain handle instance.
+    uint32_t* pCount,                                                       ///< [in,out] Pointer to the number of power limit descriptors. If count is
+                                                                            ///< zero, then the driver shall update the value with the total number of
+                                                                            ///< components of this type that are available. If count is greater than
+                                                                            ///< the number of components of this type that are available, then the
+                                                                            ///< driver shall update the value with the correct number of components.
+    zes_power_limit_ext_desc_t* pSustained                                  ///< [in,out][optional][range(0, *pCount)] Array of query results for power
+                                                                            ///< limit descriptors. If count is less than the number of components of
+                                                                            ///< this type that are available, then the driver shall only retrieve that
+                                                                            ///< number of components.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Set power limits
+/// 
+/// @details
+///     - The application can only modify unlocked members of the limit
+///       descriptors returned by ::zesPowerGetLimitsExt.
+///     - Not all the limits returned by ::zesPowerGetLimitsExt need to be
+///       supplied to this function.
+///     - Limits do not have to be supplied in the same order as returned by
+///       ::zesPowerGetLimitsExt.
+///     - The same limit can be supplied multiple times. Limits are applied in
+///       the order in which they are supplied.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hPower`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+///     - ::ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS
+///         + User does not have permissions to make these modifications.
+///     - ::ZE_RESULT_ERROR_NOT_AVAILABLE
+///         + The device is in use, meaning that the GPU is under Over clocking, applying power limits under overclocking is not supported.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesPowerSetLimitsExt(
+    zes_pwr_handle_t hPower,                                                ///< [in] Handle for the component.
+    uint32_t* pCount,                                                       ///< [in] Pointer to the number of power limit descriptors.
+    zes_power_limit_ext_desc_t* pSustained                                  ///< [in][optional][range(0, *pCount)] Array of power limit descriptors.
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Sysman Extension APIs for Engine Activity
+#if !defined(__GNUC__)
+#pragma region engineActivity
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZES_ENGINE_ACTIVITY_EXT_NAME
+/// @brief Engine Activity Extension Name
+#define ZES_ENGINE_ACTIVITY_EXT_NAME  "ZES_extension_engine_activity"
+#endif // ZES_ENGINE_ACTIVITY_EXT_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Engine Activity Extension Version(s)
+typedef enum _zes_engine_activity_ext_version_t
+{
+    ZES_ENGINE_ACTIVITY_EXT_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),          ///< version 1.0
+    ZES_ENGINE_ACTIVITY_EXT_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),      ///< latest known version
+    ZES_ENGINE_ACTIVITY_EXT_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} zes_engine_activity_ext_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Extension properties related to Engine Groups
+/// 
+/// @details
+///     - This structure may be passed to ::zesEngineGetProperties by having the
+///       pNext member of ::zes_engine_properties_t point at this struct.
+///     - Used for SRIOV per Virtual Function device utilization by
+///       ::zes_engine_group_t
+typedef struct _zes_engine_ext_properties_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    uint32_t countOfVirtualFunctionInstance;                                ///< [out] Number of Virtual Function(VF) instances associated with engine
+                                                                            ///< to monitor the utilization of hardware across all Virtual Function
+                                                                            ///< from a Physical Function (PF) instance.
+                                                                            ///< These VF-by-VF views should provide engine group and individual engine
+                                                                            ///< level granularity.
+                                                                            ///< This count represents the number of VF instances that are actively
+                                                                            ///< using the resource represented by the engine handle.
+
+} zes_engine_ext_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get activity stats for Physical Function (PF) and each Virtual
+///        Function (VF) associated with engine group.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hEngine`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE - "Engine activity extension is not supported in the environment."
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesEngineGetActivityExt(
+    zes_engine_handle_t hEngine,                                            ///< [in] Handle for the component.
+    uint32_t* pCount,                                                       ///< [in,out] Pointer to the number of VF engine stats descriptors.
+                                                                            ///<  - if count is zero, the driver shall update the value with the total
+                                                                            ///< number of engine stats available.
+                                                                            ///<  - if count is greater than the total number of engine stats
+                                                                            ///< available, the driver shall update the value with the correct number
+                                                                            ///< of engine stats available.
+                                                                            ///<  - The count returned is the sum of number of VF instances currently
+                                                                            ///< available and the PF instance.
+    zes_engine_stats_t* pStats                                              ///< [in,out][optional][range(0, *pCount)] array of engine group activity counters.
+                                                                            ///<  - if count is less than the total number of engine stats available,
+                                                                            ///< then driver shall only retrieve that number of stats.
+                                                                            ///<  - the implementation shall populate the vector with engine stat for
+                                                                            ///< PF at index 0 of the vector followed by user provided pCount-1 number
+                                                                            ///< of VF engine stats.
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Sysman Extension APIs for RAS Get State and Clear State
+#if !defined(__GNUC__)
+#pragma region rasState
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZES_RAS_GET_STATE_EXP_NAME
+/// @brief RAS Get State Extension Name
+#define ZES_RAS_GET_STATE_EXP_NAME  "ZES_extension_ras_state"
+#endif // ZES_RAS_GET_STATE_EXP_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief RAS Get State Extension Version(s)
+typedef enum _zes_ras_state_exp_version_t
+{
+    ZES_RAS_STATE_EXP_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),                ///< version 1.0
+    ZES_RAS_STATE_EXP_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),            ///< latest known version
+    ZES_RAS_STATE_EXP_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} zes_ras_state_exp_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief RAS error categories
+typedef enum _zes_ras_error_category_exp_t
+{
+    ZES_RAS_ERROR_CATEGORY_EXP_RESET = 0,                                   ///< The number of accelerator engine resets attempted by the driver
+    ZES_RAS_ERROR_CATEGORY_EXP_PROGRAMMING_ERRORS = 1,                      ///< The number of hardware exceptions generated by the way workloads have
+                                                                            ///< programmed the hardware
+    ZES_RAS_ERROR_CATEGORY_EXP_DRIVER_ERRORS = 2,                           ///< The number of low level driver communication errors have occurred
+    ZES_RAS_ERROR_CATEGORY_EXP_COMPUTE_ERRORS = 3,                          ///< The number of errors that have occurred in the compute accelerator
+                                                                            ///< hardware
+    ZES_RAS_ERROR_CATEGORY_EXP_NON_COMPUTE_ERRORS = 4,                      ///< The number of errors that have occurred in the fixed-function
+                                                                            ///< accelerator hardware
+    ZES_RAS_ERROR_CATEGORY_EXP_CACHE_ERRORS = 5,                            ///< The number of errors that have occurred in caches (L1/L3/register
+                                                                            ///< file/shared local memory/sampler)
+    ZES_RAS_ERROR_CATEGORY_EXP_DISPLAY_ERRORS = 6,                          ///< The number of errors that have occurred in the display
+    ZES_RAS_ERROR_CATEGORY_EXP_MEMORY_ERRORS = 7,                           ///< The number of errors that have occurred in Memory
+    ZES_RAS_ERROR_CATEGORY_EXP_SCALE_ERRORS = 8,                            ///< The number of errors that have occurred in Scale Fabric
+    ZES_RAS_ERROR_CATEGORY_EXP_L3FABRIC_ERRORS = 9,                         ///< The number of errors that have occurred in L3 Fabric
+    ZES_RAS_ERROR_CATEGORY_EXP_FORCE_UINT32 = 0x7fffffff
+
+} zes_ras_error_category_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Extension structure for providing RAS error counters for different
+///        error sets
+typedef struct _zes_ras_state_exp_t
+{
+    zes_ras_error_category_exp_t category;                                  ///< [out] category for which error counter is provided.
+    uint64_t errorCounter;                                                  ///< [out] Current value of RAS counter for specific error category.
+
+} zes_ras_state_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Ras Get State
+/// 
+/// @details
+///     - This function retrieves error counters for different RAS error
+///       categories.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hRas`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesRasGetStateExp(
+    zes_ras_handle_t hRas,                                                  ///< [in] Handle for the component.
+    uint32_t* pCount,                                                       ///< [in,out] pointer to the number of RAS state structures that can be retrieved.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of error categories for which state can be retrieved.
+                                                                            ///< if count is greater than the number of RAS states available, then the
+                                                                            ///< driver shall update the value with the correct number of RAS states available.
+    zes_ras_state_exp_t* pState                                             ///< [in,out][optional][range(0, *pCount)] array of query results for RAS
+                                                                            ///< error states for different categories.
+                                                                            ///< if count is less than the number of RAS states available, then driver
+                                                                            ///< shall only retrieve that number of RAS states.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Ras Clear State
+/// 
+/// @details
+///     - This function clears error counters for a RAS error category.
+///     - Clearing errors will affect other threads/applications - the counter
+///       values will start from zero.
+///     - Clearing errors requires write permissions.
+///     - The application should not call this function from simultaneous
+///       threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hRas`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::ZES_RAS_ERROR_CATEGORY_EXP_L3FABRIC_ERRORS < category`
+///     - ::ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS
+///         + Don't have permissions to clear error counters.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesRasClearStateExp(
+    zes_ras_handle_t hRas,                                                  ///< [in] Handle for the component.
+    zes_ras_error_category_exp_t category                                   ///< [in] category for which error counter is to be cleared.
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Sysman Extension APIs for Memory State
+#if !defined(__GNUC__)
+#pragma region memPageOfflineState
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZES_MEM_PAGE_OFFLINE_STATE_EXP_NAME
+/// @brief Memory State Extension Name
+#define ZES_MEM_PAGE_OFFLINE_STATE_EXP_NAME  "ZES_extension_mem_state"
+#endif // ZES_MEM_PAGE_OFFLINE_STATE_EXP_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Memory State Extension Version(s)
+typedef enum _zes_mem_page_offline_state_exp_version_t
+{
+    ZES_MEM_PAGE_OFFLINE_STATE_EXP_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),   ///< version 1.0
+    ZES_MEM_PAGE_OFFLINE_STATE_EXP_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),   ///< latest known version
+    ZES_MEM_PAGE_OFFLINE_STATE_EXP_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} zes_mem_page_offline_state_exp_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Extension properties for Memory State
+/// 
+/// @details
+///     - This structure may be returned from ::zesMemoryGetState via the
+///       `pNext` member of ::zes_mem_state_t
+///     - These additional parameters get Memory Page Offline Metrics
+typedef struct _zes_mem_page_offline_state_exp_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    uint32_t memoryPageOffline;                                             ///< [out] Returns the number of Memory Pages Offline
+    uint32_t maxMemoryPageOffline;                                          ///< [out] Returns the Allowed Memory Pages Offline
+
+} zes_mem_page_offline_state_exp_t;
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Sysman Extension APIs for Memory Bandwidth Counter Valid Bits
+#if !defined(__GNUC__)
+#pragma region memoryBwCounterValidBits
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZES_MEMORY_BANDWIDTH_COUNTER_BITS_EXP_PROPERTIES_NAME
+/// @brief Memory Bandwidth Counter Valid Bits Extension Name
+#define ZES_MEMORY_BANDWIDTH_COUNTER_BITS_EXP_PROPERTIES_NAME  "ZES_extension_mem_bandwidth_counter_bits_properties"
+#endif // ZES_MEMORY_BANDWIDTH_COUNTER_BITS_EXP_PROPERTIES_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Memory Bandwidth Counter Valid Bits Extension Version(s)
+typedef enum _zes_mem_bandwidth_counter_bits_exp_version_t
+{
+    ZES_MEM_BANDWIDTH_COUNTER_BITS_EXP_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),   ///< version 1.0
+    ZES_MEM_BANDWIDTH_COUNTER_BITS_EXP_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),   ///< latest known version
+    ZES_MEM_BANDWIDTH_COUNTER_BITS_EXP_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} zes_mem_bandwidth_counter_bits_exp_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Extension properties for reporting valid bit count for memory
+///        bandwidth counter value
+/// 
+/// @details
+///     - Number of valid read and write counter bits of memory bandwidth
+///     - This structure may be returned from ::zesMemoryGetProperties via the
+///       `pNext` member of ::zes_mem_properties_t.
+///     - Used for denoting number of valid bits in the counter value returned
+///       in ::zes_mem_bandwidth_t.
+typedef struct _zes_mem_bandwidth_counter_bits_exp_properties_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    uint32_t validBitsCount;                                                ///< [out] Returns the number of valid bits in the counter values
+
+} zes_mem_bandwidth_counter_bits_exp_properties_t;
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Sysman Extension APIs for Power Domain Properties
+#if !defined(__GNUC__)
+#pragma region powerDomainProperties
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZES_POWER_DOMAIN_PROPERTIES_EXP_NAME
+/// @brief Power Domain Properties Name
+#define ZES_POWER_DOMAIN_PROPERTIES_EXP_NAME  "ZES_extension_power_domain_properties"
+#endif // ZES_POWER_DOMAIN_PROPERTIES_EXP_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Power Domain Properties Extension Version(s)
+typedef enum _zes_power_domain_properties_exp_version_t
+{
+    ZES_POWER_DOMAIN_PROPERTIES_EXP_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),  ///< version 1.0
+    ZES_POWER_DOMAIN_PROPERTIES_EXP_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),  ///< latest known version
+    ZES_POWER_DOMAIN_PROPERTIES_EXP_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} zes_power_domain_properties_exp_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Extension structure for providing power domain information associated
+///        with a power handle
+/// 
+/// @details
+///     - This structure may be returned from ::zesPowerGetProperties via the
+///       `pNext` member of ::zes_power_properties_t.
+///     - Used for associating a power handle with a power domain.
+typedef struct _zes_power_domain_exp_properties_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    zes_power_domain_t powerDomain;                                         ///< [out] Power domain associated with the power handle.
+
+} zes_power_domain_exp_properties_t;
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Sysman Extension APIs for firmware security version
+#if !defined(__GNUC__)
+#pragma region firmwareSecurityVersion
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZES_FIRMWARE_SECURITY_VERSION_EXP_NAME
+/// @brief Firmware security version
+#define ZES_FIRMWARE_SECURITY_VERSION_EXP_NAME  "ZES_experimental_firmware_security_version"
+#endif // ZES_FIRMWARE_SECURITY_VERSION_EXP_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Firmware security version Extension Version(s)
+typedef enum _zes_firmware_security_exp_version_t
+{
+    ZES_FIRMWARE_SECURITY_EXP_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),        ///< version 1.0
+    ZES_FIRMWARE_SECURITY_EXP_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),    ///< latest known version
+    ZES_FIRMWARE_SECURITY_EXP_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} zes_firmware_security_exp_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get the firmware security version number of the currently running
+///        firmware
+/// 
+/// @details
+///     - The application should create a character array of size
+///       ::ZES_STRING_PROPERTY_SIZE and reference it for the `pVersion`
+///       parameter.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hFirmware`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pVersion`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesFirmwareGetSecurityVersionExp(
+    zes_firmware_handle_t hFirmware,                                        ///< [in] Handle for the component.
+    char* pVersion                                                          ///< [in,out] NULL terminated string value. The string "unknown" will be
+                                                                            ///< returned if this property cannot be determined.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Set the firmware security version number
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hFirmware`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesFirmwareSetSecurityVersionExp(
+    zes_firmware_handle_t hFirmware                                         ///< [in] Handle for the component.
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Sysman Extension APIs for Sysman Device Mapping
+#if !defined(__GNUC__)
+#pragma region sysmanDeviceMapping
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZES_SYSMAN_DEVICE_MAPPING_EXP_NAME
+/// @brief Sysman Device Mapping Extension Name
+#define ZES_SYSMAN_DEVICE_MAPPING_EXP_NAME  "ZES_experimental_sysman_device_mapping"
+#endif // ZES_SYSMAN_DEVICE_MAPPING_EXP_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Sysman Device Mapping Extension Version(s)
+typedef enum _zes_sysman_device_mapping_exp_version_t
+{
+    ZES_SYSMAN_DEVICE_MAPPING_EXP_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),    ///< version 1.0
+    ZES_SYSMAN_DEVICE_MAPPING_EXP_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),///< latest known version
+    ZES_SYSMAN_DEVICE_MAPPING_EXP_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} zes_sysman_device_mapping_exp_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Sub Device Properties
+typedef struct _zes_subdevice_exp_properties_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    uint32_t subdeviceId;                                                   ///< [out] this gives the ID of the sub device
+    zes_uuid_t uuid;                                                        ///< [out] universal unique identifier of the sub device.
+
+} zes_subdevice_exp_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves sub device properties for the given sysman device handle
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDeviceGetSubDevicePropertiesExp(
+    zes_device_handle_t hDevice,                                            ///< [in] Sysman handle of the device.
+    uint32_t* pCount,                                                       ///< [in,out] pointer to the number of sub devices.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of sub devices currently attached to the device.
+                                                                            ///< if count is greater than the number of sub devices currently attached
+                                                                            ///< to the device, then the driver shall update the value with the correct
+                                                                            ///< number of sub devices.
+    zes_subdevice_exp_properties_t* pSubdeviceProps                         ///< [in,out][optional][range(0, *pCount)] array of sub device property structures.
+                                                                            ///< if count is less than the number of sysman sub devices available, then
+                                                                            ///< the driver shall only retrieve that number of sub device property structures.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves sysman device and subdevice index for the given UUID and
+///        sysman driver
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDriver`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == phDevice`
+///         + `nullptr == onSubdevice`
+///         + `nullptr == subdeviceId`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDriverGetDeviceByUuidExp(
+    zes_driver_handle_t hDriver,                                            ///< [in] handle of the sysman driver instance
+    zes_uuid_t uuid,                                                        ///< [in] universal unique identifier.
+    zes_device_handle_t* phDevice,                                          ///< [out] Sysman handle of the device.
+    ze_bool_t* onSubdevice,                                                 ///< [out] True if the UUID belongs to the sub-device; false means that
+                                                                            ///< UUID belongs to the root device.
+    uint32_t* subdeviceId                                                   ///< [out] If onSubdevice is true, this gives the ID of the sub-device
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Sysman Extension APIs for Virtual Function Management Properties
+#if !defined(__GNUC__)
+#pragma region virtualFunctionManagement
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZES_VIRTUAL_FUNCTION_MANAGEMENT_EXP_NAME
+/// @brief Virtual Function Management Extension Name
+#define ZES_VIRTUAL_FUNCTION_MANAGEMENT_EXP_NAME  "ZES_experimental_virtual_function_management"
+#endif // ZES_VIRTUAL_FUNCTION_MANAGEMENT_EXP_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Virtual Function Management Extension Version(s)
+typedef enum _zes_vf_management_exp_version_t
+{
+    ZES_VF_MANAGEMENT_EXP_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),            ///< version 1.0 (deprecated)
+    ZES_VF_MANAGEMENT_EXP_VERSION_1_1 = ZE_MAKE_VERSION( 1, 1 ),            ///< version 1.1 (deprecated)
+    ZES_VF_MANAGEMENT_EXP_VERSION_1_2 = ZE_MAKE_VERSION( 1, 2 ),            ///< version 1.2
+    ZES_VF_MANAGEMENT_EXP_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 2 ),        ///< latest known version
+    ZES_VF_MANAGEMENT_EXP_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} zes_vf_management_exp_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Virtual function memory types (deprecated)
+typedef uint32_t zes_vf_info_mem_type_exp_flags_t;
+typedef enum _zes_vf_info_mem_type_exp_flag_t
+{
+    ZES_VF_INFO_MEM_TYPE_EXP_FLAG_MEM_TYPE_SYSTEM = ZE_BIT(0),              ///< System memory
+    ZES_VF_INFO_MEM_TYPE_EXP_FLAG_MEM_TYPE_DEVICE = ZE_BIT(1),              ///< Device local memory
+    ZES_VF_INFO_MEM_TYPE_EXP_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} zes_vf_info_mem_type_exp_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Virtual function utilization flag bit fields (deprecated)
+typedef uint32_t zes_vf_info_util_exp_flags_t;
+typedef enum _zes_vf_info_util_exp_flag_t
+{
+    ZES_VF_INFO_UTIL_EXP_FLAG_INFO_NONE = ZE_BIT(0),                        ///< No info associated with virtual function
+    ZES_VF_INFO_UTIL_EXP_FLAG_INFO_MEM_CPU = ZE_BIT(1),                     ///< System memory utilization associated with virtual function
+    ZES_VF_INFO_UTIL_EXP_FLAG_INFO_MEM_GPU = ZE_BIT(2),                     ///< Device memory utilization associated with virtual function
+    ZES_VF_INFO_UTIL_EXP_FLAG_INFO_ENGINE = ZE_BIT(3),                      ///< Engine utilization associated with virtual function
+    ZES_VF_INFO_UTIL_EXP_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} zes_vf_info_util_exp_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Virtual function management properties (deprecated)
+typedef struct _zes_vf_exp_properties_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    zes_pci_address_t address;                                              ///< [out] Virtual function BDF address
+    zes_uuid_t uuid;                                                        ///< [out] universal unique identifier of the device
+    zes_vf_info_util_exp_flags_t flags;                                     ///< [out] utilization flags available. May be 0 or a valid combination of
+                                                                            ///< ::zes_vf_info_util_exp_flag_t.
+
+} zes_vf_exp_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Provides memory utilization values for a virtual function (deprecated)
+typedef struct _zes_vf_util_mem_exp_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    zes_vf_info_mem_type_exp_flags_t memTypeFlags;                          ///< [out] Memory type flags.
+    uint64_t free;                                                          ///< [out] Free memory size in bytes.
+    uint64_t size;                                                          ///< [out] Total allocatable memory in bytes.
+    uint64_t timestamp;                                                     ///< [out] Wall clock time from VF when value was sampled.
+
+} zes_vf_util_mem_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Provides engine utilization values for a virtual function (deprecated)
+typedef struct _zes_vf_util_engine_exp_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    zes_engine_group_t type;                                                ///< [out] The engine group.
+    uint64_t activeCounterValue;                                            ///< [out] Represents active counter.
+    uint64_t samplingCounterValue;                                          ///< [out] Represents counter value when activeCounterValue was sampled.
+    uint64_t timestamp;                                                     ///< [out] Wall clock time when the activeCounterValue was sampled.
+
+} zes_vf_util_engine_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Virtual function management capabilities (deprecated)
+typedef struct _zes_vf_exp_capabilities_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    zes_pci_address_t address;                                              ///< [out] Virtual function BDF address
+    uint32_t vfDeviceMemSize;                                               ///< [out] Virtual function memory size in kilo bytes
+    uint32_t vfID;                                                          ///< [out] Virtual Function ID
+
+} zes_vf_exp_capabilities_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Virtual function management capabilities
+typedef struct _zes_vf_exp2_capabilities_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    zes_pci_address_t address;                                              ///< [out] Virtual function BDF address
+    uint64_t vfDeviceMemSize;                                               ///< [out] Virtual function memory size in bytes
+    uint32_t vfID;                                                          ///< [out] Virtual Function ID
+
+} zes_vf_exp2_capabilities_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Provides memory utilization values for a virtual function
+typedef struct _zes_vf_util_mem_exp2_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    zes_mem_loc_t vfMemLocation;                                            ///< [out] Location of this memory (system, device)
+    uint64_t vfMemUtilized;                                                 ///< [out] Utilized memory size in bytes.
+
+} zes_vf_util_mem_exp2_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Provides engine utilization values for a virtual function
+/// 
+/// @details
+///     - Percent utilization is calculated by taking two snapshots (s1, s2) and
+///       using the equation: %util = (s2.activeCounterValue -
+///       s1.activeCounterValue) / (s2.samplingCounterValue -
+///       s1.samplingCounterValue)
+typedef struct _zes_vf_util_engine_exp2_t
+{
+    zes_structure_type_t stype;                                             ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    zes_engine_group_t vfEngineType;                                        ///< [out] The engine group.
+    uint64_t activeCounterValue;                                            ///< [out] Represents active counter.
+    uint64_t samplingCounterValue;                                          ///< [out] Represents counter value when activeCounterValue was sampled.
+                                                                            ///< Refer to the formulae above for calculating the utilization percent
+
+} zes_vf_util_engine_exp2_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get handle of virtual function modules
+/// 
+/// @details
+///     - [DEPRECATED] No longer supported. Use ::zesDeviceEnumEnabledVFExp.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDeviceEnumActiveVFExp(
+    zes_device_handle_t hDevice,                                            ///< [in] Sysman handle of the device.
+    uint32_t* pCount,                                                       ///< [in,out] pointer to the number of components of this type.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of components of this type that are available.
+                                                                            ///< if count is greater than the number of components of this type that
+                                                                            ///< are available, then the driver shall update the value with the correct
+                                                                            ///< number of components.
+    zes_vf_handle_t* phVFhandle                                             ///< [in,out][optional][range(0, *pCount)] array of handle of components of
+                                                                            ///< this type.
+                                                                            ///< if count is less than the number of components of this type that are
+                                                                            ///< available, then the driver shall only retrieve that number of
+                                                                            ///< component handles.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get virtual function management properties
+/// 
+/// @details
+///     - [DEPRECATED] No longer supported. Use
+///       ::zesVFManagementGetVFCapabilitiesExp.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hVFhandle`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pProperties`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesVFManagementGetVFPropertiesExp(
+    zes_vf_handle_t hVFhandle,                                              ///< [in] Sysman handle for the VF component.
+    zes_vf_exp_properties_t* pProperties                                    ///< [in,out] Will contain VF properties.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get memory activity stats for each available memory types associated
+///        with Virtual Function (VF)
+/// 
+/// @details
+///     - [DEPRECATED] No longer supported. Use
+///       ::zesVFManagementGetVFMemoryUtilizationExp2.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hVFhandle`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesVFManagementGetVFMemoryUtilizationExp(
+    zes_vf_handle_t hVFhandle,                                              ///< [in] Sysman handle for the component.
+    uint32_t* pCount,                                                       ///< [in,out] Pointer to the number of VF memory stats descriptors.
+                                                                            ///<  - if count is zero, the driver shall update the value with the total
+                                                                            ///< number of memory stats available.
+                                                                            ///<  - if count is greater than the total number of memory stats
+                                                                            ///< available, the driver shall update the value with the correct number
+                                                                            ///< of memory stats available.
+                                                                            ///<  - The count returned is the sum of number of VF instances currently
+                                                                            ///< available and the PF instance.
+    zes_vf_util_mem_exp_t* pMemUtil                                         ///< [in,out][optional][range(0, *pCount)] array of memory group activity counters.
+                                                                            ///<  - if count is less than the total number of memory stats available,
+                                                                            ///< then driver shall only retrieve that number of stats.
+                                                                            ///<  - the implementation shall populate the vector pCount-1 number of VF
+                                                                            ///< memory stats.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get engine activity stats for each available engine group associated
+///        with Virtual Function (VF)
+/// 
+/// @details
+///     - [DEPRECATED] No longer supported. Use
+///       ::zesVFManagementGetVFEngineUtilizationExp2.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hVFhandle`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesVFManagementGetVFEngineUtilizationExp(
+    zes_vf_handle_t hVFhandle,                                              ///< [in] Sysman handle for the component.
+    uint32_t* pCount,                                                       ///< [in,out] Pointer to the number of VF engine stats descriptors.
+                                                                            ///<  - if count is zero, the driver shall update the value with the total
+                                                                            ///< number of engine stats available.
+                                                                            ///<  - if count is greater than the total number of engine stats
+                                                                            ///< available, the driver shall update the value with the correct number
+                                                                            ///< of engine stats available.
+                                                                            ///<  - The count returned is the sum of number of VF instances currently
+                                                                            ///< available and the PF instance.
+    zes_vf_util_engine_exp_t* pEngineUtil                                   ///< [in,out][optional][range(0, *pCount)] array of engine group activity counters.
+                                                                            ///<  - if count is less than the total number of engine stats available,
+                                                                            ///< then driver shall only retrieve that number of stats.
+                                                                            ///<  - the implementation shall populate the vector pCount-1 number of VF
+                                                                            ///< engine stats.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Configure utilization telemetry enabled or disabled associated with
+///        Virtual Function (VF)
+/// 
+/// @details
+///     - [DEPRECATED] No longer supported.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hVFhandle`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `0xf < flags`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesVFManagementSetVFTelemetryModeExp(
+    zes_vf_handle_t hVFhandle,                                              ///< [in] Sysman handle for the component.
+    zes_vf_info_util_exp_flags_t flags,                                     ///< [in] utilization flags to enable or disable. May be 0 or a valid
+                                                                            ///< combination of ::zes_vf_info_util_exp_flag_t.
+    ze_bool_t enable                                                        ///< [in] Enable utilization telemetry.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Set sampling interval to monitor for a particular utilization
+///        telemetry associated with Virtual Function (VF)
+/// 
+/// @details
+///     - [DEPRECATED] No longer supported.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hVFhandle`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `0xf < flag`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesVFManagementSetVFTelemetrySamplingIntervalExp(
+    zes_vf_handle_t hVFhandle,                                              ///< [in] Sysman handle for the component.
+    zes_vf_info_util_exp_flags_t flag,                                      ///< [in] utilization flags to set sampling interval. May be 0 or a valid
+                                                                            ///< combination of ::zes_vf_info_util_exp_flag_t.
+    uint64_t samplingInterval                                               ///< [in] Sampling interval value.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get handle of virtual function modules
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDeviceEnumEnabledVFExp(
+    zes_device_handle_t hDevice,                                            ///< [in] Sysman handle of the device.
+    uint32_t* pCount,                                                       ///< [in,out] pointer to the number of components of this type.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of components of this type that are available.
+                                                                            ///< if count is greater than the number of components of this type that
+                                                                            ///< are available, then the driver shall update the value with the correct
+                                                                            ///< number of components.
+    zes_vf_handle_t* phVFhandle                                             ///< [in,out][optional][range(0, *pCount)] array of handle of components of
+                                                                            ///< this type.
+                                                                            ///< if count is less than the number of components of this type that are
+                                                                            ///< available, then the driver shall only retrieve that number of
+                                                                            ///< component handles.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get virtual function management capabilities
+/// 
+/// @details
+///     - [DEPRECATED] No longer supported. Use
+///       ::zesVFManagementGetVFCapabilitiesExp2.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hVFhandle`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCapability`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesVFManagementGetVFCapabilitiesExp(
+    zes_vf_handle_t hVFhandle,                                              ///< [in] Sysman handle for the VF component.
+    zes_vf_exp_capabilities_t* pCapability                                  ///< [in,out] Will contain VF capability.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get memory activity stats for each available memory types associated
+///        with Virtual Function (VF)
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+///     - If VF is disable/pause/not active, utilization will give zero value.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hVFhandle`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesVFManagementGetVFMemoryUtilizationExp2(
+    zes_vf_handle_t hVFhandle,                                              ///< [in] Sysman handle for the component.
+    uint32_t* pCount,                                                       ///< [in,out] Pointer to the number of VF memory stats descriptors.
+                                                                            ///<  - if count is zero, the driver shall update the value with the total
+                                                                            ///< number of memory stats available.
+                                                                            ///<  - if count is greater than the total number of memory stats
+                                                                            ///< available, the driver shall update the value with the correct number
+                                                                            ///< of memory stats available.
+    zes_vf_util_mem_exp2_t* pMemUtil                                        ///< [in,out][optional][range(0, *pCount)] array of memory group activity counters.
+                                                                            ///<  - if count is less than the total number of memory stats available,
+                                                                            ///< then driver shall only retrieve that number of stats.
+                                                                            ///<  - the implementation shall populate the vector pCount-1 number of VF
+                                                                            ///< memory stats.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get engine activity stats for each available engine group associated
+///        with Virtual Function (VF)
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+///     - If VF is disable/pause/not active, utilization will give zero value.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hVFhandle`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesVFManagementGetVFEngineUtilizationExp2(
+    zes_vf_handle_t hVFhandle,                                              ///< [in] Sysman handle for the component.
+    uint32_t* pCount,                                                       ///< [in,out] Pointer to the number of VF engine stats descriptors.
+                                                                            ///<  - if count is zero, the driver shall update the value with the total
+                                                                            ///< number of engine stats available.
+                                                                            ///<  - if count is greater than the total number of engine stats
+                                                                            ///< available, the driver shall update the value with the correct number
+                                                                            ///< of engine stats available.
+    zes_vf_util_engine_exp2_t* pEngineUtil                                  ///< [in,out][optional][range(0, *pCount)] array of engine group activity counters.
+                                                                            ///<  - if count is less than the total number of engine stats available,
+                                                                            ///< then driver shall only retrieve that number of stats.
+                                                                            ///<  - the implementation shall populate the vector pCount-1 number of VF
+                                                                            ///< engine stats.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get virtual function management capabilities
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hVFhandle`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCapability`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesVFManagementGetVFCapabilitiesExp2(
+    zes_vf_handle_t hVFhandle,                                              ///< [in] Sysman handle for the VF component.
+    zes_vf_exp2_capabilities_t* pCapability                                 ///< [in,out] Will contain VF capability.
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+
+#if defined(__cplusplus)
+} // extern "C"
+#endif
+
+#endif // _ZES_API_H

--- a/include/level_zero/zes_ddi.h
+++ b/include/level_zero/zes_ddi.h
@@ -1,0 +1,2029 @@
+/*
+ *
+ * Copyright (C) 2019-2021 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file zes_ddi.h
+ * @version v1.12-r1.12.15
+ *
+ */
+#ifndef _ZES_DDI_H
+#define _ZES_DDI_H
+#if defined(__cplusplus)
+#pragma once
+#endif
+#include "zes_api.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesInit 
+typedef ze_result_t (ZE_APICALL *zes_pfnInit_t)(
+    zes_init_flags_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Global functions pointers
+typedef struct _zes_global_dditable_t
+{
+    zes_pfnInit_t                                               pfnInit;
+} zes_global_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Global table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zesGetGlobalProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    zes_global_dditable_t* pDdiTable                                        ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesGetGlobalProcAddrTable
+typedef ze_result_t (ZE_APICALL *zes_pfnGetGlobalProcAddrTable_t)(
+    ze_api_version_t,
+    zes_global_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDeviceGetProperties 
+typedef ze_result_t (ZE_APICALL *zes_pfnDeviceGetProperties_t)(
+    zes_device_handle_t,
+    zes_device_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDeviceGetState 
+typedef ze_result_t (ZE_APICALL *zes_pfnDeviceGetState_t)(
+    zes_device_handle_t,
+    zes_device_state_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDeviceReset 
+typedef ze_result_t (ZE_APICALL *zes_pfnDeviceReset_t)(
+    zes_device_handle_t,
+    ze_bool_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDeviceProcessesGetState 
+typedef ze_result_t (ZE_APICALL *zes_pfnDeviceProcessesGetState_t)(
+    zes_device_handle_t,
+    uint32_t*,
+    zes_process_state_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDevicePciGetProperties 
+typedef ze_result_t (ZE_APICALL *zes_pfnDevicePciGetProperties_t)(
+    zes_device_handle_t,
+    zes_pci_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDevicePciGetState 
+typedef ze_result_t (ZE_APICALL *zes_pfnDevicePciGetState_t)(
+    zes_device_handle_t,
+    zes_pci_state_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDevicePciGetBars 
+typedef ze_result_t (ZE_APICALL *zes_pfnDevicePciGetBars_t)(
+    zes_device_handle_t,
+    uint32_t*,
+    zes_pci_bar_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDevicePciGetStats 
+typedef ze_result_t (ZE_APICALL *zes_pfnDevicePciGetStats_t)(
+    zes_device_handle_t,
+    zes_pci_stats_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDeviceEnumDiagnosticTestSuites 
+typedef ze_result_t (ZE_APICALL *zes_pfnDeviceEnumDiagnosticTestSuites_t)(
+    zes_device_handle_t,
+    uint32_t*,
+    zes_diag_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDeviceEnumEngineGroups 
+typedef ze_result_t (ZE_APICALL *zes_pfnDeviceEnumEngineGroups_t)(
+    zes_device_handle_t,
+    uint32_t*,
+    zes_engine_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDeviceEventRegister 
+typedef ze_result_t (ZE_APICALL *zes_pfnDeviceEventRegister_t)(
+    zes_device_handle_t,
+    zes_event_type_flags_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDeviceEnumFabricPorts 
+typedef ze_result_t (ZE_APICALL *zes_pfnDeviceEnumFabricPorts_t)(
+    zes_device_handle_t,
+    uint32_t*,
+    zes_fabric_port_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDeviceEnumFans 
+typedef ze_result_t (ZE_APICALL *zes_pfnDeviceEnumFans_t)(
+    zes_device_handle_t,
+    uint32_t*,
+    zes_fan_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDeviceEnumFirmwares 
+typedef ze_result_t (ZE_APICALL *zes_pfnDeviceEnumFirmwares_t)(
+    zes_device_handle_t,
+    uint32_t*,
+    zes_firmware_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDeviceEnumFrequencyDomains 
+typedef ze_result_t (ZE_APICALL *zes_pfnDeviceEnumFrequencyDomains_t)(
+    zes_device_handle_t,
+    uint32_t*,
+    zes_freq_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDeviceEnumLeds 
+typedef ze_result_t (ZE_APICALL *zes_pfnDeviceEnumLeds_t)(
+    zes_device_handle_t,
+    uint32_t*,
+    zes_led_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDeviceEnumMemoryModules 
+typedef ze_result_t (ZE_APICALL *zes_pfnDeviceEnumMemoryModules_t)(
+    zes_device_handle_t,
+    uint32_t*,
+    zes_mem_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDeviceEnumPerformanceFactorDomains 
+typedef ze_result_t (ZE_APICALL *zes_pfnDeviceEnumPerformanceFactorDomains_t)(
+    zes_device_handle_t,
+    uint32_t*,
+    zes_perf_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDeviceEnumPowerDomains 
+typedef ze_result_t (ZE_APICALL *zes_pfnDeviceEnumPowerDomains_t)(
+    zes_device_handle_t,
+    uint32_t*,
+    zes_pwr_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDeviceGetCardPowerDomain 
+typedef ze_result_t (ZE_APICALL *zes_pfnDeviceGetCardPowerDomain_t)(
+    zes_device_handle_t,
+    zes_pwr_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDeviceEnumPsus 
+typedef ze_result_t (ZE_APICALL *zes_pfnDeviceEnumPsus_t)(
+    zes_device_handle_t,
+    uint32_t*,
+    zes_psu_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDeviceEnumRasErrorSets 
+typedef ze_result_t (ZE_APICALL *zes_pfnDeviceEnumRasErrorSets_t)(
+    zes_device_handle_t,
+    uint32_t*,
+    zes_ras_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDeviceEnumSchedulers 
+typedef ze_result_t (ZE_APICALL *zes_pfnDeviceEnumSchedulers_t)(
+    zes_device_handle_t,
+    uint32_t*,
+    zes_sched_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDeviceEnumStandbyDomains 
+typedef ze_result_t (ZE_APICALL *zes_pfnDeviceEnumStandbyDomains_t)(
+    zes_device_handle_t,
+    uint32_t*,
+    zes_standby_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDeviceEnumTemperatureSensors 
+typedef ze_result_t (ZE_APICALL *zes_pfnDeviceEnumTemperatureSensors_t)(
+    zes_device_handle_t,
+    uint32_t*,
+    zes_temp_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDeviceEccAvailable 
+typedef ze_result_t (ZE_APICALL *zes_pfnDeviceEccAvailable_t)(
+    zes_device_handle_t,
+    ze_bool_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDeviceEccConfigurable 
+typedef ze_result_t (ZE_APICALL *zes_pfnDeviceEccConfigurable_t)(
+    zes_device_handle_t,
+    ze_bool_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDeviceGetEccState 
+typedef ze_result_t (ZE_APICALL *zes_pfnDeviceGetEccState_t)(
+    zes_device_handle_t,
+    zes_device_ecc_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDeviceSetEccState 
+typedef ze_result_t (ZE_APICALL *zes_pfnDeviceSetEccState_t)(
+    zes_device_handle_t,
+    const zes_device_ecc_desc_t*,
+    zes_device_ecc_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDeviceGet 
+typedef ze_result_t (ZE_APICALL *zes_pfnDeviceGet_t)(
+    zes_driver_handle_t,
+    uint32_t*,
+    zes_device_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDeviceSetOverclockWaiver 
+typedef ze_result_t (ZE_APICALL *zes_pfnDeviceSetOverclockWaiver_t)(
+    zes_device_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDeviceGetOverclockDomains 
+typedef ze_result_t (ZE_APICALL *zes_pfnDeviceGetOverclockDomains_t)(
+    zes_device_handle_t,
+    uint32_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDeviceGetOverclockControls 
+typedef ze_result_t (ZE_APICALL *zes_pfnDeviceGetOverclockControls_t)(
+    zes_device_handle_t,
+    zes_overclock_domain_t,
+    uint32_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDeviceResetOverclockSettings 
+typedef ze_result_t (ZE_APICALL *zes_pfnDeviceResetOverclockSettings_t)(
+    zes_device_handle_t,
+    ze_bool_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDeviceReadOverclockState 
+typedef ze_result_t (ZE_APICALL *zes_pfnDeviceReadOverclockState_t)(
+    zes_device_handle_t,
+    zes_overclock_mode_t*,
+    ze_bool_t*,
+    ze_bool_t*,
+    zes_pending_action_t*,
+    ze_bool_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDeviceEnumOverclockDomains 
+typedef ze_result_t (ZE_APICALL *zes_pfnDeviceEnumOverclockDomains_t)(
+    zes_device_handle_t,
+    uint32_t*,
+    zes_overclock_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDeviceResetExt 
+typedef ze_result_t (ZE_APICALL *zes_pfnDeviceResetExt_t)(
+    zes_device_handle_t,
+    zes_reset_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Device functions pointers
+typedef struct _zes_device_dditable_t
+{
+    zes_pfnDeviceGetProperties_t                                pfnGetProperties;
+    zes_pfnDeviceGetState_t                                     pfnGetState;
+    zes_pfnDeviceReset_t                                        pfnReset;
+    zes_pfnDeviceProcessesGetState_t                            pfnProcessesGetState;
+    zes_pfnDevicePciGetProperties_t                             pfnPciGetProperties;
+    zes_pfnDevicePciGetState_t                                  pfnPciGetState;
+    zes_pfnDevicePciGetBars_t                                   pfnPciGetBars;
+    zes_pfnDevicePciGetStats_t                                  pfnPciGetStats;
+    zes_pfnDeviceEnumDiagnosticTestSuites_t                     pfnEnumDiagnosticTestSuites;
+    zes_pfnDeviceEnumEngineGroups_t                             pfnEnumEngineGroups;
+    zes_pfnDeviceEventRegister_t                                pfnEventRegister;
+    zes_pfnDeviceEnumFabricPorts_t                              pfnEnumFabricPorts;
+    zes_pfnDeviceEnumFans_t                                     pfnEnumFans;
+    zes_pfnDeviceEnumFirmwares_t                                pfnEnumFirmwares;
+    zes_pfnDeviceEnumFrequencyDomains_t                         pfnEnumFrequencyDomains;
+    zes_pfnDeviceEnumLeds_t                                     pfnEnumLeds;
+    zes_pfnDeviceEnumMemoryModules_t                            pfnEnumMemoryModules;
+    zes_pfnDeviceEnumPerformanceFactorDomains_t                 pfnEnumPerformanceFactorDomains;
+    zes_pfnDeviceEnumPowerDomains_t                             pfnEnumPowerDomains;
+    zes_pfnDeviceGetCardPowerDomain_t                           pfnGetCardPowerDomain;
+    zes_pfnDeviceEnumPsus_t                                     pfnEnumPsus;
+    zes_pfnDeviceEnumRasErrorSets_t                             pfnEnumRasErrorSets;
+    zes_pfnDeviceEnumSchedulers_t                               pfnEnumSchedulers;
+    zes_pfnDeviceEnumStandbyDomains_t                           pfnEnumStandbyDomains;
+    zes_pfnDeviceEnumTemperatureSensors_t                       pfnEnumTemperatureSensors;
+    zes_pfnDeviceEccAvailable_t                                 pfnEccAvailable;
+    zes_pfnDeviceEccConfigurable_t                              pfnEccConfigurable;
+    zes_pfnDeviceGetEccState_t                                  pfnGetEccState;
+    zes_pfnDeviceSetEccState_t                                  pfnSetEccState;
+    zes_pfnDeviceGet_t                                          pfnGet;
+    zes_pfnDeviceSetOverclockWaiver_t                           pfnSetOverclockWaiver;
+    zes_pfnDeviceGetOverclockDomains_t                          pfnGetOverclockDomains;
+    zes_pfnDeviceGetOverclockControls_t                         pfnGetOverclockControls;
+    zes_pfnDeviceResetOverclockSettings_t                       pfnResetOverclockSettings;
+    zes_pfnDeviceReadOverclockState_t                           pfnReadOverclockState;
+    zes_pfnDeviceEnumOverclockDomains_t                         pfnEnumOverclockDomains;
+    zes_pfnDeviceResetExt_t                                     pfnResetExt;
+} zes_device_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Device table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zesGetDeviceProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    zes_device_dditable_t* pDdiTable                                        ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesGetDeviceProcAddrTable
+typedef ze_result_t (ZE_APICALL *zes_pfnGetDeviceProcAddrTable_t)(
+    ze_api_version_t,
+    zes_device_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDeviceGetSubDevicePropertiesExp 
+typedef ze_result_t (ZE_APICALL *zes_pfnDeviceGetSubDevicePropertiesExp_t)(
+    zes_device_handle_t,
+    uint32_t*,
+    zes_subdevice_exp_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDeviceEnumActiveVFExp 
+typedef ze_result_t (ZE_APICALL *zes_pfnDeviceEnumActiveVFExp_t)(
+    zes_device_handle_t,
+    uint32_t*,
+    zes_vf_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDeviceEnumEnabledVFExp 
+typedef ze_result_t (ZE_APICALL *zes_pfnDeviceEnumEnabledVFExp_t)(
+    zes_device_handle_t,
+    uint32_t*,
+    zes_vf_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of DeviceExp functions pointers
+typedef struct _zes_device_exp_dditable_t
+{
+    zes_pfnDeviceGetSubDevicePropertiesExp_t                    pfnGetSubDevicePropertiesExp;
+    zes_pfnDeviceEnumActiveVFExp_t                              pfnEnumActiveVFExp;
+    zes_pfnDeviceEnumEnabledVFExp_t                             pfnEnumEnabledVFExp;
+} zes_device_exp_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's DeviceExp table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zesGetDeviceExpProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    zes_device_exp_dditable_t* pDdiTable                                    ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesGetDeviceExpProcAddrTable
+typedef ze_result_t (ZE_APICALL *zes_pfnGetDeviceExpProcAddrTable_t)(
+    ze_api_version_t,
+    zes_device_exp_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDriverEventListen 
+typedef ze_result_t (ZE_APICALL *zes_pfnDriverEventListen_t)(
+    ze_driver_handle_t,
+    uint32_t,
+    uint32_t,
+    zes_device_handle_t*,
+    uint32_t*,
+    zes_event_type_flags_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDriverEventListenEx 
+typedef ze_result_t (ZE_APICALL *zes_pfnDriverEventListenEx_t)(
+    ze_driver_handle_t,
+    uint64_t,
+    uint32_t,
+    zes_device_handle_t*,
+    uint32_t*,
+    zes_event_type_flags_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDriverGet 
+typedef ze_result_t (ZE_APICALL *zes_pfnDriverGet_t)(
+    uint32_t*,
+    zes_driver_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDriverGetExtensionProperties 
+typedef ze_result_t (ZE_APICALL *zes_pfnDriverGetExtensionProperties_t)(
+    zes_driver_handle_t,
+    uint32_t*,
+    zes_driver_extension_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDriverGetExtensionFunctionAddress 
+typedef ze_result_t (ZE_APICALL *zes_pfnDriverGetExtensionFunctionAddress_t)(
+    zes_driver_handle_t,
+    const char*,
+    void**
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Driver functions pointers
+typedef struct _zes_driver_dditable_t
+{
+    zes_pfnDriverEventListen_t                                  pfnEventListen;
+    zes_pfnDriverEventListenEx_t                                pfnEventListenEx;
+    zes_pfnDriverGet_t                                          pfnGet;
+    zes_pfnDriverGetExtensionProperties_t                       pfnGetExtensionProperties;
+    zes_pfnDriverGetExtensionFunctionAddress_t                  pfnGetExtensionFunctionAddress;
+} zes_driver_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Driver table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zesGetDriverProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    zes_driver_dditable_t* pDdiTable                                        ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesGetDriverProcAddrTable
+typedef ze_result_t (ZE_APICALL *zes_pfnGetDriverProcAddrTable_t)(
+    ze_api_version_t,
+    zes_driver_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDriverGetDeviceByUuidExp 
+typedef ze_result_t (ZE_APICALL *zes_pfnDriverGetDeviceByUuidExp_t)(
+    zes_driver_handle_t,
+    zes_uuid_t,
+    zes_device_handle_t*,
+    ze_bool_t*,
+    uint32_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of DriverExp functions pointers
+typedef struct _zes_driver_exp_dditable_t
+{
+    zes_pfnDriverGetDeviceByUuidExp_t                           pfnGetDeviceByUuidExp;
+} zes_driver_exp_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's DriverExp table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zesGetDriverExpProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    zes_driver_exp_dditable_t* pDdiTable                                    ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesGetDriverExpProcAddrTable
+typedef ze_result_t (ZE_APICALL *zes_pfnGetDriverExpProcAddrTable_t)(
+    ze_api_version_t,
+    zes_driver_exp_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesOverclockGetDomainProperties 
+typedef ze_result_t (ZE_APICALL *zes_pfnOverclockGetDomainProperties_t)(
+    zes_overclock_handle_t,
+    zes_overclock_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesOverclockGetDomainVFProperties 
+typedef ze_result_t (ZE_APICALL *zes_pfnOverclockGetDomainVFProperties_t)(
+    zes_overclock_handle_t,
+    zes_vf_property_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesOverclockGetDomainControlProperties 
+typedef ze_result_t (ZE_APICALL *zes_pfnOverclockGetDomainControlProperties_t)(
+    zes_overclock_handle_t,
+    zes_overclock_control_t,
+    zes_control_property_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesOverclockGetControlCurrentValue 
+typedef ze_result_t (ZE_APICALL *zes_pfnOverclockGetControlCurrentValue_t)(
+    zes_overclock_handle_t,
+    zes_overclock_control_t,
+    double*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesOverclockGetControlPendingValue 
+typedef ze_result_t (ZE_APICALL *zes_pfnOverclockGetControlPendingValue_t)(
+    zes_overclock_handle_t,
+    zes_overclock_control_t,
+    double*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesOverclockSetControlUserValue 
+typedef ze_result_t (ZE_APICALL *zes_pfnOverclockSetControlUserValue_t)(
+    zes_overclock_handle_t,
+    zes_overclock_control_t,
+    double,
+    zes_pending_action_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesOverclockGetControlState 
+typedef ze_result_t (ZE_APICALL *zes_pfnOverclockGetControlState_t)(
+    zes_overclock_handle_t,
+    zes_overclock_control_t,
+    zes_control_state_t*,
+    zes_pending_action_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesOverclockGetVFPointValues 
+typedef ze_result_t (ZE_APICALL *zes_pfnOverclockGetVFPointValues_t)(
+    zes_overclock_handle_t,
+    zes_vf_type_t,
+    zes_vf_array_type_t,
+    uint32_t,
+    uint32_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesOverclockSetVFPointValues 
+typedef ze_result_t (ZE_APICALL *zes_pfnOverclockSetVFPointValues_t)(
+    zes_overclock_handle_t,
+    zes_vf_type_t,
+    uint32_t,
+    uint32_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Overclock functions pointers
+typedef struct _zes_overclock_dditable_t
+{
+    zes_pfnOverclockGetDomainProperties_t                       pfnGetDomainProperties;
+    zes_pfnOverclockGetDomainVFProperties_t                     pfnGetDomainVFProperties;
+    zes_pfnOverclockGetDomainControlProperties_t                pfnGetDomainControlProperties;
+    zes_pfnOverclockGetControlCurrentValue_t                    pfnGetControlCurrentValue;
+    zes_pfnOverclockGetControlPendingValue_t                    pfnGetControlPendingValue;
+    zes_pfnOverclockSetControlUserValue_t                       pfnSetControlUserValue;
+    zes_pfnOverclockGetControlState_t                           pfnGetControlState;
+    zes_pfnOverclockGetVFPointValues_t                          pfnGetVFPointValues;
+    zes_pfnOverclockSetVFPointValues_t                          pfnSetVFPointValues;
+} zes_overclock_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Overclock table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zesGetOverclockProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    zes_overclock_dditable_t* pDdiTable                                     ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesGetOverclockProcAddrTable
+typedef ze_result_t (ZE_APICALL *zes_pfnGetOverclockProcAddrTable_t)(
+    ze_api_version_t,
+    zes_overclock_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesSchedulerGetProperties 
+typedef ze_result_t (ZE_APICALL *zes_pfnSchedulerGetProperties_t)(
+    zes_sched_handle_t,
+    zes_sched_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesSchedulerGetCurrentMode 
+typedef ze_result_t (ZE_APICALL *zes_pfnSchedulerGetCurrentMode_t)(
+    zes_sched_handle_t,
+    zes_sched_mode_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesSchedulerGetTimeoutModeProperties 
+typedef ze_result_t (ZE_APICALL *zes_pfnSchedulerGetTimeoutModeProperties_t)(
+    zes_sched_handle_t,
+    ze_bool_t,
+    zes_sched_timeout_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesSchedulerGetTimesliceModeProperties 
+typedef ze_result_t (ZE_APICALL *zes_pfnSchedulerGetTimesliceModeProperties_t)(
+    zes_sched_handle_t,
+    ze_bool_t,
+    zes_sched_timeslice_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesSchedulerSetTimeoutMode 
+typedef ze_result_t (ZE_APICALL *zes_pfnSchedulerSetTimeoutMode_t)(
+    zes_sched_handle_t,
+    zes_sched_timeout_properties_t*,
+    ze_bool_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesSchedulerSetTimesliceMode 
+typedef ze_result_t (ZE_APICALL *zes_pfnSchedulerSetTimesliceMode_t)(
+    zes_sched_handle_t,
+    zes_sched_timeslice_properties_t*,
+    ze_bool_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesSchedulerSetExclusiveMode 
+typedef ze_result_t (ZE_APICALL *zes_pfnSchedulerSetExclusiveMode_t)(
+    zes_sched_handle_t,
+    ze_bool_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesSchedulerSetComputeUnitDebugMode 
+typedef ze_result_t (ZE_APICALL *zes_pfnSchedulerSetComputeUnitDebugMode_t)(
+    zes_sched_handle_t,
+    ze_bool_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Scheduler functions pointers
+typedef struct _zes_scheduler_dditable_t
+{
+    zes_pfnSchedulerGetProperties_t                             pfnGetProperties;
+    zes_pfnSchedulerGetCurrentMode_t                            pfnGetCurrentMode;
+    zes_pfnSchedulerGetTimeoutModeProperties_t                  pfnGetTimeoutModeProperties;
+    zes_pfnSchedulerGetTimesliceModeProperties_t                pfnGetTimesliceModeProperties;
+    zes_pfnSchedulerSetTimeoutMode_t                            pfnSetTimeoutMode;
+    zes_pfnSchedulerSetTimesliceMode_t                          pfnSetTimesliceMode;
+    zes_pfnSchedulerSetExclusiveMode_t                          pfnSetExclusiveMode;
+    zes_pfnSchedulerSetComputeUnitDebugMode_t                   pfnSetComputeUnitDebugMode;
+} zes_scheduler_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Scheduler table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zesGetSchedulerProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    zes_scheduler_dditable_t* pDdiTable                                     ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesGetSchedulerProcAddrTable
+typedef ze_result_t (ZE_APICALL *zes_pfnGetSchedulerProcAddrTable_t)(
+    ze_api_version_t,
+    zes_scheduler_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesPerformanceFactorGetProperties 
+typedef ze_result_t (ZE_APICALL *zes_pfnPerformanceFactorGetProperties_t)(
+    zes_perf_handle_t,
+    zes_perf_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesPerformanceFactorGetConfig 
+typedef ze_result_t (ZE_APICALL *zes_pfnPerformanceFactorGetConfig_t)(
+    zes_perf_handle_t,
+    double*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesPerformanceFactorSetConfig 
+typedef ze_result_t (ZE_APICALL *zes_pfnPerformanceFactorSetConfig_t)(
+    zes_perf_handle_t,
+    double
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of PerformanceFactor functions pointers
+typedef struct _zes_performance_factor_dditable_t
+{
+    zes_pfnPerformanceFactorGetProperties_t                     pfnGetProperties;
+    zes_pfnPerformanceFactorGetConfig_t                         pfnGetConfig;
+    zes_pfnPerformanceFactorSetConfig_t                         pfnSetConfig;
+} zes_performance_factor_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's PerformanceFactor table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zesGetPerformanceFactorProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    zes_performance_factor_dditable_t* pDdiTable                            ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesGetPerformanceFactorProcAddrTable
+typedef ze_result_t (ZE_APICALL *zes_pfnGetPerformanceFactorProcAddrTable_t)(
+    ze_api_version_t,
+    zes_performance_factor_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesPowerGetProperties 
+typedef ze_result_t (ZE_APICALL *zes_pfnPowerGetProperties_t)(
+    zes_pwr_handle_t,
+    zes_power_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesPowerGetEnergyCounter 
+typedef ze_result_t (ZE_APICALL *zes_pfnPowerGetEnergyCounter_t)(
+    zes_pwr_handle_t,
+    zes_power_energy_counter_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesPowerGetLimits 
+typedef ze_result_t (ZE_APICALL *zes_pfnPowerGetLimits_t)(
+    zes_pwr_handle_t,
+    zes_power_sustained_limit_t*,
+    zes_power_burst_limit_t*,
+    zes_power_peak_limit_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesPowerSetLimits 
+typedef ze_result_t (ZE_APICALL *zes_pfnPowerSetLimits_t)(
+    zes_pwr_handle_t,
+    const zes_power_sustained_limit_t*,
+    const zes_power_burst_limit_t*,
+    const zes_power_peak_limit_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesPowerGetEnergyThreshold 
+typedef ze_result_t (ZE_APICALL *zes_pfnPowerGetEnergyThreshold_t)(
+    zes_pwr_handle_t,
+    zes_energy_threshold_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesPowerSetEnergyThreshold 
+typedef ze_result_t (ZE_APICALL *zes_pfnPowerSetEnergyThreshold_t)(
+    zes_pwr_handle_t,
+    double
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesPowerGetLimitsExt 
+typedef ze_result_t (ZE_APICALL *zes_pfnPowerGetLimitsExt_t)(
+    zes_pwr_handle_t,
+    uint32_t*,
+    zes_power_limit_ext_desc_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesPowerSetLimitsExt 
+typedef ze_result_t (ZE_APICALL *zes_pfnPowerSetLimitsExt_t)(
+    zes_pwr_handle_t,
+    uint32_t*,
+    zes_power_limit_ext_desc_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Power functions pointers
+typedef struct _zes_power_dditable_t
+{
+    zes_pfnPowerGetProperties_t                                 pfnGetProperties;
+    zes_pfnPowerGetEnergyCounter_t                              pfnGetEnergyCounter;
+    zes_pfnPowerGetLimits_t                                     pfnGetLimits;
+    zes_pfnPowerSetLimits_t                                     pfnSetLimits;
+    zes_pfnPowerGetEnergyThreshold_t                            pfnGetEnergyThreshold;
+    zes_pfnPowerSetEnergyThreshold_t                            pfnSetEnergyThreshold;
+    zes_pfnPowerGetLimitsExt_t                                  pfnGetLimitsExt;
+    zes_pfnPowerSetLimitsExt_t                                  pfnSetLimitsExt;
+} zes_power_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Power table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zesGetPowerProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    zes_power_dditable_t* pDdiTable                                         ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesGetPowerProcAddrTable
+typedef ze_result_t (ZE_APICALL *zes_pfnGetPowerProcAddrTable_t)(
+    ze_api_version_t,
+    zes_power_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesFrequencyGetProperties 
+typedef ze_result_t (ZE_APICALL *zes_pfnFrequencyGetProperties_t)(
+    zes_freq_handle_t,
+    zes_freq_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesFrequencyGetAvailableClocks 
+typedef ze_result_t (ZE_APICALL *zes_pfnFrequencyGetAvailableClocks_t)(
+    zes_freq_handle_t,
+    uint32_t*,
+    double*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesFrequencyGetRange 
+typedef ze_result_t (ZE_APICALL *zes_pfnFrequencyGetRange_t)(
+    zes_freq_handle_t,
+    zes_freq_range_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesFrequencySetRange 
+typedef ze_result_t (ZE_APICALL *zes_pfnFrequencySetRange_t)(
+    zes_freq_handle_t,
+    const zes_freq_range_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesFrequencyGetState 
+typedef ze_result_t (ZE_APICALL *zes_pfnFrequencyGetState_t)(
+    zes_freq_handle_t,
+    zes_freq_state_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesFrequencyGetThrottleTime 
+typedef ze_result_t (ZE_APICALL *zes_pfnFrequencyGetThrottleTime_t)(
+    zes_freq_handle_t,
+    zes_freq_throttle_time_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesFrequencyOcGetCapabilities 
+typedef ze_result_t (ZE_APICALL *zes_pfnFrequencyOcGetCapabilities_t)(
+    zes_freq_handle_t,
+    zes_oc_capabilities_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesFrequencyOcGetFrequencyTarget 
+typedef ze_result_t (ZE_APICALL *zes_pfnFrequencyOcGetFrequencyTarget_t)(
+    zes_freq_handle_t,
+    double*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesFrequencyOcSetFrequencyTarget 
+typedef ze_result_t (ZE_APICALL *zes_pfnFrequencyOcSetFrequencyTarget_t)(
+    zes_freq_handle_t,
+    double
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesFrequencyOcGetVoltageTarget 
+typedef ze_result_t (ZE_APICALL *zes_pfnFrequencyOcGetVoltageTarget_t)(
+    zes_freq_handle_t,
+    double*,
+    double*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesFrequencyOcSetVoltageTarget 
+typedef ze_result_t (ZE_APICALL *zes_pfnFrequencyOcSetVoltageTarget_t)(
+    zes_freq_handle_t,
+    double,
+    double
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesFrequencyOcSetMode 
+typedef ze_result_t (ZE_APICALL *zes_pfnFrequencyOcSetMode_t)(
+    zes_freq_handle_t,
+    zes_oc_mode_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesFrequencyOcGetMode 
+typedef ze_result_t (ZE_APICALL *zes_pfnFrequencyOcGetMode_t)(
+    zes_freq_handle_t,
+    zes_oc_mode_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesFrequencyOcGetIccMax 
+typedef ze_result_t (ZE_APICALL *zes_pfnFrequencyOcGetIccMax_t)(
+    zes_freq_handle_t,
+    double*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesFrequencyOcSetIccMax 
+typedef ze_result_t (ZE_APICALL *zes_pfnFrequencyOcSetIccMax_t)(
+    zes_freq_handle_t,
+    double
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesFrequencyOcGetTjMax 
+typedef ze_result_t (ZE_APICALL *zes_pfnFrequencyOcGetTjMax_t)(
+    zes_freq_handle_t,
+    double*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesFrequencyOcSetTjMax 
+typedef ze_result_t (ZE_APICALL *zes_pfnFrequencyOcSetTjMax_t)(
+    zes_freq_handle_t,
+    double
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Frequency functions pointers
+typedef struct _zes_frequency_dditable_t
+{
+    zes_pfnFrequencyGetProperties_t                             pfnGetProperties;
+    zes_pfnFrequencyGetAvailableClocks_t                        pfnGetAvailableClocks;
+    zes_pfnFrequencyGetRange_t                                  pfnGetRange;
+    zes_pfnFrequencySetRange_t                                  pfnSetRange;
+    zes_pfnFrequencyGetState_t                                  pfnGetState;
+    zes_pfnFrequencyGetThrottleTime_t                           pfnGetThrottleTime;
+    zes_pfnFrequencyOcGetCapabilities_t                         pfnOcGetCapabilities;
+    zes_pfnFrequencyOcGetFrequencyTarget_t                      pfnOcGetFrequencyTarget;
+    zes_pfnFrequencyOcSetFrequencyTarget_t                      pfnOcSetFrequencyTarget;
+    zes_pfnFrequencyOcGetVoltageTarget_t                        pfnOcGetVoltageTarget;
+    zes_pfnFrequencyOcSetVoltageTarget_t                        pfnOcSetVoltageTarget;
+    zes_pfnFrequencyOcSetMode_t                                 pfnOcSetMode;
+    zes_pfnFrequencyOcGetMode_t                                 pfnOcGetMode;
+    zes_pfnFrequencyOcGetIccMax_t                               pfnOcGetIccMax;
+    zes_pfnFrequencyOcSetIccMax_t                               pfnOcSetIccMax;
+    zes_pfnFrequencyOcGetTjMax_t                                pfnOcGetTjMax;
+    zes_pfnFrequencyOcSetTjMax_t                                pfnOcSetTjMax;
+} zes_frequency_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Frequency table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zesGetFrequencyProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    zes_frequency_dditable_t* pDdiTable                                     ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesGetFrequencyProcAddrTable
+typedef ze_result_t (ZE_APICALL *zes_pfnGetFrequencyProcAddrTable_t)(
+    ze_api_version_t,
+    zes_frequency_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesEngineGetProperties 
+typedef ze_result_t (ZE_APICALL *zes_pfnEngineGetProperties_t)(
+    zes_engine_handle_t,
+    zes_engine_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesEngineGetActivity 
+typedef ze_result_t (ZE_APICALL *zes_pfnEngineGetActivity_t)(
+    zes_engine_handle_t,
+    zes_engine_stats_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesEngineGetActivityExt 
+typedef ze_result_t (ZE_APICALL *zes_pfnEngineGetActivityExt_t)(
+    zes_engine_handle_t,
+    uint32_t*,
+    zes_engine_stats_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Engine functions pointers
+typedef struct _zes_engine_dditable_t
+{
+    zes_pfnEngineGetProperties_t                                pfnGetProperties;
+    zes_pfnEngineGetActivity_t                                  pfnGetActivity;
+    zes_pfnEngineGetActivityExt_t                               pfnGetActivityExt;
+} zes_engine_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Engine table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zesGetEngineProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    zes_engine_dditable_t* pDdiTable                                        ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesGetEngineProcAddrTable
+typedef ze_result_t (ZE_APICALL *zes_pfnGetEngineProcAddrTable_t)(
+    ze_api_version_t,
+    zes_engine_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesStandbyGetProperties 
+typedef ze_result_t (ZE_APICALL *zes_pfnStandbyGetProperties_t)(
+    zes_standby_handle_t,
+    zes_standby_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesStandbyGetMode 
+typedef ze_result_t (ZE_APICALL *zes_pfnStandbyGetMode_t)(
+    zes_standby_handle_t,
+    zes_standby_promo_mode_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesStandbySetMode 
+typedef ze_result_t (ZE_APICALL *zes_pfnStandbySetMode_t)(
+    zes_standby_handle_t,
+    zes_standby_promo_mode_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Standby functions pointers
+typedef struct _zes_standby_dditable_t
+{
+    zes_pfnStandbyGetProperties_t                               pfnGetProperties;
+    zes_pfnStandbyGetMode_t                                     pfnGetMode;
+    zes_pfnStandbySetMode_t                                     pfnSetMode;
+} zes_standby_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Standby table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zesGetStandbyProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    zes_standby_dditable_t* pDdiTable                                       ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesGetStandbyProcAddrTable
+typedef ze_result_t (ZE_APICALL *zes_pfnGetStandbyProcAddrTable_t)(
+    ze_api_version_t,
+    zes_standby_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesFirmwareGetProperties 
+typedef ze_result_t (ZE_APICALL *zes_pfnFirmwareGetProperties_t)(
+    zes_firmware_handle_t,
+    zes_firmware_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesFirmwareFlash 
+typedef ze_result_t (ZE_APICALL *zes_pfnFirmwareFlash_t)(
+    zes_firmware_handle_t,
+    void*,
+    uint32_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesFirmwareGetFlashProgress 
+typedef ze_result_t (ZE_APICALL *zes_pfnFirmwareGetFlashProgress_t)(
+    zes_firmware_handle_t,
+    uint32_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesFirmwareGetConsoleLogs 
+typedef ze_result_t (ZE_APICALL *zes_pfnFirmwareGetConsoleLogs_t)(
+    zes_firmware_handle_t,
+    size_t*,
+    char*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Firmware functions pointers
+typedef struct _zes_firmware_dditable_t
+{
+    zes_pfnFirmwareGetProperties_t                              pfnGetProperties;
+    zes_pfnFirmwareFlash_t                                      pfnFlash;
+    zes_pfnFirmwareGetFlashProgress_t                           pfnGetFlashProgress;
+    zes_pfnFirmwareGetConsoleLogs_t                             pfnGetConsoleLogs;
+} zes_firmware_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Firmware table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zesGetFirmwareProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    zes_firmware_dditable_t* pDdiTable                                      ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesGetFirmwareProcAddrTable
+typedef ze_result_t (ZE_APICALL *zes_pfnGetFirmwareProcAddrTable_t)(
+    ze_api_version_t,
+    zes_firmware_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesFirmwareGetSecurityVersionExp 
+typedef ze_result_t (ZE_APICALL *zes_pfnFirmwareGetSecurityVersionExp_t)(
+    zes_firmware_handle_t,
+    char*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesFirmwareSetSecurityVersionExp 
+typedef ze_result_t (ZE_APICALL *zes_pfnFirmwareSetSecurityVersionExp_t)(
+    zes_firmware_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of FirmwareExp functions pointers
+typedef struct _zes_firmware_exp_dditable_t
+{
+    zes_pfnFirmwareGetSecurityVersionExp_t                      pfnGetSecurityVersionExp;
+    zes_pfnFirmwareSetSecurityVersionExp_t                      pfnSetSecurityVersionExp;
+} zes_firmware_exp_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's FirmwareExp table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zesGetFirmwareExpProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    zes_firmware_exp_dditable_t* pDdiTable                                  ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesGetFirmwareExpProcAddrTable
+typedef ze_result_t (ZE_APICALL *zes_pfnGetFirmwareExpProcAddrTable_t)(
+    ze_api_version_t,
+    zes_firmware_exp_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesMemoryGetProperties 
+typedef ze_result_t (ZE_APICALL *zes_pfnMemoryGetProperties_t)(
+    zes_mem_handle_t,
+    zes_mem_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesMemoryGetState 
+typedef ze_result_t (ZE_APICALL *zes_pfnMemoryGetState_t)(
+    zes_mem_handle_t,
+    zes_mem_state_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesMemoryGetBandwidth 
+typedef ze_result_t (ZE_APICALL *zes_pfnMemoryGetBandwidth_t)(
+    zes_mem_handle_t,
+    zes_mem_bandwidth_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Memory functions pointers
+typedef struct _zes_memory_dditable_t
+{
+    zes_pfnMemoryGetProperties_t                                pfnGetProperties;
+    zes_pfnMemoryGetState_t                                     pfnGetState;
+    zes_pfnMemoryGetBandwidth_t                                 pfnGetBandwidth;
+} zes_memory_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Memory table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zesGetMemoryProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    zes_memory_dditable_t* pDdiTable                                        ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesGetMemoryProcAddrTable
+typedef ze_result_t (ZE_APICALL *zes_pfnGetMemoryProcAddrTable_t)(
+    ze_api_version_t,
+    zes_memory_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesFabricPortGetProperties 
+typedef ze_result_t (ZE_APICALL *zes_pfnFabricPortGetProperties_t)(
+    zes_fabric_port_handle_t,
+    zes_fabric_port_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesFabricPortGetLinkType 
+typedef ze_result_t (ZE_APICALL *zes_pfnFabricPortGetLinkType_t)(
+    zes_fabric_port_handle_t,
+    zes_fabric_link_type_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesFabricPortGetConfig 
+typedef ze_result_t (ZE_APICALL *zes_pfnFabricPortGetConfig_t)(
+    zes_fabric_port_handle_t,
+    zes_fabric_port_config_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesFabricPortSetConfig 
+typedef ze_result_t (ZE_APICALL *zes_pfnFabricPortSetConfig_t)(
+    zes_fabric_port_handle_t,
+    const zes_fabric_port_config_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesFabricPortGetState 
+typedef ze_result_t (ZE_APICALL *zes_pfnFabricPortGetState_t)(
+    zes_fabric_port_handle_t,
+    zes_fabric_port_state_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesFabricPortGetThroughput 
+typedef ze_result_t (ZE_APICALL *zes_pfnFabricPortGetThroughput_t)(
+    zes_fabric_port_handle_t,
+    zes_fabric_port_throughput_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesFabricPortGetFabricErrorCounters 
+typedef ze_result_t (ZE_APICALL *zes_pfnFabricPortGetFabricErrorCounters_t)(
+    zes_fabric_port_handle_t,
+    zes_fabric_port_error_counters_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesFabricPortGetMultiPortThroughput 
+typedef ze_result_t (ZE_APICALL *zes_pfnFabricPortGetMultiPortThroughput_t)(
+    zes_device_handle_t,
+    uint32_t,
+    zes_fabric_port_handle_t*,
+    zes_fabric_port_throughput_t**
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of FabricPort functions pointers
+typedef struct _zes_fabric_port_dditable_t
+{
+    zes_pfnFabricPortGetProperties_t                            pfnGetProperties;
+    zes_pfnFabricPortGetLinkType_t                              pfnGetLinkType;
+    zes_pfnFabricPortGetConfig_t                                pfnGetConfig;
+    zes_pfnFabricPortSetConfig_t                                pfnSetConfig;
+    zes_pfnFabricPortGetState_t                                 pfnGetState;
+    zes_pfnFabricPortGetThroughput_t                            pfnGetThroughput;
+    zes_pfnFabricPortGetFabricErrorCounters_t                   pfnGetFabricErrorCounters;
+    zes_pfnFabricPortGetMultiPortThroughput_t                   pfnGetMultiPortThroughput;
+} zes_fabric_port_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's FabricPort table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zesGetFabricPortProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    zes_fabric_port_dditable_t* pDdiTable                                   ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesGetFabricPortProcAddrTable
+typedef ze_result_t (ZE_APICALL *zes_pfnGetFabricPortProcAddrTable_t)(
+    ze_api_version_t,
+    zes_fabric_port_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesTemperatureGetProperties 
+typedef ze_result_t (ZE_APICALL *zes_pfnTemperatureGetProperties_t)(
+    zes_temp_handle_t,
+    zes_temp_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesTemperatureGetConfig 
+typedef ze_result_t (ZE_APICALL *zes_pfnTemperatureGetConfig_t)(
+    zes_temp_handle_t,
+    zes_temp_config_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesTemperatureSetConfig 
+typedef ze_result_t (ZE_APICALL *zes_pfnTemperatureSetConfig_t)(
+    zes_temp_handle_t,
+    const zes_temp_config_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesTemperatureGetState 
+typedef ze_result_t (ZE_APICALL *zes_pfnTemperatureGetState_t)(
+    zes_temp_handle_t,
+    double*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Temperature functions pointers
+typedef struct _zes_temperature_dditable_t
+{
+    zes_pfnTemperatureGetProperties_t                           pfnGetProperties;
+    zes_pfnTemperatureGetConfig_t                               pfnGetConfig;
+    zes_pfnTemperatureSetConfig_t                               pfnSetConfig;
+    zes_pfnTemperatureGetState_t                                pfnGetState;
+} zes_temperature_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Temperature table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zesGetTemperatureProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    zes_temperature_dditable_t* pDdiTable                                   ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesGetTemperatureProcAddrTable
+typedef ze_result_t (ZE_APICALL *zes_pfnGetTemperatureProcAddrTable_t)(
+    ze_api_version_t,
+    zes_temperature_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesPsuGetProperties 
+typedef ze_result_t (ZE_APICALL *zes_pfnPsuGetProperties_t)(
+    zes_psu_handle_t,
+    zes_psu_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesPsuGetState 
+typedef ze_result_t (ZE_APICALL *zes_pfnPsuGetState_t)(
+    zes_psu_handle_t,
+    zes_psu_state_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Psu functions pointers
+typedef struct _zes_psu_dditable_t
+{
+    zes_pfnPsuGetProperties_t                                   pfnGetProperties;
+    zes_pfnPsuGetState_t                                        pfnGetState;
+} zes_psu_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Psu table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zesGetPsuProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    zes_psu_dditable_t* pDdiTable                                           ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesGetPsuProcAddrTable
+typedef ze_result_t (ZE_APICALL *zes_pfnGetPsuProcAddrTable_t)(
+    ze_api_version_t,
+    zes_psu_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesFanGetProperties 
+typedef ze_result_t (ZE_APICALL *zes_pfnFanGetProperties_t)(
+    zes_fan_handle_t,
+    zes_fan_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesFanGetConfig 
+typedef ze_result_t (ZE_APICALL *zes_pfnFanGetConfig_t)(
+    zes_fan_handle_t,
+    zes_fan_config_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesFanSetDefaultMode 
+typedef ze_result_t (ZE_APICALL *zes_pfnFanSetDefaultMode_t)(
+    zes_fan_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesFanSetFixedSpeedMode 
+typedef ze_result_t (ZE_APICALL *zes_pfnFanSetFixedSpeedMode_t)(
+    zes_fan_handle_t,
+    const zes_fan_speed_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesFanSetSpeedTableMode 
+typedef ze_result_t (ZE_APICALL *zes_pfnFanSetSpeedTableMode_t)(
+    zes_fan_handle_t,
+    const zes_fan_speed_table_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesFanGetState 
+typedef ze_result_t (ZE_APICALL *zes_pfnFanGetState_t)(
+    zes_fan_handle_t,
+    zes_fan_speed_units_t,
+    int32_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Fan functions pointers
+typedef struct _zes_fan_dditable_t
+{
+    zes_pfnFanGetProperties_t                                   pfnGetProperties;
+    zes_pfnFanGetConfig_t                                       pfnGetConfig;
+    zes_pfnFanSetDefaultMode_t                                  pfnSetDefaultMode;
+    zes_pfnFanSetFixedSpeedMode_t                               pfnSetFixedSpeedMode;
+    zes_pfnFanSetSpeedTableMode_t                               pfnSetSpeedTableMode;
+    zes_pfnFanGetState_t                                        pfnGetState;
+} zes_fan_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Fan table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zesGetFanProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    zes_fan_dditable_t* pDdiTable                                           ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesGetFanProcAddrTable
+typedef ze_result_t (ZE_APICALL *zes_pfnGetFanProcAddrTable_t)(
+    ze_api_version_t,
+    zes_fan_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesLedGetProperties 
+typedef ze_result_t (ZE_APICALL *zes_pfnLedGetProperties_t)(
+    zes_led_handle_t,
+    zes_led_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesLedGetState 
+typedef ze_result_t (ZE_APICALL *zes_pfnLedGetState_t)(
+    zes_led_handle_t,
+    zes_led_state_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesLedSetState 
+typedef ze_result_t (ZE_APICALL *zes_pfnLedSetState_t)(
+    zes_led_handle_t,
+    ze_bool_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesLedSetColor 
+typedef ze_result_t (ZE_APICALL *zes_pfnLedSetColor_t)(
+    zes_led_handle_t,
+    const zes_led_color_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Led functions pointers
+typedef struct _zes_led_dditable_t
+{
+    zes_pfnLedGetProperties_t                                   pfnGetProperties;
+    zes_pfnLedGetState_t                                        pfnGetState;
+    zes_pfnLedSetState_t                                        pfnSetState;
+    zes_pfnLedSetColor_t                                        pfnSetColor;
+} zes_led_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Led table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zesGetLedProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    zes_led_dditable_t* pDdiTable                                           ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesGetLedProcAddrTable
+typedef ze_result_t (ZE_APICALL *zes_pfnGetLedProcAddrTable_t)(
+    ze_api_version_t,
+    zes_led_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesRasGetProperties 
+typedef ze_result_t (ZE_APICALL *zes_pfnRasGetProperties_t)(
+    zes_ras_handle_t,
+    zes_ras_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesRasGetConfig 
+typedef ze_result_t (ZE_APICALL *zes_pfnRasGetConfig_t)(
+    zes_ras_handle_t,
+    zes_ras_config_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesRasSetConfig 
+typedef ze_result_t (ZE_APICALL *zes_pfnRasSetConfig_t)(
+    zes_ras_handle_t,
+    const zes_ras_config_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesRasGetState 
+typedef ze_result_t (ZE_APICALL *zes_pfnRasGetState_t)(
+    zes_ras_handle_t,
+    ze_bool_t,
+    zes_ras_state_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Ras functions pointers
+typedef struct _zes_ras_dditable_t
+{
+    zes_pfnRasGetProperties_t                                   pfnGetProperties;
+    zes_pfnRasGetConfig_t                                       pfnGetConfig;
+    zes_pfnRasSetConfig_t                                       pfnSetConfig;
+    zes_pfnRasGetState_t                                        pfnGetState;
+} zes_ras_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Ras table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zesGetRasProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    zes_ras_dditable_t* pDdiTable                                           ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesGetRasProcAddrTable
+typedef ze_result_t (ZE_APICALL *zes_pfnGetRasProcAddrTable_t)(
+    ze_api_version_t,
+    zes_ras_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesRasGetStateExp 
+typedef ze_result_t (ZE_APICALL *zes_pfnRasGetStateExp_t)(
+    zes_ras_handle_t,
+    uint32_t*,
+    zes_ras_state_exp_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesRasClearStateExp 
+typedef ze_result_t (ZE_APICALL *zes_pfnRasClearStateExp_t)(
+    zes_ras_handle_t,
+    zes_ras_error_category_exp_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of RasExp functions pointers
+typedef struct _zes_ras_exp_dditable_t
+{
+    zes_pfnRasGetStateExp_t                                     pfnGetStateExp;
+    zes_pfnRasClearStateExp_t                                   pfnClearStateExp;
+} zes_ras_exp_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's RasExp table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zesGetRasExpProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    zes_ras_exp_dditable_t* pDdiTable                                       ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesGetRasExpProcAddrTable
+typedef ze_result_t (ZE_APICALL *zes_pfnGetRasExpProcAddrTable_t)(
+    ze_api_version_t,
+    zes_ras_exp_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDiagnosticsGetProperties 
+typedef ze_result_t (ZE_APICALL *zes_pfnDiagnosticsGetProperties_t)(
+    zes_diag_handle_t,
+    zes_diag_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDiagnosticsGetTests 
+typedef ze_result_t (ZE_APICALL *zes_pfnDiagnosticsGetTests_t)(
+    zes_diag_handle_t,
+    uint32_t*,
+    zes_diag_test_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesDiagnosticsRunTests 
+typedef ze_result_t (ZE_APICALL *zes_pfnDiagnosticsRunTests_t)(
+    zes_diag_handle_t,
+    uint32_t,
+    uint32_t,
+    zes_diag_result_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Diagnostics functions pointers
+typedef struct _zes_diagnostics_dditable_t
+{
+    zes_pfnDiagnosticsGetProperties_t                           pfnGetProperties;
+    zes_pfnDiagnosticsGetTests_t                                pfnGetTests;
+    zes_pfnDiagnosticsRunTests_t                                pfnRunTests;
+} zes_diagnostics_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Diagnostics table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zesGetDiagnosticsProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    zes_diagnostics_dditable_t* pDdiTable                                   ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesGetDiagnosticsProcAddrTable
+typedef ze_result_t (ZE_APICALL *zes_pfnGetDiagnosticsProcAddrTable_t)(
+    ze_api_version_t,
+    zes_diagnostics_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesVFManagementGetVFPropertiesExp 
+typedef ze_result_t (ZE_APICALL *zes_pfnVFManagementGetVFPropertiesExp_t)(
+    zes_vf_handle_t,
+    zes_vf_exp_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesVFManagementGetVFMemoryUtilizationExp 
+typedef ze_result_t (ZE_APICALL *zes_pfnVFManagementGetVFMemoryUtilizationExp_t)(
+    zes_vf_handle_t,
+    uint32_t*,
+    zes_vf_util_mem_exp_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesVFManagementGetVFEngineUtilizationExp 
+typedef ze_result_t (ZE_APICALL *zes_pfnVFManagementGetVFEngineUtilizationExp_t)(
+    zes_vf_handle_t,
+    uint32_t*,
+    zes_vf_util_engine_exp_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesVFManagementSetVFTelemetryModeExp 
+typedef ze_result_t (ZE_APICALL *zes_pfnVFManagementSetVFTelemetryModeExp_t)(
+    zes_vf_handle_t,
+    zes_vf_info_util_exp_flags_t,
+    ze_bool_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesVFManagementSetVFTelemetrySamplingIntervalExp 
+typedef ze_result_t (ZE_APICALL *zes_pfnVFManagementSetVFTelemetrySamplingIntervalExp_t)(
+    zes_vf_handle_t,
+    zes_vf_info_util_exp_flags_t,
+    uint64_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesVFManagementGetVFCapabilitiesExp 
+typedef ze_result_t (ZE_APICALL *zes_pfnVFManagementGetVFCapabilitiesExp_t)(
+    zes_vf_handle_t,
+    zes_vf_exp_capabilities_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesVFManagementGetVFMemoryUtilizationExp2 
+typedef ze_result_t (ZE_APICALL *zes_pfnVFManagementGetVFMemoryUtilizationExp2_t)(
+    zes_vf_handle_t,
+    uint32_t*,
+    zes_vf_util_mem_exp2_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesVFManagementGetVFEngineUtilizationExp2 
+typedef ze_result_t (ZE_APICALL *zes_pfnVFManagementGetVFEngineUtilizationExp2_t)(
+    zes_vf_handle_t,
+    uint32_t*,
+    zes_vf_util_engine_exp2_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesVFManagementGetVFCapabilitiesExp2 
+typedef ze_result_t (ZE_APICALL *zes_pfnVFManagementGetVFCapabilitiesExp2_t)(
+    zes_vf_handle_t,
+    zes_vf_exp2_capabilities_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of VFManagementExp functions pointers
+typedef struct _zes_vf_management_exp_dditable_t
+{
+    zes_pfnVFManagementGetVFPropertiesExp_t                     pfnGetVFPropertiesExp;
+    zes_pfnVFManagementGetVFMemoryUtilizationExp_t              pfnGetVFMemoryUtilizationExp;
+    zes_pfnVFManagementGetVFEngineUtilizationExp_t              pfnGetVFEngineUtilizationExp;
+    zes_pfnVFManagementSetVFTelemetryModeExp_t                  pfnSetVFTelemetryModeExp;
+    zes_pfnVFManagementSetVFTelemetrySamplingIntervalExp_t      pfnSetVFTelemetrySamplingIntervalExp;
+    zes_pfnVFManagementGetVFCapabilitiesExp_t                   pfnGetVFCapabilitiesExp;
+    zes_pfnVFManagementGetVFMemoryUtilizationExp2_t             pfnGetVFMemoryUtilizationExp2;
+    zes_pfnVFManagementGetVFEngineUtilizationExp2_t             pfnGetVFEngineUtilizationExp2;
+    zes_pfnVFManagementGetVFCapabilitiesExp2_t                  pfnGetVFCapabilitiesExp2;
+} zes_vf_management_exp_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's VFManagementExp table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zesGetVFManagementExpProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    zes_vf_management_exp_dditable_t* pDdiTable                             ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zesGetVFManagementExpProcAddrTable
+typedef ze_result_t (ZE_APICALL *zes_pfnGetVFManagementExpProcAddrTable_t)(
+    ze_api_version_t,
+    zes_vf_management_exp_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Container for all DDI tables
+typedef struct _zes_dditable_t
+{
+    zes_global_dditable_t               Global;
+    zes_device_dditable_t               Device;
+    zes_device_exp_dditable_t           DeviceExp;
+    zes_driver_dditable_t               Driver;
+    zes_driver_exp_dditable_t           DriverExp;
+    zes_overclock_dditable_t            Overclock;
+    zes_scheduler_dditable_t            Scheduler;
+    zes_performance_factor_dditable_t   PerformanceFactor;
+    zes_power_dditable_t                Power;
+    zes_frequency_dditable_t            Frequency;
+    zes_engine_dditable_t               Engine;
+    zes_standby_dditable_t              Standby;
+    zes_firmware_dditable_t             Firmware;
+    zes_firmware_exp_dditable_t         FirmwareExp;
+    zes_memory_dditable_t               Memory;
+    zes_fabric_port_dditable_t          FabricPort;
+    zes_temperature_dditable_t          Temperature;
+    zes_psu_dditable_t                  Psu;
+    zes_fan_dditable_t                  Fan;
+    zes_led_dditable_t                  Led;
+    zes_ras_dditable_t                  Ras;
+    zes_ras_exp_dditable_t              RasExp;
+    zes_diagnostics_dditable_t          Diagnostics;
+    zes_vf_management_exp_dditable_t    VFManagementExp;
+} zes_dditable_t;
+/// @brief Container for all DDI tables with version and tables set by the Driver
+typedef struct _zes_dditable_driver_t
+{
+    ze_api_version_t    version;
+    uint8_t             isValidFlag;
+    zes_global_dditable_t *             Global;
+    zes_device_dditable_t *             Device;
+    zes_device_exp_dditable_t *         DeviceExp;
+    zes_driver_dditable_t *             Driver;
+    zes_driver_exp_dditable_t *         DriverExp;
+    zes_overclock_dditable_t *          Overclock;
+    zes_scheduler_dditable_t *          Scheduler;
+    zes_performance_factor_dditable_t * PerformanceFactor;
+    zes_power_dditable_t *              Power;
+    zes_frequency_dditable_t *          Frequency;
+    zes_engine_dditable_t *             Engine;
+    zes_standby_dditable_t *            Standby;
+    zes_firmware_dditable_t *           Firmware;
+    zes_firmware_exp_dditable_t *       FirmwareExp;
+    zes_memory_dditable_t *             Memory;
+    zes_fabric_port_dditable_t *        FabricPort;
+    zes_temperature_dditable_t *        Temperature;
+    zes_psu_dditable_t *                Psu;
+    zes_fan_dditable_t *                Fan;
+    zes_led_dditable_t *                Led;
+    zes_ras_dditable_t *                Ras;
+    zes_ras_exp_dditable_t *            RasExp;
+    zes_diagnostics_dditable_t *        Diagnostics;
+    zes_vf_management_exp_dditable_t *  VFManagementExp;
+} zes_dditable_driver_t;
+
+#if defined(__cplusplus)
+} // extern "C"
+#endif
+
+#endif // _ZES_DDI_H

--- a/include/level_zero/zet.py
+++ b/include/level_zero/zet.py
@@ -1,0 +1,1885 @@
+"""
+ Copyright (C) 2019-2021 Intel Corporation
+
+ SPDX-License-Identifier: MIT
+
+ @file zet.py
+ @version v1.12-r1.12.15
+
+ """
+import platform
+from ctypes import *
+from enum import *
+
+###############################################################################
+__version__ = "1.0"
+
+###############################################################################
+## @brief Handle to a driver instance
+class zet_driver_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle of device object
+class zet_device_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle of context object
+class zet_context_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle of command list object
+class zet_command_list_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle of module object
+class zet_module_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle of function object
+class zet_kernel_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle of metric group's object
+class zet_metric_group_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle of metric's object
+class zet_metric_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle of metric streamer's object
+class zet_metric_streamer_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle of metric query pool's object
+class zet_metric_query_pool_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle of metric query's object
+class zet_metric_query_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle of tracer object
+class zet_tracer_exp_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Debug session handle
+class zet_debug_session_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Defines structure types
+class zet_structure_type_v(IntEnum):
+    METRIC_GROUP_PROPERTIES = 0x1                                           ## ::zet_metric_group_properties_t
+    METRIC_PROPERTIES = 0x2                                                 ## ::zet_metric_properties_t
+    METRIC_STREAMER_DESC = 0x3                                              ## ::zet_metric_streamer_desc_t
+    METRIC_QUERY_POOL_DESC = 0x4                                            ## ::zet_metric_query_pool_desc_t
+    PROFILE_PROPERTIES = 0x5                                                ## ::zet_profile_properties_t
+    DEVICE_DEBUG_PROPERTIES = 0x6                                           ## ::zet_device_debug_properties_t
+    DEBUG_MEMORY_SPACE_DESC = 0x7                                           ## ::zet_debug_memory_space_desc_t
+    DEBUG_REGSET_PROPERTIES = 0x8                                           ## ::zet_debug_regset_properties_t
+    GLOBAL_METRICS_TIMESTAMPS_EXP_PROPERTIES = 0x9                          ## ::zet_metric_global_timestamps_resolution_exp_t. Deprecated, use
+                                                                            ## ::ZET_STRUCTURE_TYPE_METRIC_GLOBAL_TIMESTAMPS_RESOLUTION_EXP.
+    METRIC_GLOBAL_TIMESTAMPS_RESOLUTION_EXP = 0x9                           ## ::zet_metric_global_timestamps_resolution_exp_t
+    TRACER_EXP_DESC = 0x00010001                                            ## ::zet_tracer_exp_desc_t
+    METRICS_CALCULATE_EXP_DESC = 0x00010002                                 ## ::zet_metric_calculate_exp_desc_t. Deprecated, use
+                                                                            ## ::ZET_STRUCTURE_TYPE_METRIC_CALCULATE_EXP_DESC.
+    METRIC_CALCULATE_EXP_DESC = 0x00010002                                  ## ::zet_metric_calculate_exp_desc_t
+    METRIC_PROGRAMMABLE_EXP_PROPERTIES = 0x00010003                         ## ::zet_metric_programmable_exp_properties_t
+    METRIC_PROGRAMMABLE_PARAM_INFO_EXP = 0x00010004                         ## ::zet_metric_programmable_param_info_exp_t
+    METRIC_PROGRAMMABLE_PARAM_VALUE_INFO_EXP = 0x00010005                   ## ::zet_metric_programmable_param_value_info_exp_t
+    METRIC_GROUP_TYPE_EXP = 0x00010006                                      ## ::zet_metric_group_type_exp_t
+    EXPORT_DMA_EXP_PROPERTIES = 0x00010007                                  ## ::zet_export_dma_buf_exp_properties_t
+    METRIC_TRACER_EXP_DESC = 0x00010008                                     ## ::zet_metric_tracer_exp_desc_t
+
+class zet_structure_type_t(c_int):
+    def __str__(self):
+        return str(zet_structure_type_v(self.value))
+
+
+###############################################################################
+## @brief Base for all properties types
+class zet_base_properties_t(Structure):
+    _fields_ = [
+        ("stype", zet_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p)                                             ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+    ]
+
+###############################################################################
+## @brief Base for all descriptor types
+class zet_base_desc_t(Structure):
+    _fields_ = [
+        ("stype", zet_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p)                                             ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+    ]
+
+###############################################################################
+## @brief Supported value types
+class zet_value_type_v(IntEnum):
+    UINT32 = 0                                                              ## 32-bit unsigned-integer
+    UINT64 = 1                                                              ## 64-bit unsigned-integer
+    FLOAT32 = 2                                                             ## 32-bit floating-point
+    FLOAT64 = 3                                                             ## 64-bit floating-point
+    BOOL8 = 4                                                               ## 8-bit boolean
+    STRING = 5                                                              ## C string
+    UINT8 = 6                                                               ## 8-bit unsigned-integer
+    UINT16 = 7                                                              ## 16-bit unsigned-integer
+
+class zet_value_type_t(c_int):
+    def __str__(self):
+        return str(zet_value_type_v(self.value))
+
+
+###############################################################################
+## @brief Union of values
+class zet_value_t(Structure):
+    _fields_ = [
+        ("ui32", c_ulong),                                              ## [out] 32-bit unsigned-integer
+        ("ui64", c_ulonglong),                                          ## [out] 64-bit unsigned-integer
+        ("fp32", c_float),                                              ## [out] 32-bit floating-point
+        ("fp64", c_double),                                             ## [out] 64-bit floating-point
+        ("b8", ze_bool_t)                                               ## [out] 8-bit boolean
+    ]
+
+###############################################################################
+## @brief Typed value
+class zet_typed_value_t(Structure):
+    _fields_ = [
+        ("type", zet_value_type_t),                                     ## [out] type of value
+        ("value", zet_value_t)                                          ## [out] value
+    ]
+
+###############################################################################
+## @brief Enables driver instrumentation and dependencies for device metrics
+
+###############################################################################
+## @brief Enables driver instrumentation and dependencies for program
+##        instrumentation
+
+###############################################################################
+## @brief Enables driver instrumentation and dependencies for program debugging
+
+###############################################################################
+## @brief Supported module debug info formats.
+class zet_module_debug_info_format_v(IntEnum):
+    ELF_DWARF = 0                                                           ## Format is ELF/DWARF
+
+class zet_module_debug_info_format_t(c_int):
+    def __str__(self):
+        return str(zet_module_debug_info_format_v(self.value))
+
+
+###############################################################################
+## @brief Supported device debug property flags
+class zet_device_debug_property_flags_v(IntEnum):
+    ATTACH = ZE_BIT(0)                                                      ## the device supports attaching for debug
+
+class zet_device_debug_property_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Device debug properties queried using ::zetDeviceGetDebugProperties.
+class zet_device_debug_properties_t(Structure):
+    _fields_ = [
+        ("stype", zet_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("flags", zet_device_debug_property_flags_t)                    ## [out] returns 0 (none) or a valid combination of
+                                                                        ## ::zet_device_debug_property_flag_t
+    ]
+
+###############################################################################
+## @brief Debug configuration provided to ::zetDebugAttach
+class zet_debug_config_t(Structure):
+    _fields_ = [
+        ("pid", c_ulong)                                                ## [in] the host process identifier
+    ]
+
+###############################################################################
+## @brief Supported debug event flags.
+class zet_debug_event_flags_v(IntEnum):
+    NEED_ACK = ZE_BIT(0)                                                    ## The event needs to be acknowledged by calling
+                                                                            ## ::zetDebugAcknowledgeEvent.
+
+class zet_debug_event_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Supported debug event types.
+class zet_debug_event_type_v(IntEnum):
+    INVALID = 0                                                             ## The event is invalid
+    DETACHED = 1                                                            ## The tool was detached
+    PROCESS_ENTRY = 2                                                       ## The debuggee process created command queues on the device
+    PROCESS_EXIT = 3                                                        ## The debuggee process destroyed all command queues on the device
+    MODULE_LOAD = 4                                                         ## An in-memory module was loaded onto the device
+    MODULE_UNLOAD = 5                                                       ## An in-memory module is about to get unloaded from the device
+    THREAD_STOPPED = 6                                                      ## The thread stopped due to a device exception
+    THREAD_UNAVAILABLE = 7                                                  ## The thread is not available to be stopped
+    PAGE_FAULT = 8                                                          ## A page request could not be completed on the device
+
+class zet_debug_event_type_t(c_int):
+    def __str__(self):
+        return str(zet_debug_event_type_v(self.value))
+
+
+###############################################################################
+## @brief Supported debug detach reasons.
+class zet_debug_detach_reason_v(IntEnum):
+    INVALID = 0                                                             ## The detach reason is not valid
+    HOST_EXIT = 1                                                           ## The host process exited
+
+class zet_debug_detach_reason_t(c_int):
+    def __str__(self):
+        return str(zet_debug_detach_reason_v(self.value))
+
+
+###############################################################################
+## @brief Event information for ::ZET_DEBUG_EVENT_TYPE_DETACHED
+class zet_debug_event_info_detached_t(Structure):
+    _fields_ = [
+        ("reason", zet_debug_detach_reason_t)                           ## [out] the detach reason
+    ]
+
+###############################################################################
+## @brief Event information for ::ZET_DEBUG_EVENT_TYPE_MODULE_LOAD and
+##        ::ZET_DEBUG_EVENT_TYPE_MODULE_UNLOAD
+class zet_debug_event_info_module_t(Structure):
+    _fields_ = [
+        ("format", zet_module_debug_info_format_t),                     ## [out] the module format
+        ("moduleBegin", c_ulonglong),                                   ## [out] the begin address of the in-memory module (inclusive)
+        ("moduleEnd", c_ulonglong),                                     ## [out] the end address of the in-memory module (exclusive)
+        ("load", c_ulonglong)                                           ## [out] the load address of the module on the device
+    ]
+
+###############################################################################
+## @brief Event information for ::ZET_DEBUG_EVENT_TYPE_THREAD_STOPPED and
+##        ::ZET_DEBUG_EVENT_TYPE_THREAD_UNAVAILABLE
+class zet_debug_event_info_thread_stopped_t(Structure):
+    _fields_ = [
+        ("thread", ze_device_thread_t)                                  ## [out] the stopped/unavailable thread
+    ]
+
+###############################################################################
+## @brief Page fault reasons.
+class zet_debug_page_fault_reason_v(IntEnum):
+    INVALID = 0                                                             ## The page fault reason is not valid
+    MAPPING_ERROR = 1                                                       ## The address is not mapped
+    PERMISSION_ERROR = 2                                                    ## Invalid access permissions
+
+class zet_debug_page_fault_reason_t(c_int):
+    def __str__(self):
+        return str(zet_debug_page_fault_reason_v(self.value))
+
+
+###############################################################################
+## @brief Event information for ::ZET_DEBUG_EVENT_TYPE_PAGE_FAULT
+class zet_debug_event_info_page_fault_t(Structure):
+    _fields_ = [
+        ("address", c_ulonglong),                                       ## [out] the faulting address
+        ("mask", c_ulonglong),                                          ## [out] the alignment mask
+        ("reason", zet_debug_page_fault_reason_t)                       ## [out] the page fault reason
+    ]
+
+###############################################################################
+## @brief Event type-specific information
+class zet_debug_event_info_t(Structure):
+    _fields_ = [
+        ("detached", zet_debug_event_info_detached_t),                  ## [out] type == ::ZET_DEBUG_EVENT_TYPE_DETACHED
+        ("module", zet_debug_event_info_module_t),                      ## [out] type == ::ZET_DEBUG_EVENT_TYPE_MODULE_LOAD or
+                                                                        ## ::ZET_DEBUG_EVENT_TYPE_MODULE_UNLOAD
+        ("thread", zet_debug_event_info_thread_stopped_t),              ## [out] type == ::ZET_DEBUG_EVENT_TYPE_THREAD_STOPPED or
+                                                                        ## ::ZET_DEBUG_EVENT_TYPE_THREAD_UNAVAILABLE
+        ("page_fault", zet_debug_event_info_page_fault_t)               ## [out] type == ::ZET_DEBUG_EVENT_TYPE_PAGE_FAULT
+    ]
+
+###############################################################################
+## @brief A debug event on the device.
+class zet_debug_event_t(Structure):
+    _fields_ = [
+        ("type", zet_debug_event_type_t),                               ## [out] the event type
+        ("flags", zet_debug_event_flags_t),                             ## [out] returns 0 (none) or a combination of ::zet_debug_event_flag_t
+        ("info", zet_debug_event_info_t)                                ## [out] event type specific information
+    ]
+
+###############################################################################
+## @brief Supported device memory space types.
+class zet_debug_memory_space_type_v(IntEnum):
+    DEFAULT = 0                                                             ## default memory space (attribute may be omitted)
+    SLM = 1                                                                 ## shared local memory space (GPU-only)
+    ELF = 2                                                                 ## ELF file memory space
+
+class zet_debug_memory_space_type_t(c_int):
+    def __str__(self):
+        return str(zet_debug_memory_space_type_v(self.value))
+
+
+###############################################################################
+## @brief Device memory space descriptor
+class zet_debug_memory_space_desc_t(Structure):
+    _fields_ = [
+        ("stype", zet_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("type", zet_debug_memory_space_type_t),                        ## [in] type of memory space
+        ("address", c_ulonglong)                                        ## [in] the virtual address within the memory space
+    ]
+
+###############################################################################
+## @brief Supported general register set flags.
+class zet_debug_regset_flags_v(IntEnum):
+    READABLE = ZE_BIT(0)                                                    ## register set is readable
+    WRITEABLE = ZE_BIT(1)                                                   ## register set is writeable
+
+class zet_debug_regset_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Device register set properties queried using
+##        ::zetDebugGetRegisterSetProperties.
+class zet_debug_regset_properties_t(Structure):
+    _fields_ = [
+        ("stype", zet_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("type", c_ulong),                                              ## [out] device-specific register set type
+        ("version", c_ulong),                                           ## [out] device-specific version of this register set
+        ("generalFlags", zet_debug_regset_flags_t),                     ## [out] general register set flags
+        ("deviceFlags", c_ulong),                                       ## [out] device-specific register set flags
+        ("count", c_ulong),                                             ## [out] number of registers in the set
+        ("bitSize", c_ulong),                                           ## [out] the size of a register in bits
+        ("byteSize", c_ulong)                                           ## [out] the size required for reading or writing a register in bytes
+    ]
+
+###############################################################################
+## @brief Maximum metric group name string size
+ZET_MAX_METRIC_GROUP_NAME = 256
+
+###############################################################################
+## @brief Maximum metric group description string size
+ZET_MAX_METRIC_GROUP_DESCRIPTION = 256
+
+###############################################################################
+## @brief Metric group sampling type
+class zet_metric_group_sampling_type_flags_v(IntEnum):
+    EVENT_BASED = ZE_BIT(0)                                                 ## Event based sampling
+    TIME_BASED = ZE_BIT(1)                                                  ## Time based sampling
+    EXP_TRACER_BASED = ZE_BIT(2)                                            ## Experimental Tracer based sampling
+
+class zet_metric_group_sampling_type_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Metric group properties queried using ::zetMetricGroupGetProperties
+class zet_metric_group_properties_t(Structure):
+    _fields_ = [
+        ("stype", zet_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("name", c_char * ZET_MAX_METRIC_GROUP_NAME),                   ## [out] metric group name
+        ("description", c_char * ZET_MAX_METRIC_GROUP_DESCRIPTION),     ## [out] metric group description
+        ("samplingType", zet_metric_group_sampling_type_flags_t),       ## [out] metric group sampling type.
+                                                                        ## returns a combination of ::zet_metric_group_sampling_type_flag_t.
+        ("domain", c_ulong),                                            ## [out] metric group domain number. Cannot use multiple, simultaneous
+                                                                        ## metric groups from the same domain.
+        ("metricCount", c_ulong)                                        ## [out] metric count belonging to this group
+    ]
+
+###############################################################################
+## @brief Metric types
+class zet_metric_type_v(IntEnum):
+    DURATION = 0                                                            ## Metric type: duration
+    EVENT = 1                                                               ## Metric type: event
+    EVENT_WITH_RANGE = 2                                                    ## Metric type: event with range
+    THROUGHPUT = 3                                                          ## Metric type: throughput
+    TIMESTAMP = 4                                                           ## Metric type: timestamp
+    FLAG = 5                                                                ## Metric type: flag
+    RATIO = 6                                                               ## Metric type: ratio
+    RAW = 7                                                                 ## Metric type: raw
+    EVENT_EXP_TIMESTAMP = 0x7ffffff9                                        ## Metric type: event with only timestamp and value has no meaning
+    EVENT_EXP_START = 0x7ffffffa                                            ## Metric type: the first event of a start/end event pair
+    EVENT_EXP_END = 0x7ffffffb                                              ## Metric type: the second event of a start/end event pair
+    EVENT_EXP_MONOTONIC_WRAPS_VALUE = 0x7ffffffc                            ## Metric type: value of the event is a monotonically increasing value
+                                                                            ## that can wrap around
+    EXP_EXPORT_DMA_BUF = 0x7ffffffd                                         ## Metric which exports linux dma_buf, which could be imported/mapped to
+                                                                            ## the host process
+    IP_EXP = 0x7ffffffe                                                     ## Metric type: instruction pointer. Deprecated, use
+                                                                            ## ::ZET_METRIC_TYPE_IP.
+    IP = 0x7ffffffe                                                         ## Metric type: instruction pointer
+
+class zet_metric_type_t(c_int):
+    def __str__(self):
+        return str(zet_metric_type_v(self.value))
+
+
+###############################################################################
+## @brief Metric group calculation type
+class zet_metric_group_calculation_type_v(IntEnum):
+    METRIC_VALUES = 0                                                       ## Calculated metric values from raw data.
+    MAX_METRIC_VALUES = 1                                                   ## Maximum metric values.
+
+class zet_metric_group_calculation_type_t(c_int):
+    def __str__(self):
+        return str(zet_metric_group_calculation_type_v(self.value))
+
+
+###############################################################################
+## @brief Maximum metric name string size
+ZET_MAX_METRIC_NAME = 256
+
+###############################################################################
+## @brief Maximum metric description string size
+ZET_MAX_METRIC_DESCRIPTION = 256
+
+###############################################################################
+## @brief Maximum metric component string size
+ZET_MAX_METRIC_COMPONENT = 256
+
+###############################################################################
+## @brief Maximum metric result units string size
+ZET_MAX_METRIC_RESULT_UNITS = 256
+
+###############################################################################
+## @brief Metric properties queried using ::zetMetricGetProperties
+class zet_metric_properties_t(Structure):
+    _fields_ = [
+        ("stype", zet_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("name", c_char * ZET_MAX_METRIC_NAME),                         ## [out] metric name
+        ("description", c_char * ZET_MAX_METRIC_DESCRIPTION),           ## [out] metric description
+        ("component", c_char * ZET_MAX_METRIC_COMPONENT),               ## [out] metric component
+        ("tierNumber", c_ulong),                                        ## [out] number of tier
+        ("metricType", zet_metric_type_t),                              ## [out] metric type
+        ("resultType", zet_value_type_t),                               ## [out] metric result type
+        ("resultUnits", c_char * ZET_MAX_METRIC_RESULT_UNITS)           ## [out] metric result units
+    ]
+
+###############################################################################
+## @brief Metric streamer descriptor
+class zet_metric_streamer_desc_t(Structure):
+    _fields_ = [
+        ("stype", zet_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("notifyEveryNReports", c_ulong),                               ## [in,out] number of collected reports after which notification event
+                                                                        ## will be signaled. If the requested value is not supported exactly,
+                                                                        ## then the driver may use a value that is the closest supported
+                                                                        ## approximation and shall update this member during ::zetMetricStreamerOpen.
+        ("samplingPeriod", c_ulong)                                     ## [in,out] streamer sampling period in nanoseconds. If the requested
+                                                                        ## value is not supported exactly, then the driver may use a value that
+                                                                        ## is the closest supported approximation and shall update this member
+                                                                        ## during ::zetMetricStreamerOpen.
+    ]
+
+###############################################################################
+## @brief Metric query pool types
+class zet_metric_query_pool_type_v(IntEnum):
+    PERFORMANCE = 0                                                         ## Performance metric query pool.
+    EXECUTION = 1                                                           ## Skips workload execution between begin/end calls.
+
+class zet_metric_query_pool_type_t(c_int):
+    def __str__(self):
+        return str(zet_metric_query_pool_type_v(self.value))
+
+
+###############################################################################
+## @brief Metric query pool description
+class zet_metric_query_pool_desc_t(Structure):
+    _fields_ = [
+        ("stype", zet_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("type", zet_metric_query_pool_type_t),                         ## [in] Query pool type.
+        ("count", c_ulong)                                              ## [in] Internal slots count within query pool object.
+    ]
+
+###############################################################################
+## @brief Supportted profile features
+class zet_profile_flags_v(IntEnum):
+    REGISTER_REALLOCATION = ZE_BIT(0)                                       ## request the compiler attempt to minimize register usage as much as
+                                                                            ## possible to allow for instrumentation
+    FREE_REGISTER_INFO = ZE_BIT(1)                                          ## request the compiler generate free register info
+
+class zet_profile_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Profiling meta-data for instrumentation
+class zet_profile_properties_t(Structure):
+    _fields_ = [
+        ("stype", zet_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("flags", zet_profile_flags_t),                                 ## [out] indicates which flags were enabled during compilation.
+                                                                        ## returns 0 (none) or a combination of ::zet_profile_flag_t
+        ("numTokens", c_ulong)                                          ## [out] number of tokens immediately following this structure
+    ]
+
+###############################################################################
+## @brief Supported profile token types
+class zet_profile_token_type_v(IntEnum):
+    FREE_REGISTER = 0                                                       ## GRF info
+
+class zet_profile_token_type_t(c_int):
+    def __str__(self):
+        return str(zet_profile_token_type_v(self.value))
+
+
+###############################################################################
+## @brief Profile free register token detailing unused registers in the current
+##        function
+class zet_profile_free_register_token_t(Structure):
+    _fields_ = [
+        ("type", zet_profile_token_type_t),                             ## [out] type of token
+        ("size", c_ulong),                                              ## [out] total size of the token, in bytes
+        ("count", c_ulong)                                              ## [out] number of register sequences immediately following this
+                                                                        ## structure
+    ]
+
+###############################################################################
+## @brief Profile register sequence detailing consecutive bytes, all of which
+##        are unused
+class zet_profile_register_sequence_t(Structure):
+    _fields_ = [
+        ("start", c_ulong),                                             ## [out] starting byte in the register table, representing the start of
+                                                                        ## unused bytes in the current function
+        ("count", c_ulong)                                              ## [out] number of consecutive bytes in the sequence, starting from start
+    ]
+
+###############################################################################
+## @brief API Tracing Experimental Extension Name
+ZET_API_TRACING_EXP_NAME = "ZET_experimental_api_tracing"
+
+###############################################################################
+## @brief API Tracing Experimental Extension Version(s)
+class zet_api_tracing_exp_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class zet_api_tracing_exp_version_t(c_int):
+    def __str__(self):
+        return str(zet_api_tracing_exp_version_v(self.value))
+
+
+###############################################################################
+## @brief Alias the existing callbacks definition for 'core' callbacks
+class zet_core_callbacks_t(ze_callbacks_t):
+    pass
+
+###############################################################################
+## @brief Tracer descriptor
+class zet_tracer_exp_desc_t(Structure):
+    _fields_ = [
+        ("stype", zet_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("pUserData", c_void_p)                                         ## [in] pointer passed to every tracer's callbacks
+    ]
+
+###############################################################################
+## @brief Concurrent Metric Groups Experimental Extension Name
+ZET_CONCURRENT_METRIC_GROUPS_EXP_NAME = "ZET_experimental_concurrent_metric_groups"
+
+###############################################################################
+## @brief Concurrent Metric Groups Experimental Extension Version(s)
+class zet_concurrent_metric_groups_exp_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class zet_concurrent_metric_groups_exp_version_t(c_int):
+    def __str__(self):
+        return str(zet_concurrent_metric_groups_exp_version_v(self.value))
+
+
+###############################################################################
+## @brief Metric Tracer Experimental Extension Name
+ZET_METRICS_TRACER_EXP_NAME = "ZET_experimental_metric_tracer"
+
+###############################################################################
+## @brief Metric Tracer Experimental Extension Version(s)
+class zet_metric_tracer_exp_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class zet_metric_tracer_exp_version_t(c_int):
+    def __str__(self):
+        return str(zet_metric_tracer_exp_version_v(self.value))
+
+
+###############################################################################
+## @brief Handle of metric tracer's object
+class zet_metric_tracer_exp_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle of metric decoder's object
+class zet_metric_decoder_exp_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Metric tracer descriptor
+class zet_metric_tracer_exp_desc_t(Structure):
+    _fields_ = [
+        ("stype", zet_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("notifyEveryNBytes", c_ulong)                                  ## [in,out] number of collected bytes after which notification event will
+                                                                        ## be signaled. If the requested value is not supported exactly, then the
+                                                                        ## driver may use a value that is the closest supported approximation and
+                                                                        ## shall update this member during ::zetMetricTracerCreateExp.
+    ]
+
+###############################################################################
+## @brief Decoded metric entry
+class zet_metric_entry_exp_t(Structure):
+    _fields_ = [
+        ("value", zet_value_t),                                         ## [out] value of the decodable metric entry or event. Number is
+                                                                        ## meaningful based on the metric type.
+        ("timeStamp", c_ulonglong),                                     ## [out] timestamp at which the event happened.
+        ("metricIndex", c_ulong),                                       ## [out] index to the decodable metric handle in the input array
+                                                                        ## (phMetric) in ::zetMetricTracerDecodeExp().
+        ("onSubdevice", ze_bool_t),                                     ## [out] True if the event occurred on a sub-device; false means the
+                                                                        ## device on which the metric tracer was opened does not have
+                                                                        ## sub-devices.
+        ("subdeviceId", c_ulong)                                        ## [out] If onSubdevice is true, this gives the ID of the sub-device.
+    ]
+
+###############################################################################
+## @brief Metric group type
+class zet_metric_group_type_exp_flags_v(IntEnum):
+    EXPORT_DMA_BUF = ZE_BIT(0)                                              ## Metric group and metrics exports memory using linux dma-buf, which
+                                                                            ## could be imported/mapped to the host process. Properties of the
+                                                                            ## dma_buf could be queried using ::zet_export_dma_buf_exp_properties_t.
+    USER_CREATED = ZE_BIT(1)                                                ## Metric group created using ::zetDeviceCreateMetricGroupsFromMetricsExp
+    OTHER = ZE_BIT(2)                                                       ## Metric group which has a collection of metrics
+
+class zet_metric_group_type_exp_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Query the metric group type using `pNext` of
+##        ::zet_metric_group_properties_t
+class zet_metric_group_type_exp_t(Structure):
+    _fields_ = [
+        ("stype", zet_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("type", zet_metric_group_type_exp_flags_t)                     ## [out] metric group type.
+                                                                        ## returns a combination of ::zet_metric_group_type_exp_flags_t.
+    ]
+
+###############################################################################
+## @brief Exported dma_buf properties queried using `pNext` of
+##        ::zet_metric_group_properties_t or ::zet_metric_properties_t
+class zet_export_dma_buf_exp_properties_t(Structure):
+    _fields_ = [
+        ("stype", zet_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("fd", c_int),                                                  ## [out] the file descriptor handle that could be used to import the
+                                                                        ## memory by the host process.
+        ("size", c_size_t)                                              ## [out] size in bytes of the dma_buf
+    ]
+
+###############################################################################
+## @brief Calculating Multiple Metrics Experimental Extension Name
+ZET_MULTI_METRICS_EXP_NAME = "ZET_experimental_calculate_multiple_metrics"
+
+###############################################################################
+## @brief Calculating Multiple Metrics Experimental Extension Version(s)
+class ze_calculate_multiple_metrics_exp_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class ze_calculate_multiple_metrics_exp_version_t(c_int):
+    def __str__(self):
+        return str(ze_calculate_multiple_metrics_exp_version_v(self.value))
+
+
+###############################################################################
+## @brief Global Metric Timestamps Experimental Extension Name
+ZET_GLOBAL_METRICS_TIMESTAMPS_EXP_NAME = "ZET_experimental_global_metric_timestamps"
+
+###############################################################################
+## @brief Global Metric Timestamps Experimental Extension Version(s)
+class ze_metric_global_timestamps_exp_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class ze_metric_global_timestamps_exp_version_t(c_int):
+    def __str__(self):
+        return str(ze_metric_global_timestamps_exp_version_v(self.value))
+
+
+###############################################################################
+## @brief Metric timestamps resolution
+## 
+## @details
+##     - This structure may be returned from ::zetMetricGroupGetProperties via
+##       the `pNext` member of ::zet_metric_group_properties_t.
+##     - Used for mapping metric timestamps to other timers.
+class zet_metric_global_timestamps_resolution_exp_t(Structure):
+    _fields_ = [
+        ("stype", zet_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("timerResolution", c_ulonglong),                               ## [out] Returns the resolution of metrics timer (used for timestamps) in
+                                                                        ## cycles/sec.
+        ("timestampValidBits", c_ulonglong)                             ## [out] Returns the number of valid bits in the timestamp value.
+    ]
+
+###############################################################################
+## @brief Exporting Metrics Data Experimental Extension Name
+ZET_EXPORT_METRICS_DATA_EXP_NAME = "ZET_experimental_metric_export_data"
+
+###############################################################################
+## @brief Exporting Metrics Data Experimental Extension Version(s)
+class zet_export_metric_data_exp_version_v(IntEnum):
+    _1_0 = ZE_MAKE_VERSION( 1, 0 )                                          ## version 1.0
+    CURRENT = ZE_MAKE_VERSION( 1, 0 )                                       ## latest known version
+
+class zet_export_metric_data_exp_version_t(c_int):
+    def __str__(self):
+        return str(zet_export_metric_data_exp_version_v(self.value))
+
+
+###############################################################################
+## @brief Maximum count of characters in export data element name
+ZET_MAX_METRIC_EXPORT_DATA_ELEMENT_NAME_EXP = 256
+
+###############################################################################
+## @brief Maximum export data element description string size
+ZET_MAX_METRIC_EXPORT_DATA_ELEMENT_DESCRIPTION_EXP = 256
+
+###############################################################################
+## @brief Metrics calculation descriptor
+class zet_metric_calculate_exp_desc_t(Structure):
+    _fields_ = [
+        ("stype", zet_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("rawReportSkipCount", c_ulong)                                 ## [in] number of reports to skip during calculation
+    ]
+
+###############################################################################
+## @brief Programmable Metrics Experimental Extension Name
+ZET_PROGRAMMABLE_METRICS_EXP_NAME = "ZET_experimental_programmable_metrics"
+
+###############################################################################
+## @brief Programmable Metrics Experimental Extension Version(s)
+class zet_metric_programmable_exp_version_v(IntEnum):
+    _1_1 = ZE_MAKE_VERSION( 1, 1 )                                          ## version 1.1
+    CURRENT = ZE_MAKE_VERSION( 1, 1 )                                       ## latest known version
+
+class zet_metric_programmable_exp_version_t(c_int):
+    def __str__(self):
+        return str(zet_metric_programmable_exp_version_v(self.value))
+
+
+###############################################################################
+## @brief Maximum count of characters in export data element name
+ZET_MAX_PROGRAMMABLE_METRICS_ELEMENT_NAME_EXP = 256
+
+###############################################################################
+## @brief Maximum export data element description string size
+ZET_MAX_PROGRAMMABLE_METRICS_ELEMENT_DESCRIPTION_EXP = 256
+
+###############################################################################
+## @brief Maximum count of characters in metric group name prefix
+ZET_MAX_METRIC_GROUP_NAME_PREFIX_EXP = 64
+
+###############################################################################
+## @brief Maximum metric programmable name string size
+ZET_MAX_METRIC_PROGRAMMABLE_NAME_EXP = 128
+
+###############################################################################
+## @brief Maximum metric programmable description string size
+ZET_MAX_METRIC_PROGRAMMABLE_DESCRIPTION_EXP = 128
+
+###############################################################################
+## @brief Maximum metric programmable component string size
+ZET_MAX_METRIC_PROGRAMMABLE_COMPONENT_EXP = 128
+
+###############################################################################
+## @brief Maximum metric programmable parameter string size
+ZET_MAX_METRIC_PROGRAMMABLE_PARAMETER_NAME_EXP = 128
+
+###############################################################################
+## @brief Maximum value for programmable value description
+ZET_MAX_METRIC_PROGRAMMABLE_VALUE_DESCRIPTION_EXP = 128
+
+###############################################################################
+## @brief Maximum value metric group name prefix
+ZE_MAX_METRIC_GROUP_NAME_PREFIX = 64
+
+###############################################################################
+## @brief Handle of metric programmable's object
+class zet_metric_programmable_exp_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Metric Programmable properties queried using
+##        ::zetMetricProgrammableGetPropertiesExp
+class zet_metric_programmable_exp_properties_t(Structure):
+    _fields_ = [
+        ("stype", zet_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("name", c_char * ZET_MAX_METRIC_PROGRAMMABLE_NAME_EXP),        ## [out] metric programmable name
+        ("description", c_char * ZET_MAX_METRIC_PROGRAMMABLE_DESCRIPTION_EXP),  ## [out] metric programmable description
+        ("component", c_char * ZET_MAX_METRIC_PROGRAMMABLE_COMPONENT_EXP),  ## [out] metric programmable component
+        ("tierNumber", c_ulong),                                        ## [out] tier number
+        ("domain", c_ulong),                                            ## [out] metric domain number.
+        ("parameterCount", c_ulong),                                    ## [out] number of parameters in the programmable
+        ("samplingType", zet_metric_group_sampling_type_flags_t),       ## [out] metric sampling type.
+                                                                        ## returns a combination of ::zet_metric_group_sampling_type_flag_t.
+        ("sourceId", c_ulong)                                           ## [out] unique metric source identifier(within platform)to identify the
+                                                                        ## HW block where the metric is collected.
+    ]
+
+###############################################################################
+## @brief Metric Programmable Parameter types
+class zet_metric_programmable_param_type_exp_v(IntEnum):
+    DISAGGREGATION = 0                                                      ## Metric is disaggregated.
+    LATENCY = 1                                                             ## Metric for latency measurement.
+    NORMALIZATION_UTILIZATION = 2                                           ## Produces normalization in percent using raw_metric * 100 / cycles / HW
+                                                                            ## instance_count.
+    NORMALIZATION_AVERAGE = 3                                               ## Produces normalization using raw_metric / HW instance_count.
+    NORMALIZATION_RATE = 4                                                  ## Produces normalization average using raw_metric / timestamp.
+    NORMALIZATION_BYTES = 5                                                 ## Produces normalization average using raw_metric * n bytes.
+    GENERIC = 6                                                             ## Generic Parameter type. Please refer the parameter's description.
+
+class zet_metric_programmable_param_type_exp_t(c_int):
+    def __str__(self):
+        return str(zet_metric_programmable_param_type_exp_v(self.value))
+
+
+###############################################################################
+## @brief Supported value info types
+class zet_value_info_type_exp_v(IntEnum):
+    UINT32 = 0                                                              ## 32-bit unsigned-integer
+    UINT64 = 1                                                              ## 64-bit unsigned-integer
+    FLOAT32 = 2                                                             ## 32-bit floating-point
+    FLOAT64 = 3                                                             ## 64-bit floating-point
+    BOOL8 = 4                                                               ## 8-bit boolean
+    UINT8 = 5                                                               ## 8-bit unsigned-integer
+    UINT16 = 6                                                              ## 16-bit unsigned-integer
+    UINT64_RANGE = 7                                                        ## 64-bit unsigned-integer range (minimum and maximum)
+    FLOAT64_RANGE = 8                                                       ## 64-bit floating point range (minimum and maximum)
+
+class zet_value_info_type_exp_t(c_int):
+    def __str__(self):
+        return str(zet_value_info_type_exp_v(self.value))
+
+
+###############################################################################
+## @brief Value info of type uint64_t range
+class zet_value_uint64_range_exp_t(Structure):
+    _fields_ = [
+        ("ui64Min", c_ulonglong),                                       ## [out] minimum value of the range
+        ("ui64Max", c_ulonglong)                                        ## [out] maximum value of the range
+    ]
+
+###############################################################################
+## @brief Value info of type float64 range
+class zet_value_fp64_range_exp_t(Structure):
+    _fields_ = [
+        ("fp64Min", c_double),                                          ## [out] minimum value of the range
+        ("fp64Max", c_double)                                           ## [out] maximum value of the range
+    ]
+
+###############################################################################
+## @brief Union of value information
+class zet_value_info_exp_t(Structure):
+    _fields_ = [
+        ("ui32", c_ulong),                                              ## [out] 32-bit unsigned-integer
+        ("ui64", c_ulonglong),                                          ## [out] 64-bit unsigned-integer
+        ("fp32", c_float),                                              ## [out] 32-bit floating-point
+        ("fp64", c_double),                                             ## [out] 64-bit floating-point
+        ("b8", ze_bool_t),                                              ## [out] 8-bit boolean
+        ("ui8", c_ubyte),                                               ## [out] 8-bit unsigned integer
+        ("ui16", c_ushort),                                             ## [out] 16-bit unsigned integer
+        ("ui64Range", zet_value_uint64_range_exp_t),                    ## [out] minimum and maximum value of the range
+        ("fp64Range", zet_value_fp64_range_exp_t)                       ## [out] minimum and maximum value of the range
+    ]
+
+###############################################################################
+## @brief Metric Programmable parameter information
+class zet_metric_programmable_param_info_exp_t(Structure):
+    _fields_ = [
+        ("stype", zet_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("type", zet_metric_programmable_param_type_exp_t),             ## [out] programmable parameter type
+        ("name", c_char * ZET_MAX_METRIC_PROGRAMMABLE_PARAMETER_NAME_EXP),  ## [out] metric programmable parameter name
+        ("valueInfoType", zet_value_info_type_exp_t),                   ## [out] value info type
+        ("defaultValue", zet_value_t),                                  ## [out] default value for the parameter
+        ("valueInfoCount", c_ulong)                                     ## [out] count of ::zet_metric_programmable_param_value_info_exp_t
+    ]
+
+###############################################################################
+## @brief Metric Programmable parameter value information
+class zet_metric_programmable_param_value_info_exp_t(Structure):
+    _fields_ = [
+        ("stype", zet_structure_type_t),                                ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] must be null or a pointer to an extension-specific
+                                                                        ## structure (i.e. contains stype and pNext).
+        ("valueInfo", zet_value_info_exp_t),                            ## [out] information about the parameter value
+        ("description", c_char * ZET_MAX_METRIC_PROGRAMMABLE_VALUE_DESCRIPTION_EXP) ## [out] description about the value
+    ]
+
+###############################################################################
+## @brief Metric Programmable parameter value
+class zet_metric_programmable_param_value_exp_t(Structure):
+    _fields_ = [
+        ("value", zet_value_t)                                          ## [in] parameter value
+    ]
+
+###############################################################################
+__use_win_types = "Windows" == platform.uname()[0]
+
+###############################################################################
+## @brief Function-pointer for zetMetricProgrammableGetExp
+if __use_win_types:
+    _zetMetricProgrammableGetExp_t = WINFUNCTYPE( ze_result_t, zet_device_handle_t, POINTER(c_ulong), POINTER(zet_metric_programmable_exp_handle_t) )
+else:
+    _zetMetricProgrammableGetExp_t = CFUNCTYPE( ze_result_t, zet_device_handle_t, POINTER(c_ulong), POINTER(zet_metric_programmable_exp_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zetMetricProgrammableGetPropertiesExp
+if __use_win_types:
+    _zetMetricProgrammableGetPropertiesExp_t = WINFUNCTYPE( ze_result_t, zet_metric_programmable_exp_handle_t, POINTER(zet_metric_programmable_exp_properties_t) )
+else:
+    _zetMetricProgrammableGetPropertiesExp_t = CFUNCTYPE( ze_result_t, zet_metric_programmable_exp_handle_t, POINTER(zet_metric_programmable_exp_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zetMetricProgrammableGetParamInfoExp
+if __use_win_types:
+    _zetMetricProgrammableGetParamInfoExp_t = WINFUNCTYPE( ze_result_t, zet_metric_programmable_exp_handle_t, POINTER(c_ulong), POINTER(zet_metric_programmable_param_info_exp_t) )
+else:
+    _zetMetricProgrammableGetParamInfoExp_t = CFUNCTYPE( ze_result_t, zet_metric_programmable_exp_handle_t, POINTER(c_ulong), POINTER(zet_metric_programmable_param_info_exp_t) )
+
+###############################################################################
+## @brief Function-pointer for zetMetricProgrammableGetParamValueInfoExp
+if __use_win_types:
+    _zetMetricProgrammableGetParamValueInfoExp_t = WINFUNCTYPE( ze_result_t, zet_metric_programmable_exp_handle_t, c_ulong, POINTER(c_ulong), POINTER(zet_metric_programmable_param_value_info_exp_t) )
+else:
+    _zetMetricProgrammableGetParamValueInfoExp_t = CFUNCTYPE( ze_result_t, zet_metric_programmable_exp_handle_t, c_ulong, POINTER(c_ulong), POINTER(zet_metric_programmable_param_value_info_exp_t) )
+
+
+###############################################################################
+## @brief Table of MetricProgrammableExp functions pointers
+class _zet_metric_programmable_exp_dditable_t(Structure):
+    _fields_ = [
+        ("pfnGetExp", c_void_p),                                        ## _zetMetricProgrammableGetExp_t
+        ("pfnGetPropertiesExp", c_void_p),                              ## _zetMetricProgrammableGetPropertiesExp_t
+        ("pfnGetParamInfoExp", c_void_p),                               ## _zetMetricProgrammableGetParamInfoExp_t
+        ("pfnGetParamValueInfoExp", c_void_p)                           ## _zetMetricProgrammableGetParamValueInfoExp_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zetMetricTracerCreateExp
+if __use_win_types:
+    _zetMetricTracerCreateExp_t = WINFUNCTYPE( ze_result_t, zet_context_handle_t, zet_device_handle_t, c_ulong, POINTER(zet_metric_group_handle_t), POINTER(zet_metric_tracer_exp_desc_t), ze_event_handle_t, POINTER(zet_metric_tracer_exp_handle_t) )
+else:
+    _zetMetricTracerCreateExp_t = CFUNCTYPE( ze_result_t, zet_context_handle_t, zet_device_handle_t, c_ulong, POINTER(zet_metric_group_handle_t), POINTER(zet_metric_tracer_exp_desc_t), ze_event_handle_t, POINTER(zet_metric_tracer_exp_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zetMetricTracerDestroyExp
+if __use_win_types:
+    _zetMetricTracerDestroyExp_t = WINFUNCTYPE( ze_result_t, zet_metric_tracer_exp_handle_t )
+else:
+    _zetMetricTracerDestroyExp_t = CFUNCTYPE( ze_result_t, zet_metric_tracer_exp_handle_t )
+
+###############################################################################
+## @brief Function-pointer for zetMetricTracerEnableExp
+if __use_win_types:
+    _zetMetricTracerEnableExp_t = WINFUNCTYPE( ze_result_t, zet_metric_tracer_exp_handle_t, ze_bool_t )
+else:
+    _zetMetricTracerEnableExp_t = CFUNCTYPE( ze_result_t, zet_metric_tracer_exp_handle_t, ze_bool_t )
+
+###############################################################################
+## @brief Function-pointer for zetMetricTracerDisableExp
+if __use_win_types:
+    _zetMetricTracerDisableExp_t = WINFUNCTYPE( ze_result_t, zet_metric_tracer_exp_handle_t, ze_bool_t )
+else:
+    _zetMetricTracerDisableExp_t = CFUNCTYPE( ze_result_t, zet_metric_tracer_exp_handle_t, ze_bool_t )
+
+###############################################################################
+## @brief Function-pointer for zetMetricTracerReadDataExp
+if __use_win_types:
+    _zetMetricTracerReadDataExp_t = WINFUNCTYPE( ze_result_t, zet_metric_tracer_exp_handle_t, POINTER(c_size_t), POINTER(c_ubyte) )
+else:
+    _zetMetricTracerReadDataExp_t = CFUNCTYPE( ze_result_t, zet_metric_tracer_exp_handle_t, POINTER(c_size_t), POINTER(c_ubyte) )
+
+###############################################################################
+## @brief Function-pointer for zetMetricTracerDecodeExp
+if __use_win_types:
+    _zetMetricTracerDecodeExp_t = WINFUNCTYPE( ze_result_t, zet_metric_decoder_exp_handle_t, POINTER(c_size_t), POINTER(c_ubyte), c_ulong, POINTER(zet_metric_handle_t), POINTER(c_ulong), POINTER(c_ulong), POINTER(c_ulong), POINTER(zet_metric_entry_exp_t) )
+else:
+    _zetMetricTracerDecodeExp_t = CFUNCTYPE( ze_result_t, zet_metric_decoder_exp_handle_t, POINTER(c_size_t), POINTER(c_ubyte), c_ulong, POINTER(zet_metric_handle_t), POINTER(c_ulong), POINTER(c_ulong), POINTER(c_ulong), POINTER(zet_metric_entry_exp_t) )
+
+
+###############################################################################
+## @brief Table of MetricTracerExp functions pointers
+class _zet_metric_tracer_exp_dditable_t(Structure):
+    _fields_ = [
+        ("pfnCreateExp", c_void_p),                                     ## _zetMetricTracerCreateExp_t
+        ("pfnDestroyExp", c_void_p),                                    ## _zetMetricTracerDestroyExp_t
+        ("pfnEnableExp", c_void_p),                                     ## _zetMetricTracerEnableExp_t
+        ("pfnDisableExp", c_void_p),                                    ## _zetMetricTracerDisableExp_t
+        ("pfnReadDataExp", c_void_p),                                   ## _zetMetricTracerReadDataExp_t
+        ("pfnDecodeExp", c_void_p)                                      ## _zetMetricTracerDecodeExp_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zetMetricDecoderCreateExp
+if __use_win_types:
+    _zetMetricDecoderCreateExp_t = WINFUNCTYPE( ze_result_t, zet_metric_tracer_exp_handle_t, POINTER(zet_metric_decoder_exp_handle_t) )
+else:
+    _zetMetricDecoderCreateExp_t = CFUNCTYPE( ze_result_t, zet_metric_tracer_exp_handle_t, POINTER(zet_metric_decoder_exp_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zetMetricDecoderDestroyExp
+if __use_win_types:
+    _zetMetricDecoderDestroyExp_t = WINFUNCTYPE( ze_result_t, zet_metric_decoder_exp_handle_t )
+else:
+    _zetMetricDecoderDestroyExp_t = CFUNCTYPE( ze_result_t, zet_metric_decoder_exp_handle_t )
+
+###############################################################################
+## @brief Function-pointer for zetMetricDecoderGetDecodableMetricsExp
+if __use_win_types:
+    _zetMetricDecoderGetDecodableMetricsExp_t = WINFUNCTYPE( ze_result_t, zet_metric_decoder_exp_handle_t, POINTER(c_ulong), POINTER(zet_metric_handle_t) )
+else:
+    _zetMetricDecoderGetDecodableMetricsExp_t = CFUNCTYPE( ze_result_t, zet_metric_decoder_exp_handle_t, POINTER(c_ulong), POINTER(zet_metric_handle_t) )
+
+
+###############################################################################
+## @brief Table of MetricDecoderExp functions pointers
+class _zet_metric_decoder_exp_dditable_t(Structure):
+    _fields_ = [
+        ("pfnCreateExp", c_void_p),                                     ## _zetMetricDecoderCreateExp_t
+        ("pfnDestroyExp", c_void_p),                                    ## _zetMetricDecoderDestroyExp_t
+        ("pfnGetDecodableMetricsExp", c_void_p)                         ## _zetMetricDecoderGetDecodableMetricsExp_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zetDeviceGetDebugProperties
+if __use_win_types:
+    _zetDeviceGetDebugProperties_t = WINFUNCTYPE( ze_result_t, zet_device_handle_t, POINTER(zet_device_debug_properties_t) )
+else:
+    _zetDeviceGetDebugProperties_t = CFUNCTYPE( ze_result_t, zet_device_handle_t, POINTER(zet_device_debug_properties_t) )
+
+
+###############################################################################
+## @brief Table of Device functions pointers
+class _zet_device_dditable_t(Structure):
+    _fields_ = [
+        ("pfnGetDebugProperties", c_void_p)                             ## _zetDeviceGetDebugProperties_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zetDeviceGetConcurrentMetricGroupsExp
+if __use_win_types:
+    _zetDeviceGetConcurrentMetricGroupsExp_t = WINFUNCTYPE( ze_result_t, zet_device_handle_t, c_ulong, *, *, * )
+else:
+    _zetDeviceGetConcurrentMetricGroupsExp_t = CFUNCTYPE( ze_result_t, zet_device_handle_t, c_ulong, *, *, * )
+
+###############################################################################
+## @brief Function-pointer for zetDeviceCreateMetricGroupsFromMetricsExp
+if __use_win_types:
+    _zetDeviceCreateMetricGroupsFromMetricsExp_t = WINFUNCTYPE( ze_result_t, zet_device_handle_t, c_ulong, *, *, *, *, POINTER(zet_metric_group_handle_t) )
+else:
+    _zetDeviceCreateMetricGroupsFromMetricsExp_t = CFUNCTYPE( ze_result_t, zet_device_handle_t, c_ulong, *, *, *, *, POINTER(zet_metric_group_handle_t) )
+
+
+###############################################################################
+## @brief Table of DeviceExp functions pointers
+class _zet_device_exp_dditable_t(Structure):
+    _fields_ = [
+        ("pfnGetConcurrentMetricGroupsExp", c_void_p),                  ## _zetDeviceGetConcurrentMetricGroupsExp_t
+        ("pfnCreateMetricGroupsFromMetricsExp", c_void_p)               ## _zetDeviceCreateMetricGroupsFromMetricsExp_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zetContextActivateMetricGroups
+if __use_win_types:
+    _zetContextActivateMetricGroups_t = WINFUNCTYPE( ze_result_t, zet_context_handle_t, zet_device_handle_t, c_ulong, POINTER(zet_metric_group_handle_t) )
+else:
+    _zetContextActivateMetricGroups_t = CFUNCTYPE( ze_result_t, zet_context_handle_t, zet_device_handle_t, c_ulong, POINTER(zet_metric_group_handle_t) )
+
+
+###############################################################################
+## @brief Table of Context functions pointers
+class _zet_context_dditable_t(Structure):
+    _fields_ = [
+        ("pfnActivateMetricGroups", c_void_p)                           ## _zetContextActivateMetricGroups_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zetCommandListAppendMetricStreamerMarker
+if __use_win_types:
+    _zetCommandListAppendMetricStreamerMarker_t = WINFUNCTYPE( ze_result_t, zet_command_list_handle_t, zet_metric_streamer_handle_t, c_ulong )
+else:
+    _zetCommandListAppendMetricStreamerMarker_t = CFUNCTYPE( ze_result_t, zet_command_list_handle_t, zet_metric_streamer_handle_t, c_ulong )
+
+###############################################################################
+## @brief Function-pointer for zetCommandListAppendMetricQueryBegin
+if __use_win_types:
+    _zetCommandListAppendMetricQueryBegin_t = WINFUNCTYPE( ze_result_t, zet_command_list_handle_t, zet_metric_query_handle_t )
+else:
+    _zetCommandListAppendMetricQueryBegin_t = CFUNCTYPE( ze_result_t, zet_command_list_handle_t, zet_metric_query_handle_t )
+
+###############################################################################
+## @brief Function-pointer for zetCommandListAppendMetricQueryEnd
+if __use_win_types:
+    _zetCommandListAppendMetricQueryEnd_t = WINFUNCTYPE( ze_result_t, zet_command_list_handle_t, zet_metric_query_handle_t, ze_event_handle_t, c_ulong, POINTER(ze_event_handle_t) )
+else:
+    _zetCommandListAppendMetricQueryEnd_t = CFUNCTYPE( ze_result_t, zet_command_list_handle_t, zet_metric_query_handle_t, ze_event_handle_t, c_ulong, POINTER(ze_event_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zetCommandListAppendMetricMemoryBarrier
+if __use_win_types:
+    _zetCommandListAppendMetricMemoryBarrier_t = WINFUNCTYPE( ze_result_t, zet_command_list_handle_t )
+else:
+    _zetCommandListAppendMetricMemoryBarrier_t = CFUNCTYPE( ze_result_t, zet_command_list_handle_t )
+
+
+###############################################################################
+## @brief Table of CommandList functions pointers
+class _zet_command_list_dditable_t(Structure):
+    _fields_ = [
+        ("pfnAppendMetricStreamerMarker", c_void_p),                    ## _zetCommandListAppendMetricStreamerMarker_t
+        ("pfnAppendMetricQueryBegin", c_void_p),                        ## _zetCommandListAppendMetricQueryBegin_t
+        ("pfnAppendMetricQueryEnd", c_void_p),                          ## _zetCommandListAppendMetricQueryEnd_t
+        ("pfnAppendMetricMemoryBarrier", c_void_p)                      ## _zetCommandListAppendMetricMemoryBarrier_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zetModuleGetDebugInfo
+if __use_win_types:
+    _zetModuleGetDebugInfo_t = WINFUNCTYPE( ze_result_t, zet_module_handle_t, zet_module_debug_info_format_t, POINTER(c_size_t), POINTER(c_ubyte) )
+else:
+    _zetModuleGetDebugInfo_t = CFUNCTYPE( ze_result_t, zet_module_handle_t, zet_module_debug_info_format_t, POINTER(c_size_t), POINTER(c_ubyte) )
+
+
+###############################################################################
+## @brief Table of Module functions pointers
+class _zet_module_dditable_t(Structure):
+    _fields_ = [
+        ("pfnGetDebugInfo", c_void_p)                                   ## _zetModuleGetDebugInfo_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zetKernelGetProfileInfo
+if __use_win_types:
+    _zetKernelGetProfileInfo_t = WINFUNCTYPE( ze_result_t, zet_kernel_handle_t, POINTER(zet_profile_properties_t) )
+else:
+    _zetKernelGetProfileInfo_t = CFUNCTYPE( ze_result_t, zet_kernel_handle_t, POINTER(zet_profile_properties_t) )
+
+
+###############################################################################
+## @brief Table of Kernel functions pointers
+class _zet_kernel_dditable_t(Structure):
+    _fields_ = [
+        ("pfnGetProfileInfo", c_void_p)                                 ## _zetKernelGetProfileInfo_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zetMetricGet
+if __use_win_types:
+    _zetMetricGet_t = WINFUNCTYPE( ze_result_t, zet_metric_group_handle_t, POINTER(c_ulong), POINTER(zet_metric_handle_t) )
+else:
+    _zetMetricGet_t = CFUNCTYPE( ze_result_t, zet_metric_group_handle_t, POINTER(c_ulong), POINTER(zet_metric_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zetMetricGetProperties
+if __use_win_types:
+    _zetMetricGetProperties_t = WINFUNCTYPE( ze_result_t, zet_metric_handle_t, POINTER(zet_metric_properties_t) )
+else:
+    _zetMetricGetProperties_t = CFUNCTYPE( ze_result_t, zet_metric_handle_t, POINTER(zet_metric_properties_t) )
+
+
+###############################################################################
+## @brief Table of Metric functions pointers
+class _zet_metric_dditable_t(Structure):
+    _fields_ = [
+        ("pfnGet", c_void_p),                                           ## _zetMetricGet_t
+        ("pfnGetProperties", c_void_p)                                  ## _zetMetricGetProperties_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zetMetricCreateFromProgrammableExp
+if __use_win_types:
+    _zetMetricCreateFromProgrammableExp_t = WINFUNCTYPE( ze_result_t, zet_metric_programmable_exp_handle_t, POINTER(zet_metric_programmable_param_value_exp_t), c_ulong, c_char_p, c_char_p, POINTER(c_ulong), POINTER(zet_metric_handle_t) )
+else:
+    _zetMetricCreateFromProgrammableExp_t = CFUNCTYPE( ze_result_t, zet_metric_programmable_exp_handle_t, POINTER(zet_metric_programmable_param_value_exp_t), c_ulong, c_char_p, c_char_p, POINTER(c_ulong), POINTER(zet_metric_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zetMetricDestroyExp
+if __use_win_types:
+    _zetMetricDestroyExp_t = WINFUNCTYPE( ze_result_t, zet_metric_handle_t )
+else:
+    _zetMetricDestroyExp_t = CFUNCTYPE( ze_result_t, zet_metric_handle_t )
+
+###############################################################################
+## @brief Function-pointer for zetMetricCreateFromProgrammableExp2
+if __use_win_types:
+    _zetMetricCreateFromProgrammableExp2_t = WINFUNCTYPE( ze_result_t, zet_metric_programmable_exp_handle_t, c_ulong, POINTER(zet_metric_programmable_param_value_exp_t), c_char_p, c_char_p, POINTER(c_ulong), POINTER(zet_metric_handle_t) )
+else:
+    _zetMetricCreateFromProgrammableExp2_t = CFUNCTYPE( ze_result_t, zet_metric_programmable_exp_handle_t, c_ulong, POINTER(zet_metric_programmable_param_value_exp_t), c_char_p, c_char_p, POINTER(c_ulong), POINTER(zet_metric_handle_t) )
+
+
+###############################################################################
+## @brief Table of MetricExp functions pointers
+class _zet_metric_exp_dditable_t(Structure):
+    _fields_ = [
+        ("pfnCreateFromProgrammableExp", c_void_p),                     ## _zetMetricCreateFromProgrammableExp_t
+        ("pfnDestroyExp", c_void_p),                                    ## _zetMetricDestroyExp_t
+        ("pfnCreateFromProgrammableExp2", c_void_p)                     ## _zetMetricCreateFromProgrammableExp2_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zetMetricGroupGet
+if __use_win_types:
+    _zetMetricGroupGet_t = WINFUNCTYPE( ze_result_t, zet_device_handle_t, POINTER(c_ulong), POINTER(zet_metric_group_handle_t) )
+else:
+    _zetMetricGroupGet_t = CFUNCTYPE( ze_result_t, zet_device_handle_t, POINTER(c_ulong), POINTER(zet_metric_group_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zetMetricGroupGetProperties
+if __use_win_types:
+    _zetMetricGroupGetProperties_t = WINFUNCTYPE( ze_result_t, zet_metric_group_handle_t, POINTER(zet_metric_group_properties_t) )
+else:
+    _zetMetricGroupGetProperties_t = CFUNCTYPE( ze_result_t, zet_metric_group_handle_t, POINTER(zet_metric_group_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zetMetricGroupCalculateMetricValues
+if __use_win_types:
+    _zetMetricGroupCalculateMetricValues_t = WINFUNCTYPE( ze_result_t, zet_metric_group_handle_t, zet_metric_group_calculation_type_t, c_size_t, POINTER(c_ubyte), POINTER(c_ulong), POINTER(zet_typed_value_t) )
+else:
+    _zetMetricGroupCalculateMetricValues_t = CFUNCTYPE( ze_result_t, zet_metric_group_handle_t, zet_metric_group_calculation_type_t, c_size_t, POINTER(c_ubyte), POINTER(c_ulong), POINTER(zet_typed_value_t) )
+
+
+###############################################################################
+## @brief Table of MetricGroup functions pointers
+class _zet_metric_group_dditable_t(Structure):
+    _fields_ = [
+        ("pfnGet", c_void_p),                                           ## _zetMetricGroupGet_t
+        ("pfnGetProperties", c_void_p),                                 ## _zetMetricGroupGetProperties_t
+        ("pfnCalculateMetricValues", c_void_p)                          ## _zetMetricGroupCalculateMetricValues_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zetMetricGroupCalculateMultipleMetricValuesExp
+if __use_win_types:
+    _zetMetricGroupCalculateMultipleMetricValuesExp_t = WINFUNCTYPE( ze_result_t, zet_metric_group_handle_t, zet_metric_group_calculation_type_t, c_size_t, POINTER(c_ubyte), POINTER(c_ulong), POINTER(c_ulong), POINTER(c_ulong), POINTER(zet_typed_value_t) )
+else:
+    _zetMetricGroupCalculateMultipleMetricValuesExp_t = CFUNCTYPE( ze_result_t, zet_metric_group_handle_t, zet_metric_group_calculation_type_t, c_size_t, POINTER(c_ubyte), POINTER(c_ulong), POINTER(c_ulong), POINTER(c_ulong), POINTER(zet_typed_value_t) )
+
+###############################################################################
+## @brief Function-pointer for zetMetricGroupGetGlobalTimestampsExp
+if __use_win_types:
+    _zetMetricGroupGetGlobalTimestampsExp_t = WINFUNCTYPE( ze_result_t, zet_metric_group_handle_t, ze_bool_t, POINTER(c_ulonglong), POINTER(c_ulonglong) )
+else:
+    _zetMetricGroupGetGlobalTimestampsExp_t = CFUNCTYPE( ze_result_t, zet_metric_group_handle_t, ze_bool_t, POINTER(c_ulonglong), POINTER(c_ulonglong) )
+
+###############################################################################
+## @brief Function-pointer for zetMetricGroupGetExportDataExp
+if __use_win_types:
+    _zetMetricGroupGetExportDataExp_t = WINFUNCTYPE( ze_result_t, zet_metric_group_handle_t, POINTER(c_ubyte), c_size_t, POINTER(c_size_t), * )
+else:
+    _zetMetricGroupGetExportDataExp_t = CFUNCTYPE( ze_result_t, zet_metric_group_handle_t, POINTER(c_ubyte), c_size_t, POINTER(c_size_t), * )
+
+###############################################################################
+## @brief Function-pointer for zetMetricGroupCalculateMetricExportDataExp
+if __use_win_types:
+    _zetMetricGroupCalculateMetricExportDataExp_t = WINFUNCTYPE( ze_result_t, ze_driver_handle_t, zet_metric_group_calculation_type_t, c_size_t, POINTER(c_ubyte), POINTER(zet_metric_calculate_exp_desc_t), POINTER(c_ulong), POINTER(c_ulong), POINTER(c_ulong), POINTER(zet_typed_value_t) )
+else:
+    _zetMetricGroupCalculateMetricExportDataExp_t = CFUNCTYPE( ze_result_t, ze_driver_handle_t, zet_metric_group_calculation_type_t, c_size_t, POINTER(c_ubyte), POINTER(zet_metric_calculate_exp_desc_t), POINTER(c_ulong), POINTER(c_ulong), POINTER(c_ulong), POINTER(zet_typed_value_t) )
+
+###############################################################################
+## @brief Function-pointer for zetMetricGroupCreateExp
+if __use_win_types:
+    _zetMetricGroupCreateExp_t = WINFUNCTYPE( ze_result_t, zet_device_handle_t, c_char_p, c_char_p, zet_metric_group_sampling_type_flags_t, POINTER(zet_metric_group_handle_t) )
+else:
+    _zetMetricGroupCreateExp_t = CFUNCTYPE( ze_result_t, zet_device_handle_t, c_char_p, c_char_p, zet_metric_group_sampling_type_flags_t, POINTER(zet_metric_group_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zetMetricGroupAddMetricExp
+if __use_win_types:
+    _zetMetricGroupAddMetricExp_t = WINFUNCTYPE( ze_result_t, zet_metric_group_handle_t, zet_metric_handle_t, *, c_char_p )
+else:
+    _zetMetricGroupAddMetricExp_t = CFUNCTYPE( ze_result_t, zet_metric_group_handle_t, zet_metric_handle_t, *, c_char_p )
+
+###############################################################################
+## @brief Function-pointer for zetMetricGroupRemoveMetricExp
+if __use_win_types:
+    _zetMetricGroupRemoveMetricExp_t = WINFUNCTYPE( ze_result_t, zet_metric_group_handle_t, zet_metric_handle_t )
+else:
+    _zetMetricGroupRemoveMetricExp_t = CFUNCTYPE( ze_result_t, zet_metric_group_handle_t, zet_metric_handle_t )
+
+###############################################################################
+## @brief Function-pointer for zetMetricGroupCloseExp
+if __use_win_types:
+    _zetMetricGroupCloseExp_t = WINFUNCTYPE( ze_result_t, zet_metric_group_handle_t )
+else:
+    _zetMetricGroupCloseExp_t = CFUNCTYPE( ze_result_t, zet_metric_group_handle_t )
+
+###############################################################################
+## @brief Function-pointer for zetMetricGroupDestroyExp
+if __use_win_types:
+    _zetMetricGroupDestroyExp_t = WINFUNCTYPE( ze_result_t, zet_metric_group_handle_t )
+else:
+    _zetMetricGroupDestroyExp_t = CFUNCTYPE( ze_result_t, zet_metric_group_handle_t )
+
+
+###############################################################################
+## @brief Table of MetricGroupExp functions pointers
+class _zet_metric_group_exp_dditable_t(Structure):
+    _fields_ = [
+        ("pfnCalculateMultipleMetricValuesExp", c_void_p),              ## _zetMetricGroupCalculateMultipleMetricValuesExp_t
+        ("pfnGetGlobalTimestampsExp", c_void_p),                        ## _zetMetricGroupGetGlobalTimestampsExp_t
+        ("pfnGetExportDataExp", c_void_p),                              ## _zetMetricGroupGetExportDataExp_t
+        ("pfnCalculateMetricExportDataExp", c_void_p),                  ## _zetMetricGroupCalculateMetricExportDataExp_t
+        ("pfnCreateExp", c_void_p),                                     ## _zetMetricGroupCreateExp_t
+        ("pfnAddMetricExp", c_void_p),                                  ## _zetMetricGroupAddMetricExp_t
+        ("pfnRemoveMetricExp", c_void_p),                               ## _zetMetricGroupRemoveMetricExp_t
+        ("pfnCloseExp", c_void_p),                                      ## _zetMetricGroupCloseExp_t
+        ("pfnDestroyExp", c_void_p)                                     ## _zetMetricGroupDestroyExp_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zetMetricStreamerOpen
+if __use_win_types:
+    _zetMetricStreamerOpen_t = WINFUNCTYPE( ze_result_t, zet_context_handle_t, zet_device_handle_t, zet_metric_group_handle_t, POINTER(zet_metric_streamer_desc_t), ze_event_handle_t, POINTER(zet_metric_streamer_handle_t) )
+else:
+    _zetMetricStreamerOpen_t = CFUNCTYPE( ze_result_t, zet_context_handle_t, zet_device_handle_t, zet_metric_group_handle_t, POINTER(zet_metric_streamer_desc_t), ze_event_handle_t, POINTER(zet_metric_streamer_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zetMetricStreamerClose
+if __use_win_types:
+    _zetMetricStreamerClose_t = WINFUNCTYPE( ze_result_t, zet_metric_streamer_handle_t )
+else:
+    _zetMetricStreamerClose_t = CFUNCTYPE( ze_result_t, zet_metric_streamer_handle_t )
+
+###############################################################################
+## @brief Function-pointer for zetMetricStreamerReadData
+if __use_win_types:
+    _zetMetricStreamerReadData_t = WINFUNCTYPE( ze_result_t, zet_metric_streamer_handle_t, c_ulong, POINTER(c_size_t), POINTER(c_ubyte) )
+else:
+    _zetMetricStreamerReadData_t = CFUNCTYPE( ze_result_t, zet_metric_streamer_handle_t, c_ulong, POINTER(c_size_t), POINTER(c_ubyte) )
+
+
+###############################################################################
+## @brief Table of MetricStreamer functions pointers
+class _zet_metric_streamer_dditable_t(Structure):
+    _fields_ = [
+        ("pfnOpen", c_void_p),                                          ## _zetMetricStreamerOpen_t
+        ("pfnClose", c_void_p),                                         ## _zetMetricStreamerClose_t
+        ("pfnReadData", c_void_p)                                       ## _zetMetricStreamerReadData_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zetMetricQueryPoolCreate
+if __use_win_types:
+    _zetMetricQueryPoolCreate_t = WINFUNCTYPE( ze_result_t, zet_context_handle_t, zet_device_handle_t, zet_metric_group_handle_t, POINTER(zet_metric_query_pool_desc_t), POINTER(zet_metric_query_pool_handle_t) )
+else:
+    _zetMetricQueryPoolCreate_t = CFUNCTYPE( ze_result_t, zet_context_handle_t, zet_device_handle_t, zet_metric_group_handle_t, POINTER(zet_metric_query_pool_desc_t), POINTER(zet_metric_query_pool_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zetMetricQueryPoolDestroy
+if __use_win_types:
+    _zetMetricQueryPoolDestroy_t = WINFUNCTYPE( ze_result_t, zet_metric_query_pool_handle_t )
+else:
+    _zetMetricQueryPoolDestroy_t = CFUNCTYPE( ze_result_t, zet_metric_query_pool_handle_t )
+
+
+###############################################################################
+## @brief Table of MetricQueryPool functions pointers
+class _zet_metric_query_pool_dditable_t(Structure):
+    _fields_ = [
+        ("pfnCreate", c_void_p),                                        ## _zetMetricQueryPoolCreate_t
+        ("pfnDestroy", c_void_p)                                        ## _zetMetricQueryPoolDestroy_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zetMetricQueryCreate
+if __use_win_types:
+    _zetMetricQueryCreate_t = WINFUNCTYPE( ze_result_t, zet_metric_query_pool_handle_t, c_ulong, POINTER(zet_metric_query_handle_t) )
+else:
+    _zetMetricQueryCreate_t = CFUNCTYPE( ze_result_t, zet_metric_query_pool_handle_t, c_ulong, POINTER(zet_metric_query_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zetMetricQueryDestroy
+if __use_win_types:
+    _zetMetricQueryDestroy_t = WINFUNCTYPE( ze_result_t, zet_metric_query_handle_t )
+else:
+    _zetMetricQueryDestroy_t = CFUNCTYPE( ze_result_t, zet_metric_query_handle_t )
+
+###############################################################################
+## @brief Function-pointer for zetMetricQueryReset
+if __use_win_types:
+    _zetMetricQueryReset_t = WINFUNCTYPE( ze_result_t, zet_metric_query_handle_t )
+else:
+    _zetMetricQueryReset_t = CFUNCTYPE( ze_result_t, zet_metric_query_handle_t )
+
+###############################################################################
+## @brief Function-pointer for zetMetricQueryGetData
+if __use_win_types:
+    _zetMetricQueryGetData_t = WINFUNCTYPE( ze_result_t, zet_metric_query_handle_t, POINTER(c_size_t), POINTER(c_ubyte) )
+else:
+    _zetMetricQueryGetData_t = CFUNCTYPE( ze_result_t, zet_metric_query_handle_t, POINTER(c_size_t), POINTER(c_ubyte) )
+
+
+###############################################################################
+## @brief Table of MetricQuery functions pointers
+class _zet_metric_query_dditable_t(Structure):
+    _fields_ = [
+        ("pfnCreate", c_void_p),                                        ## _zetMetricQueryCreate_t
+        ("pfnDestroy", c_void_p),                                       ## _zetMetricQueryDestroy_t
+        ("pfnReset", c_void_p),                                         ## _zetMetricQueryReset_t
+        ("pfnGetData", c_void_p)                                        ## _zetMetricQueryGetData_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zetTracerExpCreate
+if __use_win_types:
+    _zetTracerExpCreate_t = WINFUNCTYPE( ze_result_t, zet_context_handle_t, POINTER(zet_tracer_exp_desc_t), POINTER(zet_tracer_exp_handle_t) )
+else:
+    _zetTracerExpCreate_t = CFUNCTYPE( ze_result_t, zet_context_handle_t, POINTER(zet_tracer_exp_desc_t), POINTER(zet_tracer_exp_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zetTracerExpDestroy
+if __use_win_types:
+    _zetTracerExpDestroy_t = WINFUNCTYPE( ze_result_t, zet_tracer_exp_handle_t )
+else:
+    _zetTracerExpDestroy_t = CFUNCTYPE( ze_result_t, zet_tracer_exp_handle_t )
+
+###############################################################################
+## @brief Function-pointer for zetTracerExpSetPrologues
+if __use_win_types:
+    _zetTracerExpSetPrologues_t = WINFUNCTYPE( ze_result_t, zet_tracer_exp_handle_t, POINTER(zet_core_callbacks_t) )
+else:
+    _zetTracerExpSetPrologues_t = CFUNCTYPE( ze_result_t, zet_tracer_exp_handle_t, POINTER(zet_core_callbacks_t) )
+
+###############################################################################
+## @brief Function-pointer for zetTracerExpSetEpilogues
+if __use_win_types:
+    _zetTracerExpSetEpilogues_t = WINFUNCTYPE( ze_result_t, zet_tracer_exp_handle_t, POINTER(zet_core_callbacks_t) )
+else:
+    _zetTracerExpSetEpilogues_t = CFUNCTYPE( ze_result_t, zet_tracer_exp_handle_t, POINTER(zet_core_callbacks_t) )
+
+###############################################################################
+## @brief Function-pointer for zetTracerExpSetEnabled
+if __use_win_types:
+    _zetTracerExpSetEnabled_t = WINFUNCTYPE( ze_result_t, zet_tracer_exp_handle_t, ze_bool_t )
+else:
+    _zetTracerExpSetEnabled_t = CFUNCTYPE( ze_result_t, zet_tracer_exp_handle_t, ze_bool_t )
+
+
+###############################################################################
+## @brief Table of TracerExp functions pointers
+class _zet_tracer_exp_dditable_t(Structure):
+    _fields_ = [
+        ("pfnCreate", c_void_p),                                        ## _zetTracerExpCreate_t
+        ("pfnDestroy", c_void_p),                                       ## _zetTracerExpDestroy_t
+        ("pfnSetPrologues", c_void_p),                                  ## _zetTracerExpSetPrologues_t
+        ("pfnSetEpilogues", c_void_p),                                  ## _zetTracerExpSetEpilogues_t
+        ("pfnSetEnabled", c_void_p)                                     ## _zetTracerExpSetEnabled_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for zetDebugAttach
+if __use_win_types:
+    _zetDebugAttach_t = WINFUNCTYPE( ze_result_t, zet_device_handle_t, POINTER(zet_debug_config_t), POINTER(zet_debug_session_handle_t) )
+else:
+    _zetDebugAttach_t = CFUNCTYPE( ze_result_t, zet_device_handle_t, POINTER(zet_debug_config_t), POINTER(zet_debug_session_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for zetDebugDetach
+if __use_win_types:
+    _zetDebugDetach_t = WINFUNCTYPE( ze_result_t, zet_debug_session_handle_t )
+else:
+    _zetDebugDetach_t = CFUNCTYPE( ze_result_t, zet_debug_session_handle_t )
+
+###############################################################################
+## @brief Function-pointer for zetDebugReadEvent
+if __use_win_types:
+    _zetDebugReadEvent_t = WINFUNCTYPE( ze_result_t, zet_debug_session_handle_t, c_ulonglong, POINTER(zet_debug_event_t) )
+else:
+    _zetDebugReadEvent_t = CFUNCTYPE( ze_result_t, zet_debug_session_handle_t, c_ulonglong, POINTER(zet_debug_event_t) )
+
+###############################################################################
+## @brief Function-pointer for zetDebugAcknowledgeEvent
+if __use_win_types:
+    _zetDebugAcknowledgeEvent_t = WINFUNCTYPE( ze_result_t, zet_debug_session_handle_t, POINTER(zet_debug_event_t) )
+else:
+    _zetDebugAcknowledgeEvent_t = CFUNCTYPE( ze_result_t, zet_debug_session_handle_t, POINTER(zet_debug_event_t) )
+
+###############################################################################
+## @brief Function-pointer for zetDebugInterrupt
+if __use_win_types:
+    _zetDebugInterrupt_t = WINFUNCTYPE( ze_result_t, zet_debug_session_handle_t, ze_device_thread_t )
+else:
+    _zetDebugInterrupt_t = CFUNCTYPE( ze_result_t, zet_debug_session_handle_t, ze_device_thread_t )
+
+###############################################################################
+## @brief Function-pointer for zetDebugResume
+if __use_win_types:
+    _zetDebugResume_t = WINFUNCTYPE( ze_result_t, zet_debug_session_handle_t, ze_device_thread_t )
+else:
+    _zetDebugResume_t = CFUNCTYPE( ze_result_t, zet_debug_session_handle_t, ze_device_thread_t )
+
+###############################################################################
+## @brief Function-pointer for zetDebugReadMemory
+if __use_win_types:
+    _zetDebugReadMemory_t = WINFUNCTYPE( ze_result_t, zet_debug_session_handle_t, ze_device_thread_t, POINTER(zet_debug_memory_space_desc_t), c_size_t, c_void_p )
+else:
+    _zetDebugReadMemory_t = CFUNCTYPE( ze_result_t, zet_debug_session_handle_t, ze_device_thread_t, POINTER(zet_debug_memory_space_desc_t), c_size_t, c_void_p )
+
+###############################################################################
+## @brief Function-pointer for zetDebugWriteMemory
+if __use_win_types:
+    _zetDebugWriteMemory_t = WINFUNCTYPE( ze_result_t, zet_debug_session_handle_t, ze_device_thread_t, POINTER(zet_debug_memory_space_desc_t), c_size_t, c_void_p )
+else:
+    _zetDebugWriteMemory_t = CFUNCTYPE( ze_result_t, zet_debug_session_handle_t, ze_device_thread_t, POINTER(zet_debug_memory_space_desc_t), c_size_t, c_void_p )
+
+###############################################################################
+## @brief Function-pointer for zetDebugGetRegisterSetProperties
+if __use_win_types:
+    _zetDebugGetRegisterSetProperties_t = WINFUNCTYPE( ze_result_t, zet_device_handle_t, POINTER(c_ulong), POINTER(zet_debug_regset_properties_t) )
+else:
+    _zetDebugGetRegisterSetProperties_t = CFUNCTYPE( ze_result_t, zet_device_handle_t, POINTER(c_ulong), POINTER(zet_debug_regset_properties_t) )
+
+###############################################################################
+## @brief Function-pointer for zetDebugReadRegisters
+if __use_win_types:
+    _zetDebugReadRegisters_t = WINFUNCTYPE( ze_result_t, zet_debug_session_handle_t, ze_device_thread_t, c_ulong, c_ulong, c_ulong, c_void_p )
+else:
+    _zetDebugReadRegisters_t = CFUNCTYPE( ze_result_t, zet_debug_session_handle_t, ze_device_thread_t, c_ulong, c_ulong, c_ulong, c_void_p )
+
+###############################################################################
+## @brief Function-pointer for zetDebugWriteRegisters
+if __use_win_types:
+    _zetDebugWriteRegisters_t = WINFUNCTYPE( ze_result_t, zet_debug_session_handle_t, ze_device_thread_t, c_ulong, c_ulong, c_ulong, c_void_p )
+else:
+    _zetDebugWriteRegisters_t = CFUNCTYPE( ze_result_t, zet_debug_session_handle_t, ze_device_thread_t, c_ulong, c_ulong, c_ulong, c_void_p )
+
+###############################################################################
+## @brief Function-pointer for zetDebugGetThreadRegisterSetProperties
+if __use_win_types:
+    _zetDebugGetThreadRegisterSetProperties_t = WINFUNCTYPE( ze_result_t, zet_debug_session_handle_t, ze_device_thread_t, POINTER(c_ulong), POINTER(zet_debug_regset_properties_t) )
+else:
+    _zetDebugGetThreadRegisterSetProperties_t = CFUNCTYPE( ze_result_t, zet_debug_session_handle_t, ze_device_thread_t, POINTER(c_ulong), POINTER(zet_debug_regset_properties_t) )
+
+
+###############################################################################
+## @brief Table of Debug functions pointers
+class _zet_debug_dditable_t(Structure):
+    _fields_ = [
+        ("pfnAttach", c_void_p),                                        ## _zetDebugAttach_t
+        ("pfnDetach", c_void_p),                                        ## _zetDebugDetach_t
+        ("pfnReadEvent", c_void_p),                                     ## _zetDebugReadEvent_t
+        ("pfnAcknowledgeEvent", c_void_p),                              ## _zetDebugAcknowledgeEvent_t
+        ("pfnInterrupt", c_void_p),                                     ## _zetDebugInterrupt_t
+        ("pfnResume", c_void_p),                                        ## _zetDebugResume_t
+        ("pfnReadMemory", c_void_p),                                    ## _zetDebugReadMemory_t
+        ("pfnWriteMemory", c_void_p),                                   ## _zetDebugWriteMemory_t
+        ("pfnGetRegisterSetProperties", c_void_p),                      ## _zetDebugGetRegisterSetProperties_t
+        ("pfnReadRegisters", c_void_p),                                 ## _zetDebugReadRegisters_t
+        ("pfnWriteRegisters", c_void_p),                                ## _zetDebugWriteRegisters_t
+        ("pfnGetThreadRegisterSetProperties", c_void_p)                 ## _zetDebugGetThreadRegisterSetProperties_t
+    ]
+
+###############################################################################
+class _zet_dditable_t(Structure):
+    _fields_ = [
+        ("MetricProgrammableExp", _zet_metric_programmable_exp_dditable_t),
+        ("MetricTracerExp", _zet_metric_tracer_exp_dditable_t),
+        ("MetricDecoderExp", _zet_metric_decoder_exp_dditable_t),
+        ("Device", _zet_device_dditable_t),
+        ("DeviceExp", _zet_device_exp_dditable_t),
+        ("Context", _zet_context_dditable_t),
+        ("CommandList", _zet_command_list_dditable_t),
+        ("Module", _zet_module_dditable_t),
+        ("Kernel", _zet_kernel_dditable_t),
+        ("Metric", _zet_metric_dditable_t),
+        ("MetricExp", _zet_metric_exp_dditable_t),
+        ("MetricGroup", _zet_metric_group_dditable_t),
+        ("MetricGroupExp", _zet_metric_group_exp_dditable_t),
+        ("MetricStreamer", _zet_metric_streamer_dditable_t),
+        ("MetricQueryPool", _zet_metric_query_pool_dditable_t),
+        ("MetricQuery", _zet_metric_query_dditable_t),
+        ("TracerExp", _zet_tracer_exp_dditable_t),
+        ("Debug", _zet_debug_dditable_t)
+    ]
+
+###############################################################################
+## @brief zet device-driver interfaces
+class ZET_DDI:
+    def __init__(self, version : ze_api_version_t):
+        # load the ze_loader library
+        if "Windows" == platform.uname()[0]:
+            self.__dll = WinDLL("ze_loader.dll")
+        else:
+            self.__dll = CDLL("ze_loader.so")
+
+        # fill the ddi tables
+        self.__dditable = _zet_dditable_t()
+
+        # call driver to get function pointers
+        _MetricProgrammableExp = _zet_metric_programmable_exp_dditable_t()
+        r = ze_result_v(self.__dll.zetGetMetricProgrammableExpProcAddrTable(version, byref(_MetricProgrammableExp)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.MetricProgrammableExp = _MetricProgrammableExp
+
+        # attach function interface to function address
+        self.zetMetricProgrammableGetExp = _zetMetricProgrammableGetExp_t(self.__dditable.MetricProgrammableExp.pfnGetExp)
+        self.zetMetricProgrammableGetPropertiesExp = _zetMetricProgrammableGetPropertiesExp_t(self.__dditable.MetricProgrammableExp.pfnGetPropertiesExp)
+        self.zetMetricProgrammableGetParamInfoExp = _zetMetricProgrammableGetParamInfoExp_t(self.__dditable.MetricProgrammableExp.pfnGetParamInfoExp)
+        self.zetMetricProgrammableGetParamValueInfoExp = _zetMetricProgrammableGetParamValueInfoExp_t(self.__dditable.MetricProgrammableExp.pfnGetParamValueInfoExp)
+
+        # call driver to get function pointers
+        _MetricTracerExp = _zet_metric_tracer_exp_dditable_t()
+        r = ze_result_v(self.__dll.zetGetMetricTracerExpProcAddrTable(version, byref(_MetricTracerExp)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.MetricTracerExp = _MetricTracerExp
+
+        # attach function interface to function address
+        self.zetMetricTracerCreateExp = _zetMetricTracerCreateExp_t(self.__dditable.MetricTracerExp.pfnCreateExp)
+        self.zetMetricTracerDestroyExp = _zetMetricTracerDestroyExp_t(self.__dditable.MetricTracerExp.pfnDestroyExp)
+        self.zetMetricTracerEnableExp = _zetMetricTracerEnableExp_t(self.__dditable.MetricTracerExp.pfnEnableExp)
+        self.zetMetricTracerDisableExp = _zetMetricTracerDisableExp_t(self.__dditable.MetricTracerExp.pfnDisableExp)
+        self.zetMetricTracerReadDataExp = _zetMetricTracerReadDataExp_t(self.__dditable.MetricTracerExp.pfnReadDataExp)
+        self.zetMetricTracerDecodeExp = _zetMetricTracerDecodeExp_t(self.__dditable.MetricTracerExp.pfnDecodeExp)
+
+        # call driver to get function pointers
+        _MetricDecoderExp = _zet_metric_decoder_exp_dditable_t()
+        r = ze_result_v(self.__dll.zetGetMetricDecoderExpProcAddrTable(version, byref(_MetricDecoderExp)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.MetricDecoderExp = _MetricDecoderExp
+
+        # attach function interface to function address
+        self.zetMetricDecoderCreateExp = _zetMetricDecoderCreateExp_t(self.__dditable.MetricDecoderExp.pfnCreateExp)
+        self.zetMetricDecoderDestroyExp = _zetMetricDecoderDestroyExp_t(self.__dditable.MetricDecoderExp.pfnDestroyExp)
+        self.zetMetricDecoderGetDecodableMetricsExp = _zetMetricDecoderGetDecodableMetricsExp_t(self.__dditable.MetricDecoderExp.pfnGetDecodableMetricsExp)
+
+        # call driver to get function pointers
+        _Device = _zet_device_dditable_t()
+        r = ze_result_v(self.__dll.zetGetDeviceProcAddrTable(version, byref(_Device)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.Device = _Device
+
+        # attach function interface to function address
+        self.zetDeviceGetDebugProperties = _zetDeviceGetDebugProperties_t(self.__dditable.Device.pfnGetDebugProperties)
+
+        # call driver to get function pointers
+        _DeviceExp = _zet_device_exp_dditable_t()
+        r = ze_result_v(self.__dll.zetGetDeviceExpProcAddrTable(version, byref(_DeviceExp)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.DeviceExp = _DeviceExp
+
+        # attach function interface to function address
+        self.zetDeviceGetConcurrentMetricGroupsExp = _zetDeviceGetConcurrentMetricGroupsExp_t(self.__dditable.DeviceExp.pfnGetConcurrentMetricGroupsExp)
+        self.zetDeviceCreateMetricGroupsFromMetricsExp = _zetDeviceCreateMetricGroupsFromMetricsExp_t(self.__dditable.DeviceExp.pfnCreateMetricGroupsFromMetricsExp)
+
+        # call driver to get function pointers
+        _Context = _zet_context_dditable_t()
+        r = ze_result_v(self.__dll.zetGetContextProcAddrTable(version, byref(_Context)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.Context = _Context
+
+        # attach function interface to function address
+        self.zetContextActivateMetricGroups = _zetContextActivateMetricGroups_t(self.__dditable.Context.pfnActivateMetricGroups)
+
+        # call driver to get function pointers
+        _CommandList = _zet_command_list_dditable_t()
+        r = ze_result_v(self.__dll.zetGetCommandListProcAddrTable(version, byref(_CommandList)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.CommandList = _CommandList
+
+        # attach function interface to function address
+        self.zetCommandListAppendMetricStreamerMarker = _zetCommandListAppendMetricStreamerMarker_t(self.__dditable.CommandList.pfnAppendMetricStreamerMarker)
+        self.zetCommandListAppendMetricQueryBegin = _zetCommandListAppendMetricQueryBegin_t(self.__dditable.CommandList.pfnAppendMetricQueryBegin)
+        self.zetCommandListAppendMetricQueryEnd = _zetCommandListAppendMetricQueryEnd_t(self.__dditable.CommandList.pfnAppendMetricQueryEnd)
+        self.zetCommandListAppendMetricMemoryBarrier = _zetCommandListAppendMetricMemoryBarrier_t(self.__dditable.CommandList.pfnAppendMetricMemoryBarrier)
+
+        # call driver to get function pointers
+        _Module = _zet_module_dditable_t()
+        r = ze_result_v(self.__dll.zetGetModuleProcAddrTable(version, byref(_Module)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.Module = _Module
+
+        # attach function interface to function address
+        self.zetModuleGetDebugInfo = _zetModuleGetDebugInfo_t(self.__dditable.Module.pfnGetDebugInfo)
+
+        # call driver to get function pointers
+        _Kernel = _zet_kernel_dditable_t()
+        r = ze_result_v(self.__dll.zetGetKernelProcAddrTable(version, byref(_Kernel)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.Kernel = _Kernel
+
+        # attach function interface to function address
+        self.zetKernelGetProfileInfo = _zetKernelGetProfileInfo_t(self.__dditable.Kernel.pfnGetProfileInfo)
+
+        # call driver to get function pointers
+        _Metric = _zet_metric_dditable_t()
+        r = ze_result_v(self.__dll.zetGetMetricProcAddrTable(version, byref(_Metric)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.Metric = _Metric
+
+        # attach function interface to function address
+        self.zetMetricGet = _zetMetricGet_t(self.__dditable.Metric.pfnGet)
+        self.zetMetricGetProperties = _zetMetricGetProperties_t(self.__dditable.Metric.pfnGetProperties)
+
+        # call driver to get function pointers
+        _MetricExp = _zet_metric_exp_dditable_t()
+        r = ze_result_v(self.__dll.zetGetMetricExpProcAddrTable(version, byref(_MetricExp)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.MetricExp = _MetricExp
+
+        # attach function interface to function address
+        self.zetMetricCreateFromProgrammableExp = _zetMetricCreateFromProgrammableExp_t(self.__dditable.MetricExp.pfnCreateFromProgrammableExp)
+        self.zetMetricDestroyExp = _zetMetricDestroyExp_t(self.__dditable.MetricExp.pfnDestroyExp)
+        self.zetMetricCreateFromProgrammableExp2 = _zetMetricCreateFromProgrammableExp2_t(self.__dditable.MetricExp.pfnCreateFromProgrammableExp2)
+
+        # call driver to get function pointers
+        _MetricGroup = _zet_metric_group_dditable_t()
+        r = ze_result_v(self.__dll.zetGetMetricGroupProcAddrTable(version, byref(_MetricGroup)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.MetricGroup = _MetricGroup
+
+        # attach function interface to function address
+        self.zetMetricGroupGet = _zetMetricGroupGet_t(self.__dditable.MetricGroup.pfnGet)
+        self.zetMetricGroupGetProperties = _zetMetricGroupGetProperties_t(self.__dditable.MetricGroup.pfnGetProperties)
+        self.zetMetricGroupCalculateMetricValues = _zetMetricGroupCalculateMetricValues_t(self.__dditable.MetricGroup.pfnCalculateMetricValues)
+
+        # call driver to get function pointers
+        _MetricGroupExp = _zet_metric_group_exp_dditable_t()
+        r = ze_result_v(self.__dll.zetGetMetricGroupExpProcAddrTable(version, byref(_MetricGroupExp)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.MetricGroupExp = _MetricGroupExp
+
+        # attach function interface to function address
+        self.zetMetricGroupCalculateMultipleMetricValuesExp = _zetMetricGroupCalculateMultipleMetricValuesExp_t(self.__dditable.MetricGroupExp.pfnCalculateMultipleMetricValuesExp)
+        self.zetMetricGroupGetGlobalTimestampsExp = _zetMetricGroupGetGlobalTimestampsExp_t(self.__dditable.MetricGroupExp.pfnGetGlobalTimestampsExp)
+        self.zetMetricGroupGetExportDataExp = _zetMetricGroupGetExportDataExp_t(self.__dditable.MetricGroupExp.pfnGetExportDataExp)
+        self.zetMetricGroupCalculateMetricExportDataExp = _zetMetricGroupCalculateMetricExportDataExp_t(self.__dditable.MetricGroupExp.pfnCalculateMetricExportDataExp)
+        self.zetMetricGroupCreateExp = _zetMetricGroupCreateExp_t(self.__dditable.MetricGroupExp.pfnCreateExp)
+        self.zetMetricGroupAddMetricExp = _zetMetricGroupAddMetricExp_t(self.__dditable.MetricGroupExp.pfnAddMetricExp)
+        self.zetMetricGroupRemoveMetricExp = _zetMetricGroupRemoveMetricExp_t(self.__dditable.MetricGroupExp.pfnRemoveMetricExp)
+        self.zetMetricGroupCloseExp = _zetMetricGroupCloseExp_t(self.__dditable.MetricGroupExp.pfnCloseExp)
+        self.zetMetricGroupDestroyExp = _zetMetricGroupDestroyExp_t(self.__dditable.MetricGroupExp.pfnDestroyExp)
+
+        # call driver to get function pointers
+        _MetricStreamer = _zet_metric_streamer_dditable_t()
+        r = ze_result_v(self.__dll.zetGetMetricStreamerProcAddrTable(version, byref(_MetricStreamer)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.MetricStreamer = _MetricStreamer
+
+        # attach function interface to function address
+        self.zetMetricStreamerOpen = _zetMetricStreamerOpen_t(self.__dditable.MetricStreamer.pfnOpen)
+        self.zetMetricStreamerClose = _zetMetricStreamerClose_t(self.__dditable.MetricStreamer.pfnClose)
+        self.zetMetricStreamerReadData = _zetMetricStreamerReadData_t(self.__dditable.MetricStreamer.pfnReadData)
+
+        # call driver to get function pointers
+        _MetricQueryPool = _zet_metric_query_pool_dditable_t()
+        r = ze_result_v(self.__dll.zetGetMetricQueryPoolProcAddrTable(version, byref(_MetricQueryPool)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.MetricQueryPool = _MetricQueryPool
+
+        # attach function interface to function address
+        self.zetMetricQueryPoolCreate = _zetMetricQueryPoolCreate_t(self.__dditable.MetricQueryPool.pfnCreate)
+        self.zetMetricQueryPoolDestroy = _zetMetricQueryPoolDestroy_t(self.__dditable.MetricQueryPool.pfnDestroy)
+
+        # call driver to get function pointers
+        _MetricQuery = _zet_metric_query_dditable_t()
+        r = ze_result_v(self.__dll.zetGetMetricQueryProcAddrTable(version, byref(_MetricQuery)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.MetricQuery = _MetricQuery
+
+        # attach function interface to function address
+        self.zetMetricQueryCreate = _zetMetricQueryCreate_t(self.__dditable.MetricQuery.pfnCreate)
+        self.zetMetricQueryDestroy = _zetMetricQueryDestroy_t(self.__dditable.MetricQuery.pfnDestroy)
+        self.zetMetricQueryReset = _zetMetricQueryReset_t(self.__dditable.MetricQuery.pfnReset)
+        self.zetMetricQueryGetData = _zetMetricQueryGetData_t(self.__dditable.MetricQuery.pfnGetData)
+
+        # call driver to get function pointers
+        _TracerExp = _zet_tracer_exp_dditable_t()
+        r = ze_result_v(self.__dll.zetGetTracerExpProcAddrTable(version, byref(_TracerExp)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.TracerExp = _TracerExp
+
+        # attach function interface to function address
+        self.zetTracerExpCreate = _zetTracerExpCreate_t(self.__dditable.TracerExp.pfnCreate)
+        self.zetTracerExpDestroy = _zetTracerExpDestroy_t(self.__dditable.TracerExp.pfnDestroy)
+        self.zetTracerExpSetPrologues = _zetTracerExpSetPrologues_t(self.__dditable.TracerExp.pfnSetPrologues)
+        self.zetTracerExpSetEpilogues = _zetTracerExpSetEpilogues_t(self.__dditable.TracerExp.pfnSetEpilogues)
+        self.zetTracerExpSetEnabled = _zetTracerExpSetEnabled_t(self.__dditable.TracerExp.pfnSetEnabled)
+
+        # call driver to get function pointers
+        _Debug = _zet_debug_dditable_t()
+        r = ze_result_v(self.__dll.zetGetDebugProcAddrTable(version, byref(_Debug)))
+        if r != ze_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.Debug = _Debug
+
+        # attach function interface to function address
+        self.zetDebugAttach = _zetDebugAttach_t(self.__dditable.Debug.pfnAttach)
+        self.zetDebugDetach = _zetDebugDetach_t(self.__dditable.Debug.pfnDetach)
+        self.zetDebugReadEvent = _zetDebugReadEvent_t(self.__dditable.Debug.pfnReadEvent)
+        self.zetDebugAcknowledgeEvent = _zetDebugAcknowledgeEvent_t(self.__dditable.Debug.pfnAcknowledgeEvent)
+        self.zetDebugInterrupt = _zetDebugInterrupt_t(self.__dditable.Debug.pfnInterrupt)
+        self.zetDebugResume = _zetDebugResume_t(self.__dditable.Debug.pfnResume)
+        self.zetDebugReadMemory = _zetDebugReadMemory_t(self.__dditable.Debug.pfnReadMemory)
+        self.zetDebugWriteMemory = _zetDebugWriteMemory_t(self.__dditable.Debug.pfnWriteMemory)
+        self.zetDebugGetRegisterSetProperties = _zetDebugGetRegisterSetProperties_t(self.__dditable.Debug.pfnGetRegisterSetProperties)
+        self.zetDebugReadRegisters = _zetDebugReadRegisters_t(self.__dditable.Debug.pfnReadRegisters)
+        self.zetDebugWriteRegisters = _zetDebugWriteRegisters_t(self.__dditable.Debug.pfnWriteRegisters)
+        self.zetDebugGetThreadRegisterSetProperties = _zetDebugGetThreadRegisterSetProperties_t(self.__dditable.Debug.pfnGetThreadRegisterSetProperties)
+
+        # success!

--- a/include/level_zero/zet_api.h
+++ b/include/level_zero/zet_api.h
@@ -1,0 +1,3269 @@
+/*
+ *
+ * Copyright (C) 2019-2021 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file zet_api.h
+ * @version v1.12-r1.12.15
+ *
+ */
+#ifndef _ZET_API_H
+#define _ZET_API_H
+#if defined(__cplusplus)
+#pragma once
+#endif
+
+// 'core' API headers
+#include "ze_api.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+// Intel 'oneAPI' Level-Zero Tool API common types
+#if !defined(__GNUC__)
+#pragma region common
+#endif
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle to a driver instance
+typedef ze_driver_handle_t zet_driver_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle of device object
+typedef ze_device_handle_t zet_device_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle of context object
+typedef ze_context_handle_t zet_context_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle of command list object
+typedef ze_command_list_handle_t zet_command_list_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle of module object
+typedef ze_module_handle_t zet_module_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle of function object
+typedef ze_kernel_handle_t zet_kernel_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle of metric group's object
+typedef struct _zet_metric_group_handle_t *zet_metric_group_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle of metric's object
+typedef struct _zet_metric_handle_t *zet_metric_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle of metric streamer's object
+typedef struct _zet_metric_streamer_handle_t *zet_metric_streamer_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle of metric query pool's object
+typedef struct _zet_metric_query_pool_handle_t *zet_metric_query_pool_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle of metric query's object
+typedef struct _zet_metric_query_handle_t *zet_metric_query_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle of tracer object
+typedef struct _zet_tracer_exp_handle_t *zet_tracer_exp_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Debug session handle
+typedef struct _zet_debug_session_handle_t *zet_debug_session_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Defines structure types
+typedef enum _zet_structure_type_t
+{
+    ZET_STRUCTURE_TYPE_METRIC_GROUP_PROPERTIES = 0x1,                       ///< ::zet_metric_group_properties_t
+    ZET_STRUCTURE_TYPE_METRIC_PROPERTIES = 0x2,                             ///< ::zet_metric_properties_t
+    ZET_STRUCTURE_TYPE_METRIC_STREAMER_DESC = 0x3,                          ///< ::zet_metric_streamer_desc_t
+    ZET_STRUCTURE_TYPE_METRIC_QUERY_POOL_DESC = 0x4,                        ///< ::zet_metric_query_pool_desc_t
+    ZET_STRUCTURE_TYPE_PROFILE_PROPERTIES = 0x5,                            ///< ::zet_profile_properties_t
+    ZET_STRUCTURE_TYPE_DEVICE_DEBUG_PROPERTIES = 0x6,                       ///< ::zet_device_debug_properties_t
+    ZET_STRUCTURE_TYPE_DEBUG_MEMORY_SPACE_DESC = 0x7,                       ///< ::zet_debug_memory_space_desc_t
+    ZET_STRUCTURE_TYPE_DEBUG_REGSET_PROPERTIES = 0x8,                       ///< ::zet_debug_regset_properties_t
+    ZET_STRUCTURE_TYPE_GLOBAL_METRICS_TIMESTAMPS_EXP_PROPERTIES = 0x9,      ///< ::zet_metric_global_timestamps_resolution_exp_t. Deprecated, use
+                                                                            ///< ::ZET_STRUCTURE_TYPE_METRIC_GLOBAL_TIMESTAMPS_RESOLUTION_EXP.
+    ZET_STRUCTURE_TYPE_METRIC_GLOBAL_TIMESTAMPS_RESOLUTION_EXP = 0x9,       ///< ::zet_metric_global_timestamps_resolution_exp_t
+    ZET_STRUCTURE_TYPE_TRACER_EXP_DESC = 0x00010001,                        ///< ::zet_tracer_exp_desc_t
+    ZET_STRUCTURE_TYPE_METRICS_CALCULATE_EXP_DESC = 0x00010002,             ///< ::zet_metric_calculate_exp_desc_t. Deprecated, use
+                                                                            ///< ::ZET_STRUCTURE_TYPE_METRIC_CALCULATE_EXP_DESC.
+    ZET_STRUCTURE_TYPE_METRIC_CALCULATE_EXP_DESC = 0x00010002,              ///< ::zet_metric_calculate_exp_desc_t
+    ZET_STRUCTURE_TYPE_METRIC_PROGRAMMABLE_EXP_PROPERTIES = 0x00010003,     ///< ::zet_metric_programmable_exp_properties_t
+    ZET_STRUCTURE_TYPE_METRIC_PROGRAMMABLE_PARAM_INFO_EXP = 0x00010004,     ///< ::zet_metric_programmable_param_info_exp_t
+    ZET_STRUCTURE_TYPE_METRIC_PROGRAMMABLE_PARAM_VALUE_INFO_EXP = 0x00010005,   ///< ::zet_metric_programmable_param_value_info_exp_t
+    ZET_STRUCTURE_TYPE_METRIC_GROUP_TYPE_EXP = 0x00010006,                  ///< ::zet_metric_group_type_exp_t
+    ZET_STRUCTURE_TYPE_EXPORT_DMA_EXP_PROPERTIES = 0x00010007,              ///< ::zet_export_dma_buf_exp_properties_t
+    ZET_STRUCTURE_TYPE_METRIC_TRACER_EXP_DESC = 0x00010008,                 ///< ::zet_metric_tracer_exp_desc_t
+    ZET_STRUCTURE_TYPE_FORCE_UINT32 = 0x7fffffff
+
+} zet_structure_type_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Base for all properties types
+typedef struct _zet_base_properties_t
+{
+    zet_structure_type_t stype;                                             ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+
+} zet_base_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Base for all descriptor types
+typedef struct _zet_base_desc_t
+{
+    zet_structure_type_t stype;                                             ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+
+} zet_base_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported value types
+typedef enum _zet_value_type_t
+{
+    ZET_VALUE_TYPE_UINT32 = 0,                                              ///< 32-bit unsigned-integer
+    ZET_VALUE_TYPE_UINT64 = 1,                                              ///< 64-bit unsigned-integer
+    ZET_VALUE_TYPE_FLOAT32 = 2,                                             ///< 32-bit floating-point
+    ZET_VALUE_TYPE_FLOAT64 = 3,                                             ///< 64-bit floating-point
+    ZET_VALUE_TYPE_BOOL8 = 4,                                               ///< 8-bit boolean
+    ZET_VALUE_TYPE_STRING = 5,                                              ///< C string
+    ZET_VALUE_TYPE_UINT8 = 6,                                               ///< 8-bit unsigned-integer
+    ZET_VALUE_TYPE_UINT16 = 7,                                              ///< 16-bit unsigned-integer
+    ZET_VALUE_TYPE_FORCE_UINT32 = 0x7fffffff
+
+} zet_value_type_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Union of values
+typedef union _zet_value_t
+{
+    uint32_t ui32;                                                          ///< [out] 32-bit unsigned-integer
+    uint64_t ui64;                                                          ///< [out] 64-bit unsigned-integer
+    float fp32;                                                             ///< [out] 32-bit floating-point
+    double fp64;                                                            ///< [out] 64-bit floating-point
+    ze_bool_t b8;                                                           ///< [out] 8-bit boolean
+
+} zet_value_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Typed value
+typedef struct _zet_typed_value_t
+{
+    zet_value_type_t type;                                                  ///< [out] type of value
+    zet_value_t value;                                                      ///< [out] value
+
+} zet_typed_value_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Enables driver instrumentation and dependencies for device metrics
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Enables driver instrumentation and dependencies for program
+///        instrumentation
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Enables driver instrumentation and dependencies for program debugging
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zet_base_properties_t
+typedef struct _zet_base_properties_t zet_base_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zet_base_desc_t
+typedef struct _zet_base_desc_t zet_base_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zet_typed_value_t
+typedef struct _zet_typed_value_t zet_typed_value_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zet_device_debug_properties_t
+typedef struct _zet_device_debug_properties_t zet_device_debug_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zet_debug_config_t
+typedef struct _zet_debug_config_t zet_debug_config_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zet_debug_event_info_detached_t
+typedef struct _zet_debug_event_info_detached_t zet_debug_event_info_detached_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zet_debug_event_info_module_t
+typedef struct _zet_debug_event_info_module_t zet_debug_event_info_module_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zet_debug_event_info_thread_stopped_t
+typedef struct _zet_debug_event_info_thread_stopped_t zet_debug_event_info_thread_stopped_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zet_debug_event_info_page_fault_t
+typedef struct _zet_debug_event_info_page_fault_t zet_debug_event_info_page_fault_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zet_debug_event_t
+typedef struct _zet_debug_event_t zet_debug_event_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zet_debug_memory_space_desc_t
+typedef struct _zet_debug_memory_space_desc_t zet_debug_memory_space_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zet_debug_regset_properties_t
+typedef struct _zet_debug_regset_properties_t zet_debug_regset_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zet_metric_group_properties_t
+typedef struct _zet_metric_group_properties_t zet_metric_group_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zet_metric_properties_t
+typedef struct _zet_metric_properties_t zet_metric_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zet_metric_streamer_desc_t
+typedef struct _zet_metric_streamer_desc_t zet_metric_streamer_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zet_metric_query_pool_desc_t
+typedef struct _zet_metric_query_pool_desc_t zet_metric_query_pool_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zet_profile_properties_t
+typedef struct _zet_profile_properties_t zet_profile_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zet_profile_free_register_token_t
+typedef struct _zet_profile_free_register_token_t zet_profile_free_register_token_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zet_profile_register_sequence_t
+typedef struct _zet_profile_register_sequence_t zet_profile_register_sequence_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zet_tracer_exp_desc_t
+typedef struct _zet_tracer_exp_desc_t zet_tracer_exp_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zet_metric_tracer_exp_desc_t
+typedef struct _zet_metric_tracer_exp_desc_t zet_metric_tracer_exp_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zet_metric_entry_exp_t
+typedef struct _zet_metric_entry_exp_t zet_metric_entry_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zet_metric_group_type_exp_t
+typedef struct _zet_metric_group_type_exp_t zet_metric_group_type_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zet_export_dma_buf_exp_properties_t
+typedef struct _zet_export_dma_buf_exp_properties_t zet_export_dma_buf_exp_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zet_metric_global_timestamps_resolution_exp_t
+typedef struct _zet_metric_global_timestamps_resolution_exp_t zet_metric_global_timestamps_resolution_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zet_metric_calculate_exp_desc_t
+typedef struct _zet_metric_calculate_exp_desc_t zet_metric_calculate_exp_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zet_metric_programmable_exp_properties_t
+typedef struct _zet_metric_programmable_exp_properties_t zet_metric_programmable_exp_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zet_value_uint64_range_exp_t
+typedef struct _zet_value_uint64_range_exp_t zet_value_uint64_range_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zet_value_fp64_range_exp_t
+typedef struct _zet_value_fp64_range_exp_t zet_value_fp64_range_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zet_metric_programmable_param_info_exp_t
+typedef struct _zet_metric_programmable_param_info_exp_t zet_metric_programmable_param_info_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zet_metric_programmable_param_value_info_exp_t
+typedef struct _zet_metric_programmable_param_value_info_exp_t zet_metric_programmable_param_value_info_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Forward-declare zet_metric_programmable_param_value_exp_t
+typedef struct _zet_metric_programmable_param_value_exp_t zet_metric_programmable_param_value_exp_t;
+
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Tool APIs for Device
+#if !defined(__GNUC__)
+#pragma region device
+#endif
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Tool APIs for Context
+#if !defined(__GNUC__)
+#pragma region context
+#endif
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Tool APIs for Command List
+#if !defined(__GNUC__)
+#pragma region cmdlist
+#endif
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Tool APIs for Module
+#if !defined(__GNUC__)
+#pragma region module
+#endif
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported module debug info formats.
+typedef enum _zet_module_debug_info_format_t
+{
+    ZET_MODULE_DEBUG_INFO_FORMAT_ELF_DWARF = 0,                             ///< Format is ELF/DWARF
+    ZET_MODULE_DEBUG_INFO_FORMAT_FORCE_UINT32 = 0x7fffffff
+
+} zet_module_debug_info_format_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieve debug info from module.
+/// 
+/// @details
+///     - The caller can pass nullptr for pDebugInfo when querying only for
+///       size.
+///     - The implementation will copy the native binary into a buffer supplied
+///       by the caller.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hModule`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::ZET_MODULE_DEBUG_INFO_FORMAT_ELF_DWARF < format`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pSize`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetModuleGetDebugInfo(
+    zet_module_handle_t hModule,                                            ///< [in] handle of the module
+    zet_module_debug_info_format_t format,                                  ///< [in] debug info format requested
+    size_t* pSize,                                                          ///< [in,out] size of debug info in bytes
+    uint8_t* pDebugInfo                                                     ///< [in,out][optional] byte pointer to debug info
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Tool APIs for Program Debug
+#if !defined(__GNUC__)
+#pragma region debug
+#endif
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported device debug property flags
+typedef uint32_t zet_device_debug_property_flags_t;
+typedef enum _zet_device_debug_property_flag_t
+{
+    ZET_DEVICE_DEBUG_PROPERTY_FLAG_ATTACH = ZE_BIT(0),                      ///< the device supports attaching for debug
+    ZET_DEVICE_DEBUG_PROPERTY_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} zet_device_debug_property_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Device debug properties queried using ::zetDeviceGetDebugProperties.
+typedef struct _zet_device_debug_properties_t
+{
+    zet_structure_type_t stype;                                             ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    zet_device_debug_property_flags_t flags;                                ///< [out] returns 0 (none) or a valid combination of
+                                                                            ///< ::zet_device_debug_property_flag_t
+
+} zet_device_debug_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves debug properties of the device.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pDebugProperties`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetDeviceGetDebugProperties(
+    zet_device_handle_t hDevice,                                            ///< [in] device handle
+    zet_device_debug_properties_t* pDebugProperties                         ///< [in,out] query result for debug properties
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Debug configuration provided to ::zetDebugAttach
+typedef struct _zet_debug_config_t
+{
+    uint32_t pid;                                                           ///< [in] the host process identifier
+
+} zet_debug_config_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Attach to a device.
+/// 
+/// @details
+///     - The device must be enabled for debug; see
+///       ::zesSchedulerSetComputeUnitDebugMode.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == config`
+///         + `nullptr == phDebug`
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + attaching to this device is not supported
+///     - ::ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS
+///         + caller does not have sufficient permissions
+///     - ::ZE_RESULT_ERROR_NOT_AVAILABLE
+///         + a debugger is already attached
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetDebugAttach(
+    zet_device_handle_t hDevice,                                            ///< [in] device handle
+    const zet_debug_config_t* config,                                       ///< [in] the debug configuration
+    zet_debug_session_handle_t* phDebug                                     ///< [out] debug session handle
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Close a debug session.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDebug`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetDebugDetach(
+    zet_debug_session_handle_t hDebug                                       ///< [in][release] debug session handle
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported debug event flags.
+typedef uint32_t zet_debug_event_flags_t;
+typedef enum _zet_debug_event_flag_t
+{
+    ZET_DEBUG_EVENT_FLAG_NEED_ACK = ZE_BIT(0),                              ///< The event needs to be acknowledged by calling
+                                                                            ///< ::zetDebugAcknowledgeEvent.
+    ZET_DEBUG_EVENT_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} zet_debug_event_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported debug event types.
+typedef enum _zet_debug_event_type_t
+{
+    ZET_DEBUG_EVENT_TYPE_INVALID = 0,                                       ///< The event is invalid
+    ZET_DEBUG_EVENT_TYPE_DETACHED = 1,                                      ///< The tool was detached
+    ZET_DEBUG_EVENT_TYPE_PROCESS_ENTRY = 2,                                 ///< The debuggee process created command queues on the device
+    ZET_DEBUG_EVENT_TYPE_PROCESS_EXIT = 3,                                  ///< The debuggee process destroyed all command queues on the device
+    ZET_DEBUG_EVENT_TYPE_MODULE_LOAD = 4,                                   ///< An in-memory module was loaded onto the device
+    ZET_DEBUG_EVENT_TYPE_MODULE_UNLOAD = 5,                                 ///< An in-memory module is about to get unloaded from the device
+    ZET_DEBUG_EVENT_TYPE_THREAD_STOPPED = 6,                                ///< The thread stopped due to a device exception
+    ZET_DEBUG_EVENT_TYPE_THREAD_UNAVAILABLE = 7,                            ///< The thread is not available to be stopped
+    ZET_DEBUG_EVENT_TYPE_PAGE_FAULT = 8,                                    ///< A page request could not be completed on the device
+    ZET_DEBUG_EVENT_TYPE_FORCE_UINT32 = 0x7fffffff
+
+} zet_debug_event_type_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported debug detach reasons.
+typedef enum _zet_debug_detach_reason_t
+{
+    ZET_DEBUG_DETACH_REASON_INVALID = 0,                                    ///< The detach reason is not valid
+    ZET_DEBUG_DETACH_REASON_HOST_EXIT = 1,                                  ///< The host process exited
+    ZET_DEBUG_DETACH_REASON_FORCE_UINT32 = 0x7fffffff
+
+} zet_debug_detach_reason_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Event information for ::ZET_DEBUG_EVENT_TYPE_DETACHED
+typedef struct _zet_debug_event_info_detached_t
+{
+    zet_debug_detach_reason_t reason;                                       ///< [out] the detach reason
+
+} zet_debug_event_info_detached_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Event information for ::ZET_DEBUG_EVENT_TYPE_MODULE_LOAD and
+///        ::ZET_DEBUG_EVENT_TYPE_MODULE_UNLOAD
+typedef struct _zet_debug_event_info_module_t
+{
+    zet_module_debug_info_format_t format;                                  ///< [out] the module format
+    uint64_t moduleBegin;                                                   ///< [out] the begin address of the in-memory module (inclusive)
+    uint64_t moduleEnd;                                                     ///< [out] the end address of the in-memory module (exclusive)
+    uint64_t load;                                                          ///< [out] the load address of the module on the device
+
+} zet_debug_event_info_module_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Event information for ::ZET_DEBUG_EVENT_TYPE_THREAD_STOPPED and
+///        ::ZET_DEBUG_EVENT_TYPE_THREAD_UNAVAILABLE
+typedef struct _zet_debug_event_info_thread_stopped_t
+{
+    ze_device_thread_t thread;                                              ///< [out] the stopped/unavailable thread
+
+} zet_debug_event_info_thread_stopped_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Page fault reasons.
+typedef enum _zet_debug_page_fault_reason_t
+{
+    ZET_DEBUG_PAGE_FAULT_REASON_INVALID = 0,                                ///< The page fault reason is not valid
+    ZET_DEBUG_PAGE_FAULT_REASON_MAPPING_ERROR = 1,                          ///< The address is not mapped
+    ZET_DEBUG_PAGE_FAULT_REASON_PERMISSION_ERROR = 2,                       ///< Invalid access permissions
+    ZET_DEBUG_PAGE_FAULT_REASON_FORCE_UINT32 = 0x7fffffff
+
+} zet_debug_page_fault_reason_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Event information for ::ZET_DEBUG_EVENT_TYPE_PAGE_FAULT
+typedef struct _zet_debug_event_info_page_fault_t
+{
+    uint64_t address;                                                       ///< [out] the faulting address
+    uint64_t mask;                                                          ///< [out] the alignment mask
+    zet_debug_page_fault_reason_t reason;                                   ///< [out] the page fault reason
+
+} zet_debug_event_info_page_fault_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Event type-specific information
+typedef union _zet_debug_event_info_t
+{
+    zet_debug_event_info_detached_t detached;                               ///< [out] type == ::ZET_DEBUG_EVENT_TYPE_DETACHED
+    zet_debug_event_info_module_t module;                                   ///< [out] type == ::ZET_DEBUG_EVENT_TYPE_MODULE_LOAD or
+                                                                            ///< ::ZET_DEBUG_EVENT_TYPE_MODULE_UNLOAD
+    zet_debug_event_info_thread_stopped_t thread;                           ///< [out] type == ::ZET_DEBUG_EVENT_TYPE_THREAD_STOPPED or
+                                                                            ///< ::ZET_DEBUG_EVENT_TYPE_THREAD_UNAVAILABLE
+    zet_debug_event_info_page_fault_t page_fault;                           ///< [out] type == ::ZET_DEBUG_EVENT_TYPE_PAGE_FAULT
+
+} zet_debug_event_info_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief A debug event on the device.
+typedef struct _zet_debug_event_t
+{
+    zet_debug_event_type_t type;                                            ///< [out] the event type
+    zet_debug_event_flags_t flags;                                          ///< [out] returns 0 (none) or a combination of ::zet_debug_event_flag_t
+    zet_debug_event_info_t info;                                            ///< [out] event type specific information
+
+} zet_debug_event_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Read the topmost debug event.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDebug`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == event`
+///     - ::ZE_RESULT_NOT_READY
+///         + the timeout expired
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetDebugReadEvent(
+    zet_debug_session_handle_t hDebug,                                      ///< [in] debug session handle
+    uint64_t timeout,                                                       ///< [in] if non-zero, then indicates the maximum time (in milliseconds) to
+                                                                            ///< yield before returning ::ZE_RESULT_SUCCESS or ::ZE_RESULT_NOT_READY;
+                                                                            ///< if zero, then immediately returns the status of the event;
+                                                                            ///< if `UINT64_MAX`, then function will not return until complete or
+                                                                            ///< device is lost.
+                                                                            ///< Due to external dependencies, timeout may be rounded to the closest
+                                                                            ///< value allowed by the accuracy of those dependencies.
+    zet_debug_event_t* event                                                ///< [in,out] a pointer to a ::zet_debug_event_t.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Acknowledge a debug event.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDebug`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == event`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetDebugAcknowledgeEvent(
+    zet_debug_session_handle_t hDebug,                                      ///< [in] debug session handle
+    const zet_debug_event_t* event                                          ///< [in] a pointer to a ::zet_debug_event_t.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Interrupt device threads.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDebug`
+///     - ::ZE_RESULT_ERROR_NOT_AVAILABLE
+///         + the thread is already stopped or unavailable
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetDebugInterrupt(
+    zet_debug_session_handle_t hDebug,                                      ///< [in] debug session handle
+    ze_device_thread_t thread                                               ///< [in] the thread to interrupt
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Resume device threads.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDebug`
+///     - ::ZE_RESULT_ERROR_NOT_AVAILABLE
+///         + the thread is already running or unavailable
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetDebugResume(
+    zet_debug_session_handle_t hDebug,                                      ///< [in] debug session handle
+    ze_device_thread_t thread                                               ///< [in] the thread to resume
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported device memory space types.
+typedef enum _zet_debug_memory_space_type_t
+{
+    ZET_DEBUG_MEMORY_SPACE_TYPE_DEFAULT = 0,                                ///< default memory space (attribute may be omitted)
+    ZET_DEBUG_MEMORY_SPACE_TYPE_SLM = 1,                                    ///< shared local memory space (GPU-only)
+    ZET_DEBUG_MEMORY_SPACE_TYPE_ELF = 2,                                    ///< ELF file memory space
+    ZET_DEBUG_MEMORY_SPACE_TYPE_FORCE_UINT32 = 0x7fffffff
+
+} zet_debug_memory_space_type_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Device memory space descriptor
+typedef struct _zet_debug_memory_space_desc_t
+{
+    zet_structure_type_t stype;                                             ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    zet_debug_memory_space_type_t type;                                     ///< [in] type of memory space
+    uint64_t address;                                                       ///< [in] the virtual address within the memory space
+
+} zet_debug_memory_space_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Read memory.
+/// 
+/// @details
+///     - The thread identifier 'all' can be used for accessing the default
+///       memory space, e.g. for setting breakpoints.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDebug`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == desc`
+///         + `nullptr == buffer`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::ZET_DEBUG_MEMORY_SPACE_TYPE_ELF < desc->type`
+///     - ::ZE_RESULT_ERROR_NOT_AVAILABLE
+///         + the thread is running or unavailable
+///         + the memory cannot be accessed from the supplied thread
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetDebugReadMemory(
+    zet_debug_session_handle_t hDebug,                                      ///< [in] debug session handle
+    ze_device_thread_t thread,                                              ///< [in] the thread identifier.
+    const zet_debug_memory_space_desc_t* desc,                              ///< [in] memory space descriptor
+    size_t size,                                                            ///< [in] the number of bytes to read
+    void* buffer                                                            ///< [in,out] a buffer to hold a copy of the memory
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Write memory.
+/// 
+/// @details
+///     - The thread identifier 'all' can be used for accessing the default
+///       memory space, e.g. for setting breakpoints.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDebug`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == desc`
+///         + `nullptr == buffer`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::ZET_DEBUG_MEMORY_SPACE_TYPE_ELF < desc->type`
+///     - ::ZE_RESULT_ERROR_NOT_AVAILABLE
+///         + the thread is running or unavailable
+///         + the memory cannot be accessed from the supplied thread
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetDebugWriteMemory(
+    zet_debug_session_handle_t hDebug,                                      ///< [in] debug session handle
+    ze_device_thread_t thread,                                              ///< [in] the thread identifier.
+    const zet_debug_memory_space_desc_t* desc,                              ///< [in] memory space descriptor
+    size_t size,                                                            ///< [in] the number of bytes to write
+    const void* buffer                                                      ///< [in] a buffer holding the pattern to write
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported general register set flags.
+typedef uint32_t zet_debug_regset_flags_t;
+typedef enum _zet_debug_regset_flag_t
+{
+    ZET_DEBUG_REGSET_FLAG_READABLE = ZE_BIT(0),                             ///< register set is readable
+    ZET_DEBUG_REGSET_FLAG_WRITEABLE = ZE_BIT(1),                            ///< register set is writeable
+    ZET_DEBUG_REGSET_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} zet_debug_regset_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Device register set properties queried using
+///        ::zetDebugGetRegisterSetProperties.
+typedef struct _zet_debug_regset_properties_t
+{
+    zet_structure_type_t stype;                                             ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    uint32_t type;                                                          ///< [out] device-specific register set type
+    uint32_t version;                                                       ///< [out] device-specific version of this register set
+    zet_debug_regset_flags_t generalFlags;                                  ///< [out] general register set flags
+    uint32_t deviceFlags;                                                   ///< [out] device-specific register set flags
+    uint32_t count;                                                         ///< [out] number of registers in the set
+    uint32_t bitSize;                                                       ///< [out] the size of a register in bits
+    uint32_t byteSize;                                                      ///< [out] the size required for reading or writing a register in bytes
+
+} zet_debug_regset_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves debug register set properties.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetDebugGetRegisterSetProperties(
+    zet_device_handle_t hDevice,                                            ///< [in] device handle
+    uint32_t* pCount,                                                       ///< [in,out] pointer to the number of register set properties.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of register set properties available.
+                                                                            ///< if count is greater than the number of register set properties
+                                                                            ///< available, then the driver shall update the value with the correct
+                                                                            ///< number of registry set properties available.
+    zet_debug_regset_properties_t* pRegisterSetProperties                   ///< [in,out][optional][range(0, *pCount)] array of query results for
+                                                                            ///< register set properties.
+                                                                            ///< if count is less than the number of register set properties available,
+                                                                            ///< then driver shall only retrieve that number of register set properties.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves debug register set properties for a given thread.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDebug`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+///     - ::ZE_RESULT_ERROR_NOT_AVAILABLE
+///         + the thread is running or unavailable
+///     - ::ZE_RESULT_ERROR_INVALID_ARGUMENT
+///         + the thread argument specifies more than one or a non-existant thread
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetDebugGetThreadRegisterSetProperties(
+    zet_debug_session_handle_t hDebug,                                      ///< [in] debug session handle
+    ze_device_thread_t thread,                                              ///< [in] the thread identifier specifying a single stopped thread
+    uint32_t* pCount,                                                       ///< [in,out] pointer to the number of register set properties.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of register set properties available.
+                                                                            ///< if count is greater than the number of register set properties
+                                                                            ///< available, then the driver shall update the value with the correct
+                                                                            ///< number of registry set properties available.
+    zet_debug_regset_properties_t* pRegisterSetProperties                   ///< [in,out][optional][range(0, *pCount)] array of query results for
+                                                                            ///< register set properties.
+                                                                            ///< if count is less than the number of register set properties available,
+                                                                            ///< then driver shall only retrieve that number of register set properties.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Read register state.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDebug`
+///     - ::ZE_RESULT_ERROR_NOT_AVAILABLE
+///         + the thread is running or unavailable
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetDebugReadRegisters(
+    zet_debug_session_handle_t hDebug,                                      ///< [in] debug session handle
+    ze_device_thread_t thread,                                              ///< [in] the thread identifier
+    uint32_t type,                                                          ///< [in] register set type
+    uint32_t start,                                                         ///< [in] the starting offset into the register state area; must be less
+                                                                            ///< than the `count` member of ::zet_debug_regset_properties_t for the
+                                                                            ///< type
+    uint32_t count,                                                         ///< [in] the number of registers to read; start+count must be less than or
+                                                                            ///< equal to the `count` member of ::zet_debug_register_group_properties_t
+                                                                            ///< for the type
+    void* pRegisterValues                                                   ///< [in,out][optional][range(0, count)] buffer of register values
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Write register state.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDebug`
+///     - ::ZE_RESULT_ERROR_NOT_AVAILABLE
+///         + the thread is running or unavailable
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetDebugWriteRegisters(
+    zet_debug_session_handle_t hDebug,                                      ///< [in] debug session handle
+    ze_device_thread_t thread,                                              ///< [in] the thread identifier
+    uint32_t type,                                                          ///< [in] register set type
+    uint32_t start,                                                         ///< [in] the starting offset into the register state area; must be less
+                                                                            ///< than the `count` member of ::zet_debug_regset_properties_t for the
+                                                                            ///< type
+    uint32_t count,                                                         ///< [in] the number of registers to write; start+count must be less than
+                                                                            ///< or equal to the `count` member of
+                                                                            ///< ::zet_debug_register_group_properties_t for the type
+    void* pRegisterValues                                                   ///< [in,out][optional][range(0, count)] buffer of register values
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Tool APIs for Metric
+#if !defined(__GNUC__)
+#pragma region metric
+#endif
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves metric group for a device.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetMetricGroupGet(
+    zet_device_handle_t hDevice,                                            ///< [in] handle of the device
+    uint32_t* pCount,                                                       ///< [in,out] pointer to the number of metric groups.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of metric groups available.
+                                                                            ///< if count is greater than the number of metric groups available, then
+                                                                            ///< the driver shall update the value with the correct number of metric
+                                                                            ///< groups available.
+    zet_metric_group_handle_t* phMetricGroups                               ///< [in,out][optional][range(0, *pCount)] array of handle of metric groups.
+                                                                            ///< if count is less than the number of metric groups available, then
+                                                                            ///< driver shall only retrieve that number of metric groups.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZET_MAX_METRIC_GROUP_NAME
+/// @brief Maximum metric group name string size
+#define ZET_MAX_METRIC_GROUP_NAME  256
+#endif // ZET_MAX_METRIC_GROUP_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZET_MAX_METRIC_GROUP_DESCRIPTION
+/// @brief Maximum metric group description string size
+#define ZET_MAX_METRIC_GROUP_DESCRIPTION  256
+#endif // ZET_MAX_METRIC_GROUP_DESCRIPTION
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Metric group sampling type
+typedef uint32_t zet_metric_group_sampling_type_flags_t;
+typedef enum _zet_metric_group_sampling_type_flag_t
+{
+    ZET_METRIC_GROUP_SAMPLING_TYPE_FLAG_EVENT_BASED = ZE_BIT(0),            ///< Event based sampling
+    ZET_METRIC_GROUP_SAMPLING_TYPE_FLAG_TIME_BASED = ZE_BIT(1),             ///< Time based sampling
+    ZET_METRIC_GROUP_SAMPLING_TYPE_FLAG_EXP_TRACER_BASED = ZE_BIT(2),       ///< Experimental Tracer based sampling
+    ZET_METRIC_GROUP_SAMPLING_TYPE_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} zet_metric_group_sampling_type_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Metric group properties queried using ::zetMetricGroupGetProperties
+typedef struct _zet_metric_group_properties_t
+{
+    zet_structure_type_t stype;                                             ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    char name[ZET_MAX_METRIC_GROUP_NAME];                                   ///< [out] metric group name
+    char description[ZET_MAX_METRIC_GROUP_DESCRIPTION];                     ///< [out] metric group description
+    zet_metric_group_sampling_type_flags_t samplingType;                    ///< [out] metric group sampling type.
+                                                                            ///< returns a combination of ::zet_metric_group_sampling_type_flag_t.
+    uint32_t domain;                                                        ///< [out] metric group domain number. Cannot use multiple, simultaneous
+                                                                            ///< metric groups from the same domain.
+    uint32_t metricCount;                                                   ///< [out] metric count belonging to this group
+
+} zet_metric_group_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves attributes of a metric group.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hMetricGroup`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pProperties`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetMetricGroupGetProperties(
+    zet_metric_group_handle_t hMetricGroup,                                 ///< [in] handle of the metric group
+    zet_metric_group_properties_t* pProperties                              ///< [in,out] metric group properties
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Metric types
+typedef enum _zet_metric_type_t
+{
+    ZET_METRIC_TYPE_DURATION = 0,                                           ///< Metric type: duration
+    ZET_METRIC_TYPE_EVENT = 1,                                              ///< Metric type: event
+    ZET_METRIC_TYPE_EVENT_WITH_RANGE = 2,                                   ///< Metric type: event with range
+    ZET_METRIC_TYPE_THROUGHPUT = 3,                                         ///< Metric type: throughput
+    ZET_METRIC_TYPE_TIMESTAMP = 4,                                          ///< Metric type: timestamp
+    ZET_METRIC_TYPE_FLAG = 5,                                               ///< Metric type: flag
+    ZET_METRIC_TYPE_RATIO = 6,                                              ///< Metric type: ratio
+    ZET_METRIC_TYPE_RAW = 7,                                                ///< Metric type: raw
+    ZET_METRIC_TYPE_EVENT_EXP_TIMESTAMP = 0x7ffffff9,                       ///< Metric type: event with only timestamp and value has no meaning
+    ZET_METRIC_TYPE_EVENT_EXP_START = 0x7ffffffa,                           ///< Metric type: the first event of a start/end event pair
+    ZET_METRIC_TYPE_EVENT_EXP_END = 0x7ffffffb,                             ///< Metric type: the second event of a start/end event pair
+    ZET_METRIC_TYPE_EVENT_EXP_MONOTONIC_WRAPS_VALUE = 0x7ffffffc,           ///< Metric type: value of the event is a monotonically increasing value
+                                                                            ///< that can wrap around
+    ZET_METRIC_TYPE_EXP_EXPORT_DMA_BUF = 0x7ffffffd,                        ///< Metric which exports linux dma_buf, which could be imported/mapped to
+                                                                            ///< the host process
+    ZET_METRIC_TYPE_IP_EXP = 0x7ffffffe,                                    ///< Metric type: instruction pointer. Deprecated, use
+                                                                            ///< ::ZET_METRIC_TYPE_IP.
+    ZET_METRIC_TYPE_IP = 0x7ffffffe,                                        ///< Metric type: instruction pointer
+    ZET_METRIC_TYPE_FORCE_UINT32 = 0x7fffffff
+
+} zet_metric_type_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Metric group calculation type
+typedef enum _zet_metric_group_calculation_type_t
+{
+    ZET_METRIC_GROUP_CALCULATION_TYPE_METRIC_VALUES = 0,                    ///< Calculated metric values from raw data.
+    ZET_METRIC_GROUP_CALCULATION_TYPE_MAX_METRIC_VALUES = 1,                ///< Maximum metric values.
+    ZET_METRIC_GROUP_CALCULATION_TYPE_FORCE_UINT32 = 0x7fffffff
+
+} zet_metric_group_calculation_type_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Calculates metric values from raw data.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hMetricGroup`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::ZET_METRIC_GROUP_CALCULATION_TYPE_MAX_METRIC_VALUES < type`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pRawData`
+///         + `nullptr == pMetricValueCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetMetricGroupCalculateMetricValues(
+    zet_metric_group_handle_t hMetricGroup,                                 ///< [in] handle of the metric group
+    zet_metric_group_calculation_type_t type,                               ///< [in] calculation type to be applied on raw data
+    size_t rawDataSize,                                                     ///< [in] size in bytes of raw data buffer
+    const uint8_t* pRawData,                                                ///< [in][range(0, rawDataSize)] buffer of raw data to calculate
+    uint32_t* pMetricValueCount,                                            ///< [in,out] pointer to number of metric values calculated.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of metric values to be calculated.
+                                                                            ///< if count is greater than the number available in the raw data buffer,
+                                                                            ///< then the driver shall update the value with the actual number of
+                                                                            ///< metric values to be calculated.
+    zet_typed_value_t* pMetricValues                                        ///< [in,out][optional][range(0, *pMetricValueCount)] buffer of calculated metrics.
+                                                                            ///< if count is less than the number available in the raw data buffer,
+                                                                            ///< then driver shall only calculate that number of metric values.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves metric from a metric group.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hMetricGroup`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetMetricGet(
+    zet_metric_group_handle_t hMetricGroup,                                 ///< [in] handle of the metric group
+    uint32_t* pCount,                                                       ///< [in,out] pointer to the number of metrics.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of metrics available.
+                                                                            ///< if count is greater than the number of metrics available, then the
+                                                                            ///< driver shall update the value with the correct number of metrics available.
+    zet_metric_handle_t* phMetrics                                          ///< [in,out][optional][range(0, *pCount)] array of handle of metrics.
+                                                                            ///< if count is less than the number of metrics available, then driver
+                                                                            ///< shall only retrieve that number of metrics.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZET_MAX_METRIC_NAME
+/// @brief Maximum metric name string size
+#define ZET_MAX_METRIC_NAME  256
+#endif // ZET_MAX_METRIC_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZET_MAX_METRIC_DESCRIPTION
+/// @brief Maximum metric description string size
+#define ZET_MAX_METRIC_DESCRIPTION  256
+#endif // ZET_MAX_METRIC_DESCRIPTION
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZET_MAX_METRIC_COMPONENT
+/// @brief Maximum metric component string size
+#define ZET_MAX_METRIC_COMPONENT  256
+#endif // ZET_MAX_METRIC_COMPONENT
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZET_MAX_METRIC_RESULT_UNITS
+/// @brief Maximum metric result units string size
+#define ZET_MAX_METRIC_RESULT_UNITS  256
+#endif // ZET_MAX_METRIC_RESULT_UNITS
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Metric properties queried using ::zetMetricGetProperties
+typedef struct _zet_metric_properties_t
+{
+    zet_structure_type_t stype;                                             ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    char name[ZET_MAX_METRIC_NAME];                                         ///< [out] metric name
+    char description[ZET_MAX_METRIC_DESCRIPTION];                           ///< [out] metric description
+    char component[ZET_MAX_METRIC_COMPONENT];                               ///< [out] metric component
+    uint32_t tierNumber;                                                    ///< [out] number of tier
+    zet_metric_type_t metricType;                                           ///< [out] metric type
+    zet_value_type_t resultType;                                            ///< [out] metric result type
+    char resultUnits[ZET_MAX_METRIC_RESULT_UNITS];                          ///< [out] metric result units
+
+} zet_metric_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves attributes of a metric.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hMetric`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pProperties`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetMetricGetProperties(
+    zet_metric_handle_t hMetric,                                            ///< [in] handle of the metric
+    zet_metric_properties_t* pProperties                                    ///< [in,out] metric properties
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Activates metric groups.
+/// 
+/// @details
+///     - Immediately reconfigures the device to activate only those metric
+///       groups provided.
+///     - Any metric groups previously activated but not provided will be
+///       deactivated.
+///     - Deactivating metric groups that are still in-use will result in
+///       undefined behavior.
+///     - All metric groups must have different domains, see
+///       ::zet_metric_group_properties_t.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same device handle.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_SIZE
+///         + `(nullptr == phMetricGroups) && (0 < count)`
+///     - ::ZE_RESULT_ERROR_INVALID_ARGUMENT
+///         + Multiple metric groups share the same domain
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetContextActivateMetricGroups(
+    zet_context_handle_t hContext,                                          ///< [in] handle of the context object
+    zet_device_handle_t hDevice,                                            ///< [in] handle of the device
+    uint32_t count,                                                         ///< [in] metric group count to activate; must be 0 if `nullptr ==
+                                                                            ///< phMetricGroups`
+    zet_metric_group_handle_t* phMetricGroups                               ///< [in][optional][range(0, count)] handles of the metric groups to activate.
+                                                                            ///< nullptr deactivates all previously used metric groups.
+                                                                            ///< all metrics groups must come from a different domains.
+                                                                            ///< metric query and metric stream must use activated metric groups.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Metric streamer descriptor
+typedef struct _zet_metric_streamer_desc_t
+{
+    zet_structure_type_t stype;                                             ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    uint32_t notifyEveryNReports;                                           ///< [in,out] number of collected reports after which notification event
+                                                                            ///< will be signaled. If the requested value is not supported exactly,
+                                                                            ///< then the driver may use a value that is the closest supported
+                                                                            ///< approximation and shall update this member during ::zetMetricStreamerOpen.
+    uint32_t samplingPeriod;                                                ///< [in,out] streamer sampling period in nanoseconds. If the requested
+                                                                            ///< value is not supported exactly, then the driver may use a value that
+                                                                            ///< is the closest supported approximation and shall update this member
+                                                                            ///< during ::zetMetricStreamerOpen.
+
+} zet_metric_streamer_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Opens metric streamer for a device.
+/// 
+/// @details
+///     - The notification event must have been created from an event pool that
+///       was created using ::ZE_EVENT_POOL_FLAG_HOST_VISIBLE flag.
+///     - The duration of the signal event created from an event pool that was
+///       created using ::ZE_EVENT_POOL_FLAG_KERNEL_TIMESTAMP flag is undefined.
+///       However, for consistency and orthogonality the event will report
+///       correctly as signaled when used by other event API functionality.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same device handle.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+///         + `nullptr == hDevice`
+///         + `nullptr == hMetricGroup`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == desc`
+///         + `nullptr == phMetricStreamer`
+///     - ::ZE_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetMetricStreamerOpen(
+    zet_context_handle_t hContext,                                          ///< [in] handle of the context object
+    zet_device_handle_t hDevice,                                            ///< [in] handle of the device
+    zet_metric_group_handle_t hMetricGroup,                                 ///< [in] handle of the metric group
+    zet_metric_streamer_desc_t* desc,                                       ///< [in,out] metric streamer descriptor
+    ze_event_handle_t hNotificationEvent,                                   ///< [in][optional] event used for report availability notification
+    zet_metric_streamer_handle_t* phMetricStreamer                          ///< [out] handle of metric streamer
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Append metric streamer marker into a command list.
+/// 
+/// @details
+///     - The application must ensure the metric streamer is accessible by the
+///       device on which the command list was created.
+///     - The application must ensure the command list and metric streamer were
+///       created on the same context.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same command list handle.
+///     - Allow to associate metric stream time based metrics with executed
+///       workload.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandList`
+///         + `nullptr == hMetricStreamer`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetCommandListAppendMetricStreamerMarker(
+    zet_command_list_handle_t hCommandList,                                 ///< [in] handle of the command list
+    zet_metric_streamer_handle_t hMetricStreamer,                           ///< [in] handle of the metric streamer
+    uint32_t value                                                          ///< [in] streamer marker value
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Closes metric streamer.
+/// 
+/// @details
+///     - The application must **not** call this function from simultaneous
+///       threads with the same metric streamer handle.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hMetricStreamer`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetMetricStreamerClose(
+    zet_metric_streamer_handle_t hMetricStreamer                            ///< [in][release] handle of the metric streamer
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Reads data from metric streamer.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hMetricStreamer`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pRawDataSize`
+///     - ::ZE_RESULT_WARNING_DROPPED_DATA
+///         + Metric streamer data may have been dropped. Reduce sampling period.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetMetricStreamerReadData(
+    zet_metric_streamer_handle_t hMetricStreamer,                           ///< [in] handle of the metric streamer
+    uint32_t maxReportCount,                                                ///< [in] the maximum number of reports the application wants to receive.
+                                                                            ///< if `UINT32_MAX`, then function will retrieve all reports available
+    size_t* pRawDataSize,                                                   ///< [in,out] pointer to size in bytes of raw data requested to read.
+                                                                            ///< if size is zero, then the driver will update the value with the total
+                                                                            ///< size in bytes needed for all reports available.
+                                                                            ///< if size is non-zero, then driver will only retrieve the number of
+                                                                            ///< reports that fit into the buffer.
+                                                                            ///< if size is larger than size needed for all reports, then driver will
+                                                                            ///< update the value with the actual size needed.
+    uint8_t* pRawData                                                       ///< [in,out][optional][range(0, *pRawDataSize)] buffer containing streamer
+                                                                            ///< reports in raw format
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Metric query pool types
+typedef enum _zet_metric_query_pool_type_t
+{
+    ZET_METRIC_QUERY_POOL_TYPE_PERFORMANCE = 0,                             ///< Performance metric query pool.
+    ZET_METRIC_QUERY_POOL_TYPE_EXECUTION = 1,                               ///< Skips workload execution between begin/end calls.
+    ZET_METRIC_QUERY_POOL_TYPE_FORCE_UINT32 = 0x7fffffff
+
+} zet_metric_query_pool_type_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Metric query pool description
+typedef struct _zet_metric_query_pool_desc_t
+{
+    zet_structure_type_t stype;                                             ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    zet_metric_query_pool_type_t type;                                      ///< [in] Query pool type.
+    uint32_t count;                                                         ///< [in] Internal slots count within query pool object.
+
+} zet_metric_query_pool_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Creates a pool of metric queries on the context.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+///         + `nullptr == hDevice`
+///         + `nullptr == hMetricGroup`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == desc`
+///         + `nullptr == phMetricQueryPool`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::ZET_METRIC_QUERY_POOL_TYPE_EXECUTION < desc->type`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetMetricQueryPoolCreate(
+    zet_context_handle_t hContext,                                          ///< [in] handle of the context object
+    zet_device_handle_t hDevice,                                            ///< [in] handle of the device
+    zet_metric_group_handle_t hMetricGroup,                                 ///< [in] metric group associated with the query object.
+    const zet_metric_query_pool_desc_t* desc,                               ///< [in] metric query pool descriptor
+    zet_metric_query_pool_handle_t* phMetricQueryPool                       ///< [out] handle of metric query pool
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Deletes a query pool object.
+/// 
+/// @details
+///     - The application must destroy all query handles created from the pool
+///       before destroying the pool itself.
+///     - The application must ensure the device is not currently referencing
+///       the any query within the pool before it is deleted.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same query pool handle.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hMetricQueryPool`
+///     - ::ZE_RESULT_ERROR_HANDLE_OBJECT_IN_USE
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetMetricQueryPoolDestroy(
+    zet_metric_query_pool_handle_t hMetricQueryPool                         ///< [in][release] handle of the metric query pool
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Creates metric query from the pool.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hMetricQueryPool`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == phMetricQuery`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetMetricQueryCreate(
+    zet_metric_query_pool_handle_t hMetricQueryPool,                        ///< [in] handle of the metric query pool
+    uint32_t index,                                                         ///< [in] index of the query within the pool
+    zet_metric_query_handle_t* phMetricQuery                                ///< [out] handle of metric query
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Deletes a metric query object.
+/// 
+/// @details
+///     - The application must ensure the device is not currently referencing
+///       the query before it is deleted.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same query handle.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hMetricQuery`
+///     - ::ZE_RESULT_ERROR_HANDLE_OBJECT_IN_USE
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetMetricQueryDestroy(
+    zet_metric_query_handle_t hMetricQuery                                  ///< [in][release] handle of metric query
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Resets a metric query object back to initial state.
+/// 
+/// @details
+///     - The application must ensure the device is not currently referencing
+///       the query before it is reset
+///     - The application must **not** call this function from simultaneous
+///       threads with the same query handle.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hMetricQuery`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetMetricQueryReset(
+    zet_metric_query_handle_t hMetricQuery                                  ///< [in] handle of metric query
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Appends metric query begin into a command list.
+/// 
+/// @details
+///     - The application must ensure the metric query is accessible by the
+///       device on which the command list was created.
+///     - The application must ensure the command list and metric query were
+///       created on the same context.
+///     - This command blocks all following commands from beginning until the
+///       execution of the query completes.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same command list handle.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandList`
+///         + `nullptr == hMetricQuery`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetCommandListAppendMetricQueryBegin(
+    zet_command_list_handle_t hCommandList,                                 ///< [in] handle of the command list
+    zet_metric_query_handle_t hMetricQuery                                  ///< [in] handle of the metric query
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Appends metric query end into a command list.
+/// 
+/// @details
+///     - The application must ensure the metric query and events are accessible
+///       by the device on which the command list was created.
+///     - The application must ensure the command list, events and metric query
+///       were created on the same context.
+///     - The duration of the signal event created from an event pool that was
+///       created using ::ZE_EVENT_POOL_FLAG_KERNEL_TIMESTAMP flag is undefined.
+///       However, for consistency and orthogonality the event will report
+///       correctly as signaled when used by other event API functionality.
+///     - If numWaitEvents is zero, then all previous commands are completed
+///       prior to the execution of the query.
+///     - If numWaitEvents is non-zero, then all phWaitEvents must be signaled
+///       prior to the execution of the query.
+///     - This command blocks all following commands from beginning until the
+///       execution of the query completes.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same command list handle.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandList`
+///         + `nullptr == hMetricQuery`
+///     - ::ZE_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT
+///     - ::ZE_RESULT_ERROR_INVALID_SIZE
+///         + `(nullptr == phWaitEvents) && (0 < numWaitEvents)`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetCommandListAppendMetricQueryEnd(
+    zet_command_list_handle_t hCommandList,                                 ///< [in] handle of the command list
+    zet_metric_query_handle_t hMetricQuery,                                 ///< [in] handle of the metric query
+    ze_event_handle_t hSignalEvent,                                         ///< [in][optional] handle of the event to signal on completion
+    uint32_t numWaitEvents,                                                 ///< [in] must be zero
+    ze_event_handle_t* phWaitEvents                                         ///< [in][mbz] must be nullptr
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Appends metric query commands to flush all caches.
+/// 
+/// @details
+///     - The application must **not** call this function from simultaneous
+///       threads with the same command list handle.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hCommandList`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetCommandListAppendMetricMemoryBarrier(
+    zet_command_list_handle_t hCommandList                                  ///< [in] handle of the command list
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves raw data for a given metric query.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hMetricQuery`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pRawDataSize`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetMetricQueryGetData(
+    zet_metric_query_handle_t hMetricQuery,                                 ///< [in] handle of the metric query
+    size_t* pRawDataSize,                                                   ///< [in,out] pointer to size in bytes of raw data requested to read.
+                                                                            ///< if size is zero, then the driver will update the value with the total
+                                                                            ///< size in bytes needed for all reports available.
+                                                                            ///< if size is non-zero, then driver will only retrieve the number of
+                                                                            ///< reports that fit into the buffer.
+                                                                            ///< if size is larger than size needed for all reports, then driver will
+                                                                            ///< update the value with the actual size needed.
+    uint8_t* pRawData                                                       ///< [in,out][optional][range(0, *pRawDataSize)] buffer containing query
+                                                                            ///< reports in raw format
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Tool APIs for Program Instrumentation (PIN)
+#if !defined(__GNUC__)
+#pragma region pin
+#endif
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supportted profile features
+typedef uint32_t zet_profile_flags_t;
+typedef enum _zet_profile_flag_t
+{
+    ZET_PROFILE_FLAG_REGISTER_REALLOCATION = ZE_BIT(0),                     ///< request the compiler attempt to minimize register usage as much as
+                                                                            ///< possible to allow for instrumentation
+    ZET_PROFILE_FLAG_FREE_REGISTER_INFO = ZE_BIT(1),                        ///< request the compiler generate free register info
+    ZET_PROFILE_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} zet_profile_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Profiling meta-data for instrumentation
+typedef struct _zet_profile_properties_t
+{
+    zet_structure_type_t stype;                                             ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    zet_profile_flags_t flags;                                              ///< [out] indicates which flags were enabled during compilation.
+                                                                            ///< returns 0 (none) or a combination of ::zet_profile_flag_t
+    uint32_t numTokens;                                                     ///< [out] number of tokens immediately following this structure
+
+} zet_profile_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported profile token types
+typedef enum _zet_profile_token_type_t
+{
+    ZET_PROFILE_TOKEN_TYPE_FREE_REGISTER = 0,                               ///< GRF info
+    ZET_PROFILE_TOKEN_TYPE_FORCE_UINT32 = 0x7fffffff
+
+} zet_profile_token_type_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Profile free register token detailing unused registers in the current
+///        function
+typedef struct _zet_profile_free_register_token_t
+{
+    zet_profile_token_type_t type;                                          ///< [out] type of token
+    uint32_t size;                                                          ///< [out] total size of the token, in bytes
+    uint32_t count;                                                         ///< [out] number of register sequences immediately following this
+                                                                            ///< structure
+
+} zet_profile_free_register_token_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Profile register sequence detailing consecutive bytes, all of which
+///        are unused
+typedef struct _zet_profile_register_sequence_t
+{
+    uint32_t start;                                                         ///< [out] starting byte in the register table, representing the start of
+                                                                            ///< unused bytes in the current function
+    uint32_t count;                                                         ///< [out] number of consecutive bytes in the sequence, starting from start
+
+} zet_profile_register_sequence_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieve profiling information generated for the kernel.
+/// 
+/// @details
+///     - Module must be created using the following build option:
+///         + "-zet-profile-flags <n>" - enable generation of profile
+///           information
+///         + "<n>" must be a combination of ::zet_profile_flag_t, in hex
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hKernel`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pProfileProperties`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetKernelGetProfileInfo(
+    zet_kernel_handle_t hKernel,                                            ///< [in] handle to kernel
+    zet_profile_properties_t* pProfileProperties                            ///< [out] pointer to profile properties
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Tool Experimental Extension APIs for API Tracing
+#if !defined(__GNUC__)
+#pragma region tracing
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZET_API_TRACING_EXP_NAME
+/// @brief API Tracing Experimental Extension Name
+#define ZET_API_TRACING_EXP_NAME  "ZET_experimental_api_tracing"
+#endif // ZET_API_TRACING_EXP_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief API Tracing Experimental Extension Version(s)
+typedef enum _zet_api_tracing_exp_version_t
+{
+    ZET_API_TRACING_EXP_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),              ///< version 1.0
+    ZET_API_TRACING_EXP_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),          ///< latest known version
+    ZET_API_TRACING_EXP_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} zet_api_tracing_exp_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Alias the existing callbacks definition for 'core' callbacks
+typedef ze_callbacks_t zet_core_callbacks_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Tracer descriptor
+typedef struct _zet_tracer_exp_desc_t
+{
+    zet_structure_type_t stype;                                             ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    void* pUserData;                                                        ///< [in] pointer passed to every tracer's callbacks
+
+} zet_tracer_exp_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Creates a tracer on the context.
+/// 
+/// @details
+///     - The application must only use the tracer for the context which was
+///       provided during creation.
+///     - The tracer is created in the disabled state.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == desc`
+///         + `nullptr == desc->pUserData`
+///         + `nullptr == phTracer`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetTracerExpCreate(
+    zet_context_handle_t hContext,                                          ///< [in] handle of the context object
+    const zet_tracer_exp_desc_t* desc,                                      ///< [in] pointer to tracer descriptor
+    zet_tracer_exp_handle_t* phTracer                                       ///< [out] pointer to handle of tracer object created
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Destroys a tracer.
+/// 
+/// @details
+///     - The application must **not** call this function from simultaneous
+///       threads with the same tracer handle.
+///     - The implementation of this function must be thread-safe.
+///     - The implementation of this function will stall and wait on any
+///       outstanding threads executing callbacks before freeing any Host
+///       allocations associated with this tracer.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hTracer`
+///     - ::ZE_RESULT_ERROR_HANDLE_OBJECT_IN_USE
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetTracerExpDestroy(
+    zet_tracer_exp_handle_t hTracer                                         ///< [in][release] handle of tracer object to destroy
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Sets the collection of callbacks to be executed **before** driver
+///        execution.
+/// 
+/// @details
+///     - The application only needs to set the function pointers it is
+///       interested in receiving; all others should be 'nullptr'
+///     - The application must ensure that no other threads are executing
+///       functions for which the tracing functions are changing.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same tracer handle.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hTracer`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCoreCbs`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetTracerExpSetPrologues(
+    zet_tracer_exp_handle_t hTracer,                                        ///< [in] handle of the tracer
+    zet_core_callbacks_t* pCoreCbs                                          ///< [in] pointer to table of 'core' callback function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Sets the collection of callbacks to be executed **after** driver
+///        execution.
+/// 
+/// @details
+///     - The application only needs to set the function pointers it is
+///       interested in receiving; all others should be 'nullptr'
+///     - The application must ensure that no other threads are executing
+///       functions for which the tracing functions are changing.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same tracer handle.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hTracer`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCoreCbs`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetTracerExpSetEpilogues(
+    zet_tracer_exp_handle_t hTracer,                                        ///< [in] handle of the tracer
+    zet_core_callbacks_t* pCoreCbs                                          ///< [in] pointer to table of 'core' callback function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Enables (or disables) the tracer
+/// 
+/// @details
+///     - The application must **not** call this function from simultaneous
+///       threads with the same tracer handle.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hTracer`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetTracerExpSetEnabled(
+    zet_tracer_exp_handle_t hTracer,                                        ///< [in] handle of the tracer
+    ze_bool_t enable                                                        ///< [in] enable the tracer if true; disable if false
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Tool Experimental Extension to get Concurrent Metric Groups
+#if !defined(__GNUC__)
+#pragma region concurrentMetricGroup
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZET_CONCURRENT_METRIC_GROUPS_EXP_NAME
+/// @brief Concurrent Metric Groups Experimental Extension Name
+#define ZET_CONCURRENT_METRIC_GROUPS_EXP_NAME  "ZET_experimental_concurrent_metric_groups"
+#endif // ZET_CONCURRENT_METRIC_GROUPS_EXP_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Concurrent Metric Groups Experimental Extension Version(s)
+typedef enum _zet_concurrent_metric_groups_exp_version_t
+{
+    ZET_CONCURRENT_METRIC_GROUPS_EXP_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ), ///< version 1.0
+    ZET_CONCURRENT_METRIC_GROUPS_EXP_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ), ///< latest known version
+    ZET_CONCURRENT_METRIC_GROUPS_EXP_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} zet_concurrent_metric_groups_exp_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get sets of metric groups which could be collected concurrently.
+/// 
+/// @details
+///     - Re-arrange the input metric groups to provide sets of concurrent
+///       metric groups.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///         + `nullptr == phMetricGroups`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetDeviceGetConcurrentMetricGroupsExp(
+    zet_device_handle_t hDevice,                                            ///< [in] handle of the device
+    uint32_t metricGroupCount,                                              ///< [in] metric group count
+    zet_metric_group_handle_t * phMetricGroups,                             ///< [in,out] metrics groups to be re-arranged to be sets of concurrent
+                                                                            ///< groups
+    uint32_t * pMetricGroupsCountPerConcurrentGroup,                        ///< [in,out][optional][*pConcurrentGroupCount] count of metric groups per
+                                                                            ///< concurrent group.
+    uint32_t * pConcurrentGroupCount                                        ///< [out] number of concurrent groups.
+                                                                            ///< The value of this parameter could be used to determine the number of
+                                                                            ///< replays necessary.
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Tool Experimental Extension for Metrics Tracer
+#if !defined(__GNUC__)
+#pragma region metricTracer
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZET_METRICS_TRACER_EXP_NAME
+/// @brief Metric Tracer Experimental Extension Name
+#define ZET_METRICS_TRACER_EXP_NAME  "ZET_experimental_metric_tracer"
+#endif // ZET_METRICS_TRACER_EXP_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Metric Tracer Experimental Extension Version(s)
+typedef enum _zet_metric_tracer_exp_version_t
+{
+    ZET_METRIC_TRACER_EXP_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),            ///< version 1.0
+    ZET_METRIC_TRACER_EXP_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),        ///< latest known version
+    ZET_METRIC_TRACER_EXP_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} zet_metric_tracer_exp_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle of metric tracer's object
+typedef struct _zet_metric_tracer_exp_handle_t *zet_metric_tracer_exp_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle of metric decoder's object
+typedef struct _zet_metric_decoder_exp_handle_t *zet_metric_decoder_exp_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Metric tracer descriptor
+typedef struct _zet_metric_tracer_exp_desc_t
+{
+    zet_structure_type_t stype;                                             ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    uint32_t notifyEveryNBytes;                                             ///< [in,out] number of collected bytes after which notification event will
+                                                                            ///< be signaled. If the requested value is not supported exactly, then the
+                                                                            ///< driver may use a value that is the closest supported approximation and
+                                                                            ///< shall update this member during ::zetMetricTracerCreateExp.
+
+} zet_metric_tracer_exp_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Decoded metric entry
+typedef struct _zet_metric_entry_exp_t
+{
+    zet_value_t value;                                                      ///< [out] value of the decodable metric entry or event. Number is
+                                                                            ///< meaningful based on the metric type.
+    uint64_t timeStamp;                                                     ///< [out] timestamp at which the event happened.
+    uint32_t metricIndex;                                                   ///< [out] index to the decodable metric handle in the input array
+                                                                            ///< (phMetric) in ::zetMetricTracerDecodeExp().
+    ze_bool_t onSubdevice;                                                  ///< [out] True if the event occurred on a sub-device; false means the
+                                                                            ///< device on which the metric tracer was opened does not have
+                                                                            ///< sub-devices.
+    uint32_t subdeviceId;                                                   ///< [out] If onSubdevice is true, this gives the ID of the sub-device.
+
+} zet_metric_entry_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Create a metric tracer for a device.
+/// 
+/// @details
+///     - The notification event must have been created from an event pool that
+///       was created using ::ZE_EVENT_POOL_FLAG_HOST_VISIBLE flag.
+///     - The duration of the signal event created from an event pool that was
+///       created using ::ZE_EVENT_POOL_FLAG_KERNEL_TIMESTAMP flag is undefined.
+///       However, for consistency and orthogonality the event will report
+///       correctly as signaled when used by other event API functionality.
+///     - The application must **not** call this function from simultaneous
+///       threads with the same device handle.
+///     - The metric tracer is created in disabled state
+///     - Metric groups must support sampling type
+///       ZET_METRIC_SAMPLING_TYPE_EXP_FLAG_TRACER_BASED
+///     - All metric groups must be first activated
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hContext`
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == phMetricGroups`
+///         + `nullptr == desc`
+///         + `nullptr == phMetricTracer`
+///     - ::ZE_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetMetricTracerCreateExp(
+    zet_context_handle_t hContext,                                          ///< [in] handle of the context object
+    zet_device_handle_t hDevice,                                            ///< [in] handle of the device
+    uint32_t metricGroupCount,                                              ///< [in] metric group count
+    zet_metric_group_handle_t* phMetricGroups,                              ///< [in][range(0, metricGroupCount )] handles of the metric groups to
+                                                                            ///< trace
+    zet_metric_tracer_exp_desc_t* desc,                                     ///< [in,out] metric tracer descriptor
+    ze_event_handle_t hNotificationEvent,                                   ///< [in][optional] event used for report availability notification. Note:
+                                                                            ///< If buffer is not drained when the event it flagged, there is a risk of
+                                                                            ///< HW event buffer being overrun
+    zet_metric_tracer_exp_handle_t* phMetricTracer                          ///< [out] handle of the metric tracer
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Destroy a metric tracer.
+/// 
+/// @details
+///     - The application must **not** call this function from simultaneous
+///       threads with the same metric tracer handle.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hMetricTracer`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetMetricTracerDestroyExp(
+    zet_metric_tracer_exp_handle_t hMetricTracer                            ///< [in] handle of the metric tracer
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Start events collection
+/// 
+/// @details
+///     - Driver implementations must make this API call have as minimal
+///       overhead as possible, to allow applications start/stop event
+///       collection at any point during execution
+///     - The application must **not** call this function from simultaneous
+///       threads with the same metric tracer handle.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hMetricTracer`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetMetricTracerEnableExp(
+    zet_metric_tracer_exp_handle_t hMetricTracer,                           ///< [in] handle of the metric tracer
+    ze_bool_t synchronous                                                   ///< [in] request synchronous behavior. Confirmation of successful
+                                                                            ///< asynchronous operation is done by calling ::zetMetricTracerReadDataExp()
+                                                                            ///< and checking the return status: ::ZE_RESULT_NOT_READY will be returned
+                                                                            ///< when the tracer is inactive. ::ZE_RESULT_SUCCESS will be returned 
+                                                                            ///< when the tracer is active.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Stop events collection
+/// 
+/// @details
+///     - Driver implementations must make this API call have as minimal
+///       overhead as possible, to allow applications start/stop event
+///       collection at any point during execution
+///     - The application must **not** call this function from simultaneous
+///       threads with the same metric tracer handle.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hMetricTracer`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetMetricTracerDisableExp(
+    zet_metric_tracer_exp_handle_t hMetricTracer,                           ///< [in] handle of the metric tracer
+    ze_bool_t synchronous                                                   ///< [in] request synchronous behavior. Confirmation of successful
+                                                                            ///< asynchronous operation is done by calling ::zetMetricTracerReadDataExp()
+                                                                            ///< and checking the return status: ::ZE_RESULT_SUCCESS will be returned
+                                                                            ///< when the tracer is active or when it is inactive but still has data. 
+                                                                            ///< ::ZE_RESULT_NOT_READY will be returned when the tracer is inactive and
+                                                                            ///< has no more data to be retrieved.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Read data from the metric tracer
+/// 
+/// @details
+///     - The application must **not** call this function from simultaneous
+///       threads with the same metric tracer handle.
+///     - Data can be retrieved after tracer is disabled. When buffers are
+///       drained ::ZE_RESULT_NOT_READY will be returned
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hMetricTracer`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pRawDataSize`
+///     - ::ZE_RESULT_WARNING_DROPPED_DATA
+///         + Metric tracer data may have been dropped.
+///     - ::ZE_RESULT_NOT_READY
+///         + Metric tracer is disabled and no data is available to read.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetMetricTracerReadDataExp(
+    zet_metric_tracer_exp_handle_t hMetricTracer,                           ///< [in] handle of the metric tracer
+    size_t* pRawDataSize,                                                   ///< [in,out] pointer to size in bytes of raw data requested to read.
+                                                                            ///< if size is zero, then the driver will update the value with the total
+                                                                            ///< size in bytes needed for all data available.
+                                                                            ///< if size is non-zero, then driver will only retrieve that amount of
+                                                                            ///< data. 
+                                                                            ///< if size is larger than size needed for all data, then driver will
+                                                                            ///< update the value with the actual size needed.
+    uint8_t* pRawData                                                       ///< [in,out][optional][range(0, *pRawDataSize)] buffer containing tracer
+                                                                            ///< data in raw format
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Create a metric decoder for a given metric tracer.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hMetricTracer`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == phMetricDecoder`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetMetricDecoderCreateExp(
+    zet_metric_tracer_exp_handle_t hMetricTracer,                           ///< [in] handle of the metric tracer
+    zet_metric_decoder_exp_handle_t* phMetricDecoder                        ///< [out] handle of the metric decoder object
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Destroy a metric decoder.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == phMetricDecoder`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetMetricDecoderDestroyExp(
+    zet_metric_decoder_exp_handle_t phMetricDecoder                         ///< [in] handle of the metric decoder object
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Return the list of the decodable metrics from the decoder.
+/// 
+/// @details
+///     - The decodable metrics handles returned by this API are defined by the
+///       metric groups in the tracer on which the decoder was created.
+///     - The decodable metrics handles returned by this API are only valid to
+///       decode metrics raw data with ::zetMetricTracerDecodeExp(). Decodable
+///       metric handles are not valid to compare with metrics handles included
+///       in metric groups.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hMetricDecoder`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+///         + `nullptr == phMetrics`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetMetricDecoderGetDecodableMetricsExp(
+    zet_metric_decoder_exp_handle_t hMetricDecoder,                         ///< [in] handle of the metric decoder object
+    uint32_t* pCount,                                                       ///< [in,out] pointer to number of decodable metric in the hMetricDecoder
+                                                                            ///< handle. If count is zero, then the driver shall 
+                                                                            ///< update the value with the total number of decodable metrics available
+                                                                            ///< in the decoder. if count is greater than zero 
+                                                                            ///< but less than the total number of decodable metrics available in the
+                                                                            ///< decoder, then only that number will be returned. 
+                                                                            ///< if count is greater than the number of decodable metrics available in
+                                                                            ///< the decoder, then the driver shall update the 
+                                                                            ///< value with the actual number of decodable metrics available. 
+    zet_metric_handle_t* phMetrics                                          ///< [in,out] [range(0, *pCount)] array of handles of decodable metrics in
+                                                                            ///< the hMetricDecoder handle provided.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Decode raw events collected from a tracer.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == phMetricDecoder`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pRawDataSize`
+///         + `nullptr == phMetrics`
+///         + `nullptr == pSetCount`
+///         + `nullptr == pMetricEntriesCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetMetricTracerDecodeExp(
+    zet_metric_decoder_exp_handle_t phMetricDecoder,                        ///< [in] handle of the metric decoder object
+    size_t* pRawDataSize,                                                   ///< [in,out] size in bytes of raw data buffer. If pMetricEntriesCount is
+                                                                            ///< greater than zero but less than total number of 
+                                                                            ///< decodable metrics available in the raw data buffer, then driver shall
+                                                                            ///< update this value with actual number of raw 
+                                                                            ///< data bytes processed.
+    uint8_t* pRawData,                                                      ///< [in,out][optional][range(0, *pRawDataSize)] buffer containing tracer
+                                                                            ///< data in raw format
+    uint32_t metricsCount,                                                  ///< [in] number of decodable metrics in the tracer for which the
+                                                                            ///< hMetricDecoder handle was provided. See 
+                                                                            ///< ::zetMetricDecoderGetDecodableMetricsExp(). If metricCount is greater
+                                                                            ///< than zero but less than the number decodable 
+                                                                            ///< metrics available in the raw data buffer, then driver shall only
+                                                                            ///< decode those.
+    zet_metric_handle_t* phMetrics,                                         ///< [in] [range(0, metricsCount)] array of handles of decodable metrics in
+                                                                            ///< the decoder for which the hMetricDecoder handle was 
+                                                                            ///< provided. Metrics handles are expected to be for decodable metrics,
+                                                                            ///< see ::zetMetricDecoderGetDecodableMetricsExp() 
+    uint32_t* pSetCount,                                                    ///< [in,out] pointer to number of metric sets. If count is zero, then the
+                                                                            ///< driver shall update the value with the total
+                                                                            ///< number of metric sets to be decoded. If count is greater than the
+                                                                            ///< number available in the raw data buffer, then the
+                                                                            ///< driver shall update the value with the actual number of metric sets to
+                                                                            ///< be decoded. There is a 1:1 relation between
+                                                                            ///< the number of sets and sub-devices returned in the decoded entries.
+    uint32_t* pMetricEntriesCountPerSet,                                    ///< [in,out][optional][range(0, *pSetCount)] buffer of metric entries
+                                                                            ///< counts per metric set, one value per set.
+    uint32_t* pMetricEntriesCount,                                          ///< [in,out]  pointer to the total number of metric entries decoded, for
+                                                                            ///< all metric sets. If count is zero, then the
+                                                                            ///< driver shall update the value with the total number of metric entries
+                                                                            ///< to be decoded. If count is greater than zero
+                                                                            ///< but less than the total number of metric entries available in the raw
+                                                                            ///< data, then user provided number will be decoded.
+                                                                            ///< If count is greater than the number available in the raw data buffer,
+                                                                            ///< then the driver shall update the value with
+                                                                            ///< the actual number of decodable metric entries decoded. If set to null,
+                                                                            ///< then driver will only update the value of
+                                                                            ///< pSetCount.
+    zet_metric_entry_exp_t* pMetricEntries                                  ///< [in,out][optional][range(0, *pMetricEntriesCount)] buffer containing
+                                                                            ///< decoded metric entries
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Tool Experimental Extension for Metrics/Metric Groups which export Memory
+#if !defined(__GNUC__)
+#pragma region metricExportMemory
+#endif
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Metric group type
+typedef uint32_t zet_metric_group_type_exp_flags_t;
+typedef enum _zet_metric_group_type_exp_flag_t
+{
+    ZET_METRIC_GROUP_TYPE_EXP_FLAG_EXPORT_DMA_BUF = ZE_BIT(0),              ///< Metric group and metrics exports memory using linux dma-buf, which
+                                                                            ///< could be imported/mapped to the host process. Properties of the
+                                                                            ///< dma_buf could be queried using ::zet_export_dma_buf_exp_properties_t.
+    ZET_METRIC_GROUP_TYPE_EXP_FLAG_USER_CREATED = ZE_BIT(1),                ///< Metric group created using ::zetDeviceCreateMetricGroupsFromMetricsExp
+    ZET_METRIC_GROUP_TYPE_EXP_FLAG_OTHER = ZE_BIT(2),                       ///< Metric group which has a collection of metrics
+    ZET_METRIC_GROUP_TYPE_EXP_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} zet_metric_group_type_exp_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Query the metric group type using `pNext` of
+///        ::zet_metric_group_properties_t
+typedef struct _zet_metric_group_type_exp_t
+{
+    zet_structure_type_t stype;                                             ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    zet_metric_group_type_exp_flags_t type;                                 ///< [out] metric group type.
+                                                                            ///< returns a combination of ::zet_metric_group_type_exp_flags_t.
+
+} zet_metric_group_type_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported dma_buf properties queried using `pNext` of
+///        ::zet_metric_group_properties_t or ::zet_metric_properties_t
+typedef struct _zet_export_dma_buf_exp_properties_t
+{
+    zet_structure_type_t stype;                                             ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    int fd;                                                                 ///< [out] the file descriptor handle that could be used to import the
+                                                                            ///< memory by the host process.
+    size_t size;                                                            ///< [out] size in bytes of the dma_buf
+
+} zet_export_dma_buf_exp_properties_t;
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Tool Experimental Extension for Calculating Multiple Metrics
+#if !defined(__GNUC__)
+#pragma region multiMetricValues
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZET_MULTI_METRICS_EXP_NAME
+/// @brief Calculating Multiple Metrics Experimental Extension Name
+#define ZET_MULTI_METRICS_EXP_NAME  "ZET_experimental_calculate_multiple_metrics"
+#endif // ZET_MULTI_METRICS_EXP_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Calculating Multiple Metrics Experimental Extension Version(s)
+typedef enum _ze_calculate_multiple_metrics_exp_version_t
+{
+    ZE_CALCULATE_MULTIPLE_METRICS_EXP_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),///< version 1.0
+    ZE_CALCULATE_MULTIPLE_METRICS_EXP_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),///< latest known version
+    ZE_CALCULATE_MULTIPLE_METRICS_EXP_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} ze_calculate_multiple_metrics_exp_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Calculate one or more sets of metric values from raw data.
+/// 
+/// @details
+///     - This function is similar to ::zetMetricGroupCalculateMetricValues
+///       except it may calculate more than one set of metric values from a
+///       single data buffer.  There may be one set of metric values for each
+///       sub-device, for example.
+///     - Each set of metric values may consist of a different number of metric
+///       values, returned as the metric value count.
+///     - All metric values are calculated into a single buffer; use the metric
+///       counts to determine which metric values belong to which set.
+///     - The application may call this function from simultaneous threads.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hMetricGroup`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::ZET_METRIC_GROUP_CALCULATION_TYPE_MAX_METRIC_VALUES < type`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pRawData`
+///         + `nullptr == pSetCount`
+///         + `nullptr == pTotalMetricValueCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetMetricGroupCalculateMultipleMetricValuesExp(
+    zet_metric_group_handle_t hMetricGroup,                                 ///< [in] handle of the metric group
+    zet_metric_group_calculation_type_t type,                               ///< [in] calculation type to be applied on raw data
+    size_t rawDataSize,                                                     ///< [in] size in bytes of raw data buffer
+    const uint8_t* pRawData,                                                ///< [in][range(0, rawDataSize)] buffer of raw data to calculate
+    uint32_t* pSetCount,                                                    ///< [in,out] pointer to number of metric sets.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of metric sets to be calculated.
+                                                                            ///< if count is greater than the number available in the raw data buffer,
+                                                                            ///< then the driver shall update the value with the actual number of
+                                                                            ///< metric sets to be calculated.
+    uint32_t* pTotalMetricValueCount,                                       ///< [in,out] pointer to number of the total number of metric values
+                                                                            ///< calculated, for all metric sets.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of metric values to be calculated.
+                                                                            ///< if count is greater than the number available in the raw data buffer,
+                                                                            ///< then the driver shall update the value with the actual number of
+                                                                            ///< metric values to be calculated.
+    uint32_t* pMetricCounts,                                                ///< [in,out][optional][range(0, *pSetCount)] buffer of metric counts per
+                                                                            ///< metric set.
+    zet_typed_value_t* pMetricValues                                        ///< [in,out][optional][range(0, *pTotalMetricValueCount)] buffer of
+                                                                            ///< calculated metrics.
+                                                                            ///< if count is less than the number available in the raw data buffer,
+                                                                            ///< then driver shall only calculate that number of metric values.
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Tool Experimental Extension for Global Metric Timestamps
+#if !defined(__GNUC__)
+#pragma region GlobalTimestamps
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZET_GLOBAL_METRICS_TIMESTAMPS_EXP_NAME
+/// @brief Global Metric Timestamps Experimental Extension Name
+#define ZET_GLOBAL_METRICS_TIMESTAMPS_EXP_NAME  "ZET_experimental_global_metric_timestamps"
+#endif // ZET_GLOBAL_METRICS_TIMESTAMPS_EXP_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Global Metric Timestamps Experimental Extension Version(s)
+typedef enum _ze_metric_global_timestamps_exp_version_t
+{
+    ZE_METRIC_GLOBAL_TIMESTAMPS_EXP_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),  ///< version 1.0
+    ZE_METRIC_GLOBAL_TIMESTAMPS_EXP_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),  ///< latest known version
+    ZE_METRIC_GLOBAL_TIMESTAMPS_EXP_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} ze_metric_global_timestamps_exp_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Metric timestamps resolution
+/// 
+/// @details
+///     - This structure may be returned from ::zetMetricGroupGetProperties via
+///       the `pNext` member of ::zet_metric_group_properties_t.
+///     - Used for mapping metric timestamps to other timers.
+typedef struct _zet_metric_global_timestamps_resolution_exp_t
+{
+    zet_structure_type_t stype;                                             ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    uint64_t timerResolution;                                               ///< [out] Returns the resolution of metrics timer (used for timestamps) in
+                                                                            ///< cycles/sec.
+    uint64_t timestampValidBits;                                            ///< [out] Returns the number of valid bits in the timestamp value.
+
+} zet_metric_global_timestamps_resolution_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Returns metric timestamps synchronized with global device timestamps,
+///        optionally synchronized with host
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - By default, the global and metrics timestamps are synchronized to the
+///       device.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hMetricGroup`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == globalTimestamp`
+///         + `nullptr == metricTimestamp`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetMetricGroupGetGlobalTimestampsExp(
+    zet_metric_group_handle_t hMetricGroup,                                 ///< [in] handle of the metric group
+    ze_bool_t synchronizedWithHost,                                         ///< [in] Returns the timestamps synchronized to the host or the device.
+    uint64_t* globalTimestamp,                                              ///< [out] Device timestamp.
+    uint64_t* metricTimestamp                                               ///< [out] Metric timestamp.
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Tool Experimental Extension for Exporting Metrics Data
+#if !defined(__GNUC__)
+#pragma region metricExportData
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZET_EXPORT_METRICS_DATA_EXP_NAME
+/// @brief Exporting Metrics Data Experimental Extension Name
+#define ZET_EXPORT_METRICS_DATA_EXP_NAME  "ZET_experimental_metric_export_data"
+#endif // ZET_EXPORT_METRICS_DATA_EXP_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exporting Metrics Data Experimental Extension Version(s)
+typedef enum _zet_export_metric_data_exp_version_t
+{
+    ZET_EXPORT_METRIC_DATA_EXP_VERSION_1_0 = ZE_MAKE_VERSION( 1, 0 ),       ///< version 1.0
+    ZET_EXPORT_METRIC_DATA_EXP_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 0 ),   ///< latest known version
+    ZET_EXPORT_METRIC_DATA_EXP_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} zet_export_metric_data_exp_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZET_MAX_METRIC_EXPORT_DATA_ELEMENT_NAME_EXP
+/// @brief Maximum count of characters in export data element name
+#define ZET_MAX_METRIC_EXPORT_DATA_ELEMENT_NAME_EXP  256
+#endif // ZET_MAX_METRIC_EXPORT_DATA_ELEMENT_NAME_EXP
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZET_MAX_METRIC_EXPORT_DATA_ELEMENT_DESCRIPTION_EXP
+/// @brief Maximum export data element description string size
+#define ZET_MAX_METRIC_EXPORT_DATA_ELEMENT_DESCRIPTION_EXP  256
+#endif // ZET_MAX_METRIC_EXPORT_DATA_ELEMENT_DESCRIPTION_EXP
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Metrics calculation descriptor
+typedef struct _zet_metric_calculate_exp_desc_t
+{
+    zet_structure_type_t stype;                                             ///< [in] type of this structure
+    const void* pNext;                                                      ///< [in][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    uint32_t rawReportSkipCount;                                            ///< [in] number of reports to skip during calculation
+
+} zet_metric_calculate_exp_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Export Metrics Data for system independent calculation.
+/// 
+/// @details
+///     - This function exports raw data and necessary information to perform
+///       metrics calculation of collected data in a different system than where
+///       data was collected, which may or may not have accelerators.
+///     - Implementations can choose to describe the data arrangement of the
+///       exported data, using any mechanism which allows users to read and
+///       process them.
+///     - The application may call this function from simultaneous threads.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hMetricGroup`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pRawData`
+///         + `nullptr == pExportDataSize`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetMetricGroupGetExportDataExp(
+    zet_metric_group_handle_t hMetricGroup,                                 ///< [in] handle of the metric group
+    const uint8_t* pRawData,                                                ///< [in] buffer of raw data
+    size_t rawDataSize,                                                     ///< [in] size in bytes of raw data buffer
+    size_t* pExportDataSize,                                                ///< [in,out] size in bytes of export data buffer
+                                                                            ///< if size is zero, then the driver shall update the value with the
+                                                                            ///< number of bytes necessary to store the exported data.
+                                                                            ///< if size is greater than required, then the driver shall update the
+                                                                            ///< value with the actual number of bytes necessary to store the exported data.
+    uint8_t * pExportData                                                   ///< [in,out][optional][range(0, *pExportDataSize)] buffer of exported data.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Calculate one or more sets of metric values from exported raw data.
+/// 
+/// @details
+///     - Calculate metrics values using exported data returned by
+///       ::zetMetricGroupGetExportDataExp.
+///     - This function is similar to
+///       ::zetMetricGroupCalculateMultipleMetricValuesExp except it would
+///       calculate from exported metric data.
+///     - This function could be used to calculate metrics on a system different
+///       from where the metric raw data was collected.
+///     - The application may call this function from simultaneous threads.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDriver`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::ZET_METRIC_GROUP_CALCULATION_TYPE_MAX_METRIC_VALUES < type`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pExportData`
+///         + `nullptr == pCalculateDescriptor`
+///         + `nullptr == pSetCount`
+///         + `nullptr == pTotalMetricValueCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetMetricGroupCalculateMetricExportDataExp(
+    ze_driver_handle_t hDriver,                                             ///< [in] handle of the driver instance
+    zet_metric_group_calculation_type_t type,                               ///< [in] calculation type to be applied on raw data
+    size_t exportDataSize,                                                  ///< [in] size in bytes of exported data buffer
+    const uint8_t* pExportData,                                             ///< [in][range(0, exportDataSize)] buffer of exported data to calculate
+    zet_metric_calculate_exp_desc_t* pCalculateDescriptor,                  ///< [in] descriptor specifying calculation specific parameters
+    uint32_t* pSetCount,                                                    ///< [in,out] pointer to number of metric sets.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of metric sets to be calculated.
+                                                                            ///< if count is greater than the number available in the raw data buffer,
+                                                                            ///< then the driver shall update the value with the actual number of
+                                                                            ///< metric sets to be calculated.
+    uint32_t* pTotalMetricValueCount,                                       ///< [in,out] pointer to number of the total number of metric values
+                                                                            ///< calculated, for all metric sets.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of metric values to be calculated.
+                                                                            ///< if count is greater than the number available in the raw data buffer,
+                                                                            ///< then the driver shall update the value with the actual number of
+                                                                            ///< metric values to be calculated.
+    uint32_t* pMetricCounts,                                                ///< [in,out][optional][range(0, *pSetCount)] buffer of metric counts per
+                                                                            ///< metric set.
+    zet_typed_value_t* pMetricValues                                        ///< [in,out][optional][range(0, *pTotalMetricValueCount)] buffer of
+                                                                            ///< calculated metrics.
+                                                                            ///< if count is less than the number available in the raw data buffer,
+                                                                            ///< then driver shall only calculate that number of metric values.
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Level-Zero Tool Experimental Extension for Programmable Metrics
+#if !defined(__GNUC__)
+#pragma region metricProgrammable
+#endif
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZET_PROGRAMMABLE_METRICS_EXP_NAME
+/// @brief Programmable Metrics Experimental Extension Name
+#define ZET_PROGRAMMABLE_METRICS_EXP_NAME  "ZET_experimental_programmable_metrics"
+#endif // ZET_PROGRAMMABLE_METRICS_EXP_NAME
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Programmable Metrics Experimental Extension Version(s)
+typedef enum _zet_metric_programmable_exp_version_t
+{
+    ZET_METRIC_PROGRAMMABLE_EXP_VERSION_1_1 = ZE_MAKE_VERSION( 1, 1 ),      ///< version 1.1
+    ZET_METRIC_PROGRAMMABLE_EXP_VERSION_CURRENT = ZE_MAKE_VERSION( 1, 1 ),  ///< latest known version
+    ZET_METRIC_PROGRAMMABLE_EXP_VERSION_FORCE_UINT32 = 0x7fffffff
+
+} zet_metric_programmable_exp_version_t;
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZET_MAX_PROGRAMMABLE_METRICS_ELEMENT_NAME_EXP
+/// @brief Maximum count of characters in export data element name
+#define ZET_MAX_PROGRAMMABLE_METRICS_ELEMENT_NAME_EXP  256
+#endif // ZET_MAX_PROGRAMMABLE_METRICS_ELEMENT_NAME_EXP
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZET_MAX_PROGRAMMABLE_METRICS_ELEMENT_DESCRIPTION_EXP
+/// @brief Maximum export data element description string size
+#define ZET_MAX_PROGRAMMABLE_METRICS_ELEMENT_DESCRIPTION_EXP  256
+#endif // ZET_MAX_PROGRAMMABLE_METRICS_ELEMENT_DESCRIPTION_EXP
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZET_MAX_METRIC_GROUP_NAME_PREFIX_EXP
+/// @brief Maximum count of characters in metric group name prefix
+#define ZET_MAX_METRIC_GROUP_NAME_PREFIX_EXP  64
+#endif // ZET_MAX_METRIC_GROUP_NAME_PREFIX_EXP
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZET_MAX_METRIC_PROGRAMMABLE_NAME_EXP
+/// @brief Maximum metric programmable name string size
+#define ZET_MAX_METRIC_PROGRAMMABLE_NAME_EXP  128
+#endif // ZET_MAX_METRIC_PROGRAMMABLE_NAME_EXP
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZET_MAX_METRIC_PROGRAMMABLE_DESCRIPTION_EXP
+/// @brief Maximum metric programmable description string size
+#define ZET_MAX_METRIC_PROGRAMMABLE_DESCRIPTION_EXP  128
+#endif // ZET_MAX_METRIC_PROGRAMMABLE_DESCRIPTION_EXP
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZET_MAX_METRIC_PROGRAMMABLE_COMPONENT_EXP
+/// @brief Maximum metric programmable component string size
+#define ZET_MAX_METRIC_PROGRAMMABLE_COMPONENT_EXP  128
+#endif // ZET_MAX_METRIC_PROGRAMMABLE_COMPONENT_EXP
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZET_MAX_METRIC_PROGRAMMABLE_PARAMETER_NAME_EXP
+/// @brief Maximum metric programmable parameter string size
+#define ZET_MAX_METRIC_PROGRAMMABLE_PARAMETER_NAME_EXP  128
+#endif // ZET_MAX_METRIC_PROGRAMMABLE_PARAMETER_NAME_EXP
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZET_MAX_METRIC_PROGRAMMABLE_VALUE_DESCRIPTION_EXP
+/// @brief Maximum value for programmable value description
+#define ZET_MAX_METRIC_PROGRAMMABLE_VALUE_DESCRIPTION_EXP  128
+#endif // ZET_MAX_METRIC_PROGRAMMABLE_VALUE_DESCRIPTION_EXP
+
+///////////////////////////////////////////////////////////////////////////////
+#ifndef ZE_MAX_METRIC_GROUP_NAME_PREFIX
+/// @brief Maximum value metric group name prefix
+#define ZE_MAX_METRIC_GROUP_NAME_PREFIX  64
+#endif // ZE_MAX_METRIC_GROUP_NAME_PREFIX
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle of metric programmable's object
+typedef struct _zet_metric_programmable_exp_handle_t *zet_metric_programmable_exp_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Metric Programmable properties queried using
+///        ::zetMetricProgrammableGetPropertiesExp
+typedef struct _zet_metric_programmable_exp_properties_t
+{
+    zet_structure_type_t stype;                                             ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    char name[ZET_MAX_METRIC_PROGRAMMABLE_NAME_EXP];                        ///< [out] metric programmable name
+    char description[ZET_MAX_METRIC_PROGRAMMABLE_DESCRIPTION_EXP];          ///< [out] metric programmable description
+    char component[ZET_MAX_METRIC_PROGRAMMABLE_COMPONENT_EXP];              ///< [out] metric programmable component
+    uint32_t tierNumber;                                                    ///< [out] tier number
+    uint32_t domain;                                                        ///< [out] metric domain number.
+    uint32_t parameterCount;                                                ///< [out] number of parameters in the programmable
+    zet_metric_group_sampling_type_flags_t samplingType;                    ///< [out] metric sampling type.
+                                                                            ///< returns a combination of ::zet_metric_group_sampling_type_flag_t.
+    uint32_t sourceId;                                                      ///< [out] unique metric source identifier(within platform)to identify the
+                                                                            ///< HW block where the metric is collected.
+
+} zet_metric_programmable_exp_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Metric Programmable Parameter types
+typedef enum _zet_metric_programmable_param_type_exp_t
+{
+    ZET_METRIC_PROGRAMMABLE_PARAM_TYPE_EXP_DISAGGREGATION = 0,              ///< Metric is disaggregated.
+    ZET_METRIC_PROGRAMMABLE_PARAM_TYPE_EXP_LATENCY = 1,                     ///< Metric for latency measurement.
+    ZET_METRIC_PROGRAMMABLE_PARAM_TYPE_EXP_NORMALIZATION_UTILIZATION = 2,   ///< Produces normalization in percent using raw_metric * 100 / cycles / HW
+                                                                            ///< instance_count.
+    ZET_METRIC_PROGRAMMABLE_PARAM_TYPE_EXP_NORMALIZATION_AVERAGE = 3,       ///< Produces normalization using raw_metric / HW instance_count.
+    ZET_METRIC_PROGRAMMABLE_PARAM_TYPE_EXP_NORMALIZATION_RATE = 4,          ///< Produces normalization average using raw_metric / timestamp.
+    ZET_METRIC_PROGRAMMABLE_PARAM_TYPE_EXP_NORMALIZATION_BYTES = 5,         ///< Produces normalization average using raw_metric * n bytes.
+    ZET_METRIC_PROGRAMMABLE_PARAM_TYPE_EXP_GENERIC = 6,                     ///< Generic Parameter type. Please refer the parameter's description.
+    ZET_METRIC_PROGRAMMABLE_PARAM_TYPE_EXP_FORCE_UINT32 = 0x7fffffff
+
+} zet_metric_programmable_param_type_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported value info types
+typedef enum _zet_value_info_type_exp_t
+{
+    ZET_VALUE_INFO_TYPE_EXP_UINT32 = 0,                                     ///< 32-bit unsigned-integer
+    ZET_VALUE_INFO_TYPE_EXP_UINT64 = 1,                                     ///< 64-bit unsigned-integer
+    ZET_VALUE_INFO_TYPE_EXP_FLOAT32 = 2,                                    ///< 32-bit floating-point
+    ZET_VALUE_INFO_TYPE_EXP_FLOAT64 = 3,                                    ///< 64-bit floating-point
+    ZET_VALUE_INFO_TYPE_EXP_BOOL8 = 4,                                      ///< 8-bit boolean
+    ZET_VALUE_INFO_TYPE_EXP_UINT8 = 5,                                      ///< 8-bit unsigned-integer
+    ZET_VALUE_INFO_TYPE_EXP_UINT16 = 6,                                     ///< 16-bit unsigned-integer
+    ZET_VALUE_INFO_TYPE_EXP_UINT64_RANGE = 7,                               ///< 64-bit unsigned-integer range (minimum and maximum)
+    ZET_VALUE_INFO_TYPE_EXP_FLOAT64_RANGE = 8,                              ///< 64-bit floating point range (minimum and maximum)
+    ZET_VALUE_INFO_TYPE_EXP_FORCE_UINT32 = 0x7fffffff
+
+} zet_value_info_type_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Value info of type uint64_t range
+typedef struct _zet_value_uint64_range_exp_t
+{
+    uint64_t ui64Min;                                                       ///< [out] minimum value of the range
+    uint64_t ui64Max;                                                       ///< [out] maximum value of the range
+
+} zet_value_uint64_range_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Value info of type float64 range
+typedef struct _zet_value_fp64_range_exp_t
+{
+    double fp64Min;                                                         ///< [out] minimum value of the range
+    double fp64Max;                                                         ///< [out] maximum value of the range
+
+} zet_value_fp64_range_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Union of value information
+typedef union _zet_value_info_exp_t
+{
+    uint32_t ui32;                                                          ///< [out] 32-bit unsigned-integer
+    uint64_t ui64;                                                          ///< [out] 64-bit unsigned-integer
+    float fp32;                                                             ///< [out] 32-bit floating-point
+    double fp64;                                                            ///< [out] 64-bit floating-point
+    ze_bool_t b8;                                                           ///< [out] 8-bit boolean
+    uint8_t ui8;                                                            ///< [out] 8-bit unsigned integer
+    uint16_t ui16;                                                          ///< [out] 16-bit unsigned integer
+    zet_value_uint64_range_exp_t ui64Range;                                 ///< [out] minimum and maximum value of the range
+    zet_value_fp64_range_exp_t fp64Range;                                   ///< [out] minimum and maximum value of the range
+
+} zet_value_info_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Metric Programmable parameter information
+typedef struct _zet_metric_programmable_param_info_exp_t
+{
+    zet_structure_type_t stype;                                             ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    zet_metric_programmable_param_type_exp_t type;                          ///< [out] programmable parameter type
+    char name[ZET_MAX_METRIC_PROGRAMMABLE_PARAMETER_NAME_EXP];              ///< [out] metric programmable parameter name
+    zet_value_info_type_exp_t valueInfoType;                                ///< [out] value info type
+    zet_value_t defaultValue;                                               ///< [out] default value for the parameter
+    uint32_t valueInfoCount;                                                ///< [out] count of ::zet_metric_programmable_param_value_info_exp_t
+
+} zet_metric_programmable_param_info_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Metric Programmable parameter value information
+typedef struct _zet_metric_programmable_param_value_info_exp_t
+{
+    zet_structure_type_t stype;                                             ///< [in] type of this structure
+    void* pNext;                                                            ///< [in,out][optional] must be null or a pointer to an extension-specific
+                                                                            ///< structure (i.e. contains stype and pNext).
+    zet_value_info_exp_t valueInfo;                                         ///< [out] information about the parameter value
+    char description[ZET_MAX_METRIC_PROGRAMMABLE_VALUE_DESCRIPTION_EXP];    ///< [out] description about the value
+
+} zet_metric_programmable_param_value_info_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Metric Programmable parameter value
+typedef struct _zet_metric_programmable_param_value_exp_t
+{
+    zet_value_t value;                                                      ///< [in] parameter value
+
+} zet_metric_programmable_param_value_exp_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Query and get the available metric programmable handles.
+/// 
+/// @details
+///     - Query the available programmable handles using *pCount = 0.
+///     - Returns all programmable metric handles available in the device.
+///     - The application may call this function from simultaneous threads.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetMetricProgrammableGetExp(
+    zet_device_handle_t hDevice,                                            ///< [in] handle of the device
+    uint32_t* pCount,                                                       ///< [in,out] pointer to the number of metric programmable handles.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< total number of metric programmable handles available.
+                                                                            ///< if count is greater than the number of metric programmable handles
+                                                                            ///< available, then the driver shall update the value with the correct
+                                                                            ///< number of metric programmable handles available.
+    zet_metric_programmable_exp_handle_t* phMetricProgrammables             ///< [in,out][optional][range(0, *pCount)] array of handle of metric programmables.
+                                                                            ///< if count is less than the number of metric programmables available,
+                                                                            ///< then driver shall only retrieve that number of metric programmables.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get the properties of the metric programmable.
+/// 
+/// @details
+///     - Returns the properties of the metric programmable.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hMetricProgrammable`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pProperties`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetMetricProgrammableGetPropertiesExp(
+    zet_metric_programmable_exp_handle_t hMetricProgrammable,               ///< [in] handle of the metric programmable
+    zet_metric_programmable_exp_properties_t* pProperties                   ///< [in,out] properties of the metric programmable
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get the information about the parameters of the metric programmable.
+/// 
+/// @details
+///     - Returns information about the parameters of the metric programmable
+///       handle.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hMetricProgrammable`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pParameterCount`
+///         + `nullptr == pParameterInfo`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetMetricProgrammableGetParamInfoExp(
+    zet_metric_programmable_exp_handle_t hMetricProgrammable,               ///< [in] handle of the metric programmable
+    uint32_t* pParameterCount,                                              ///< [in,out] count of the parameters to retrieve parameter info.
+                                                                            ///< if value pParameterCount is greater than count of parameters
+                                                                            ///< available, then pParameterCount will be updated with count of
+                                                                            ///< parameters available.
+                                                                            ///< The count of parameters available can be queried using ::zetMetricProgrammableGetPropertiesExp.
+    zet_metric_programmable_param_info_exp_t* pParameterInfo                ///< [in,out][range(1, *pParameterCount)] array of parameter info.
+                                                                            ///< if parameterCount is less than the number of parameters available,
+                                                                            ///< then driver shall only retrieve that number of parameter info.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get the information about the parameter value of the metric
+///        programmable.
+/// 
+/// @details
+///     - Returns the value-information about the parameter at the specific
+///       ordinal of the metric programmable handle.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hMetricProgrammable`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pValueInfoCount`
+///         + `nullptr == pValueInfo`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetMetricProgrammableGetParamValueInfoExp(
+    zet_metric_programmable_exp_handle_t hMetricProgrammable,               ///< [in] handle of the metric programmable
+    uint32_t parameterOrdinal,                                              ///< [in] ordinal of the parameter in the metric programmable
+    uint32_t* pValueInfoCount,                                              ///< [in,out] count of parameter value information to retrieve.
+                                                                            ///< if value at pValueInfoCount is greater than count of value info
+                                                                            ///< available, then pValueInfoCount will be updated with count of value
+                                                                            ///< info available.
+                                                                            ///< The count of parameter value info available can be queried using ::zetMetricProgrammableGetParamInfoExp.
+    zet_metric_programmable_param_value_info_exp_t* pValueInfo              ///< [in,out][range(1, *pValueInfoCount)] array of parameter value info.
+                                                                            ///< if pValueInfoCount is less than the number of value info available,
+                                                                            ///< then driver shall only retrieve that number of value info.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Create metric handles by applying parameter values on the metric
+///        programmable handle.
+/// 
+/// @details
+///     - Multiple parameter values could be used to prepare a metric.
+///     - If parameterCount = 0, the default value of the metric programmable
+///       would be used for all parameters.
+///     - The implementation can post-fix a C string to the metric name and
+///       description, based on the parameter values chosen.
+///     - ::zetMetricProgrammableGetParamInfoExp() returns a list of parameters
+///       in a defined order.
+///     - Therefore, the list of values passed in to the API should respect the
+///       same order such that the desired parameter is set with expected value
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hMetricProgrammable`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pParameterValues`
+///         + `nullptr == pName`
+///         + `nullptr == pDescription`
+///         + `nullptr == pMetricHandleCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetMetricCreateFromProgrammableExp2(
+    zet_metric_programmable_exp_handle_t hMetricProgrammable,               ///< [in] handle of the metric programmable
+    uint32_t parameterCount,                                                ///< [in] Count of parameters to set.
+    zet_metric_programmable_param_value_exp_t* pParameterValues,            ///< [in] list of parameter values to be set.
+    const char* pName,                                                      ///< [in] pointer to metric name to be used. Must point to a
+                                                                            ///< null-terminated character array no longer than ::ZET_MAX_METRIC_NAME.
+    const char* pDescription,                                               ///< [in] pointer to metric description to be used. Must point to a
+                                                                            ///< null-terminated character array no longer than
+                                                                            ///< ::ZET_MAX_METRIC_DESCRIPTION.
+    uint32_t* pMetricHandleCount,                                           ///< [in,out] Pointer to the number of metric handles.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< number of metric handles available for this programmable.
+                                                                            ///< if count is greater than the number of metric handles available, then
+                                                                            ///< the driver shall update the value with the correct number of metric
+                                                                            ///< handles available.
+    zet_metric_handle_t* phMetricHandles                                    ///< [in,out][optional][range(0,*pMetricHandleCount)] array of handle of metrics.
+                                                                            ///< if count is less than the number of metrics available, then driver
+                                                                            ///< shall only retrieve that number of metric handles.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Create metric handles by applying parameter values on the metric
+///        programmable handle.
+/// 
+/// @details
+///     - This API is deprecated. Please use
+///       ::zetMetricCreateFromProgrammableExp2()
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hMetricProgrammable`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pParameterValues`
+///         + `nullptr == pName`
+///         + `nullptr == pDescription`
+///         + `nullptr == pMetricHandleCount`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetMetricCreateFromProgrammableExp(
+    zet_metric_programmable_exp_handle_t hMetricProgrammable,               ///< [in] handle of the metric programmable
+    zet_metric_programmable_param_value_exp_t* pParameterValues,            ///< [in] list of parameter values to be set.
+    uint32_t parameterCount,                                                ///< [in] Count of parameters to set.
+    const char* pName,                                                      ///< [in] pointer to metric name to be used. Must point to a
+                                                                            ///< null-terminated character array no longer than ::ZET_MAX_METRIC_NAME.
+    const char* pDescription,                                               ///< [in] pointer to metric description to be used. Must point to a
+                                                                            ///< null-terminated character array no longer than
+                                                                            ///< ::ZET_MAX_METRIC_DESCRIPTION.
+    uint32_t* pMetricHandleCount,                                           ///< [in,out] Pointer to the number of metric handles.
+                                                                            ///< if count is zero, then the driver shall update the value with the
+                                                                            ///< number of metric handles available for this programmable.
+                                                                            ///< if count is greater than the number of metric handles available, then
+                                                                            ///< the driver shall update the value with the correct number of metric
+                                                                            ///< handles available.
+    zet_metric_handle_t* phMetricHandles                                    ///< [in,out][optional][range(0,*pMetricHandleCount)] array of handle of metrics.
+                                                                            ///< if count is less than the number of metrics available, then driver
+                                                                            ///< shall only retrieve that number of metric handles.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Create multiple metric group handles from metric handles.
+/// 
+/// @details
+///     - Creates multiple metric groups from metrics which were created using
+///       ::zetMetricCreateFromProgrammableExp2().
+///     - Metrics whose Hardware resources do not overlap are added to same
+///       metric group.
+///     - The metric groups created using this API are managed by the
+///       application and cannot be retrieved using ::zetMetricGroupGet().
+///     - The created metric groups are ready for activation and collection.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///         + `nullptr == phMetrics`
+///     - ::ZE_RESULT_ERROR_INVALID_ARGUMENT
+///         + metricGroupCount is lesser than the number of metric group handles that could be created.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetDeviceCreateMetricGroupsFromMetricsExp(
+    zet_device_handle_t hDevice,                                            ///< [in] handle of the device.
+    uint32_t metricCount,                                                   ///< [in] number of metric handles.
+    zet_metric_handle_t * phMetrics,                                        ///< [in] metric handles to be added to the metric groups.
+    const char * pMetricGroupNamePrefix,                                    ///< [in] prefix to the name created for the metric groups. Must point to a
+                                                                            ///< null-terminated character array no longer than
+                                                                            ///< ::ZET_MAX_METRIC_GROUP_NAME_PREFIX_EXP.
+    const char * pDescription,                                              ///< [in] pointer to description of the metric groups. Must point to a
+                                                                            ///< null-terminated character array no longer than
+                                                                            ///< ::ZET_MAX_METRIC_GROUP_DESCRIPTION.
+    uint32_t * pMetricGroupCount,                                           ///< [in,out] pointer to the number of metric group handles to be created.
+                                                                            ///< if pMetricGroupCount is zero, then the driver shall update the value
+                                                                            ///< with the maximum possible number of metric group handles that could be created.
+                                                                            ///< if pMetricGroupCount is greater than the number of metric group
+                                                                            ///< handles that could be created, then the driver shall update the value
+                                                                            ///< with the correct number of metric group handles generated.
+                                                                            ///< if pMetricGroupCount is lesser than the number of metric group handles
+                                                                            ///< that could be created, then ::ZE_RESULT_ERROR_INVALID_ARGUMENT is returned.
+    zet_metric_group_handle_t* phMetricGroup                                ///< [in,out][optional][range(0, *pMetricGroupCount)] array of handle of
+                                                                            ///< metric group handles.
+                                                                            ///< Created Metric group handles.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Create metric group handle.
+/// 
+/// @details
+///     - This API is deprecated. Please use
+///       ::zetDeviceCreateMetricGroupsFromMetricsExp 
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hDevice`
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `nullptr == pName`
+///         + `nullptr == pDescription`
+///         + `nullptr == phMetricGroup`
+///     - ::ZE_RESULT_ERROR_INVALID_ENUMERATION
+///         + `0x7 < samplingType`
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetMetricGroupCreateExp(
+    zet_device_handle_t hDevice,                                            ///< [in] handle of the device
+    const char* pName,                                                      ///< [in] pointer to metric group name. Must point to a null-terminated
+                                                                            ///< character array no longer than ::ZET_MAX_METRIC_GROUP_NAME.
+    const char* pDescription,                                               ///< [in] pointer to metric group description. Must point to a
+                                                                            ///< null-terminated character array no longer than
+                                                                            ///< ::ZET_MAX_METRIC_GROUP_DESCRIPTION.
+    zet_metric_group_sampling_type_flags_t samplingType,                    ///< [in] Sampling type for the metric group.
+    zet_metric_group_handle_t* phMetricGroup                                ///< [in,out] Created Metric group handle
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Add a metric handle to the metric group handle created using
+///        ::zetDeviceCreateMetricGroupsFromMetricsExp.
+/// 
+/// @details
+///     - Reasons for failing to add the metric could be queried using
+///       pErrorString
+///     - Multiple additions of same metric would add the metric only once to
+///       the hMetricGroup
+///     - Metric handles from multiple domains may be used in a single metric
+///       group.
+///     - Metric handles from different sourceIds (refer
+///       ::zet_metric_programmable_exp_properties_t) are not allowed in a
+///       single metric group.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hMetricGroup`
+///         + `nullptr == hMetric`
+///     - ::ZE_RESULT_ERROR_INVALID_ARGUMENT
+///         + If a Metric handle from a pre-defined metric group is requested to be added.
+///     - ::ZE_RESULT_ERROR_HANDLE_OBJECT_IN_USE
+///         + If the metric group is currently activated.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetMetricGroupAddMetricExp(
+    zet_metric_group_handle_t hMetricGroup,                                 ///< [in] Handle of the metric group
+    zet_metric_handle_t hMetric,                                            ///< [in] Metric to be added to the group.
+    size_t * pErrorStringSize,                                              ///< [in,out][optional] Size of the error string to query, if an error was
+                                                                            ///< reported during adding the metric handle.
+                                                                            ///< if *pErrorStringSize is zero, then the driver shall update the value
+                                                                            ///< with the size of the error string in bytes.
+    char* pErrorString                                                      ///< [in,out][optional][range(0, *pErrorStringSize)] Error string.
+                                                                            ///< if *pErrorStringSize is less than the length of the error string
+                                                                            ///< available, then driver shall only retrieve that length of error string.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Remove a metric from the metric group handle created using
+///        ::zetDeviceCreateMetricGroupsFromMetricsExp.
+/// 
+/// @details
+///     - Remove an already added metric handle from the metric group.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hMetricGroup`
+///         + `nullptr == hMetric`
+///     - ::ZE_RESULT_ERROR_INVALID_ARGUMENT
+///         + If trying to remove a metric not previously added to the metric group
+///         + If the input metric group is a pre-defined metric group
+///     - ::ZE_RESULT_ERROR_HANDLE_OBJECT_IN_USE
+///         + If the metric group is currently activated
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetMetricGroupRemoveMetricExp(
+    zet_metric_group_handle_t hMetricGroup,                                 ///< [in] Handle of the metric group
+    zet_metric_handle_t hMetric                                             ///< [in] Metric handle to be removed from the metric group.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Closes a created metric group using
+///        ::zetDeviceCreateMetricGroupsFromMetricsExp, so that it can be
+///        activated.
+/// 
+/// @details
+///     - Finalizes the ::zetMetricGroupAddMetricExp and
+///       ::zetMetricGroupRemoveMetricExp operations on the metric group.
+///     - This is a necessary step before activation of the created metric
+///       group.
+///     - Add / Remove of metrics is possible after ::zetMetricGroupCloseExp.
+///       However, a call to ::zetMetricGroupCloseExp is necessary after
+///       modifying the metric group.
+///     - Implementations could choose to add new metrics to the group during
+///       ::zetMetricGroupCloseExp, which are related and might add value to the
+///       metrics already added by the application
+///     - Applications can query the list of metrics in the metric group using
+///       ::zetMetricGet
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hMetricGroup`
+///     - ::ZE_RESULT_ERROR_INVALID_ARGUMENT
+///         + If the input metric group is a pre-defined metric group
+///     - ::ZE_RESULT_ERROR_HANDLE_OBJECT_IN_USE
+///         + If the metric group is currently activated
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetMetricGroupCloseExp(
+    zet_metric_group_handle_t hMetricGroup                                  ///< [in] Handle of the metric group
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Destroy a metric group created using
+///        ::zetDeviceCreateMetricGroupsFromMetricsExp.
+/// 
+/// @details
+///     - Metric handles created using ::zetMetricCreateFromProgrammableExp2 and
+///       are part of the metricGroup are not destroyed.
+///     - It is necessary to call ::zetMetricDestroyExp for each of the metric
+///       handles (created from ::zetMetricCreateFromProgrammableExp2) to
+///       destroy them.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hMetricGroup`
+///     - ::ZE_RESULT_ERROR_INVALID_ARGUMENT
+///         + If trying to destroy a pre-defined metric group
+///     - ::ZE_RESULT_ERROR_HANDLE_OBJECT_IN_USE
+///         + If trying to destroy an activated metric group
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetMetricGroupDestroyExp(
+    zet_metric_group_handle_t hMetricGroup                                  ///< [in] Handle of the metric group to destroy
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Destroy a metric created using ::zetMetricCreateFromProgrammableExp2.
+/// 
+/// @details
+///     - If a metric is added to a metric group, the metric has to be removed
+///       using ::zetMetricGroupRemoveMetricExp before it can be destroyed.
+/// 
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_DEVICE_LOST
+///     - ::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hMetric`
+///     - ::ZE_RESULT_ERROR_INVALID_ARGUMENT
+///         + If trying to destroy a metric from pre-defined metric group
+///     - ::ZE_RESULT_ERROR_HANDLE_OBJECT_IN_USE
+///         + If trying to destroy a metric currently added to a metric group
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zetMetricDestroyExp(
+    zet_metric_handle_t hMetric                                             ///< [in] Handle of the metric to destroy
+    );
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+
+#if defined(__cplusplus)
+} // extern "C"
+#endif
+
+#endif // _ZET_API_H

--- a/include/level_zero/zet_ddi.h
+++ b/include/level_zero/zet_ddi.h
@@ -1,0 +1,1198 @@
+/*
+ *
+ * Copyright (C) 2019-2021 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file zet_ddi.h
+ * @version v1.12-r1.12.15
+ *
+ */
+#ifndef _ZET_DDI_H
+#define _ZET_DDI_H
+#if defined(__cplusplus)
+#pragma once
+#endif
+#include "zet_api.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetMetricProgrammableGetExp 
+typedef ze_result_t (ZE_APICALL *zet_pfnMetricProgrammableGetExp_t)(
+    zet_device_handle_t,
+    uint32_t*,
+    zet_metric_programmable_exp_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetMetricProgrammableGetPropertiesExp 
+typedef ze_result_t (ZE_APICALL *zet_pfnMetricProgrammableGetPropertiesExp_t)(
+    zet_metric_programmable_exp_handle_t,
+    zet_metric_programmable_exp_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetMetricProgrammableGetParamInfoExp 
+typedef ze_result_t (ZE_APICALL *zet_pfnMetricProgrammableGetParamInfoExp_t)(
+    zet_metric_programmable_exp_handle_t,
+    uint32_t*,
+    zet_metric_programmable_param_info_exp_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetMetricProgrammableGetParamValueInfoExp 
+typedef ze_result_t (ZE_APICALL *zet_pfnMetricProgrammableGetParamValueInfoExp_t)(
+    zet_metric_programmable_exp_handle_t,
+    uint32_t,
+    uint32_t*,
+    zet_metric_programmable_param_value_info_exp_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of MetricProgrammableExp functions pointers
+typedef struct _zet_metric_programmable_exp_dditable_t
+{
+    zet_pfnMetricProgrammableGetExp_t                           pfnGetExp;
+    zet_pfnMetricProgrammableGetPropertiesExp_t                 pfnGetPropertiesExp;
+    zet_pfnMetricProgrammableGetParamInfoExp_t                  pfnGetParamInfoExp;
+    zet_pfnMetricProgrammableGetParamValueInfoExp_t             pfnGetParamValueInfoExp;
+} zet_metric_programmable_exp_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's MetricProgrammableExp table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zetGetMetricProgrammableExpProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    zet_metric_programmable_exp_dditable_t* pDdiTable                       ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetGetMetricProgrammableExpProcAddrTable
+typedef ze_result_t (ZE_APICALL *zet_pfnGetMetricProgrammableExpProcAddrTable_t)(
+    ze_api_version_t,
+    zet_metric_programmable_exp_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetMetricTracerCreateExp 
+typedef ze_result_t (ZE_APICALL *zet_pfnMetricTracerCreateExp_t)(
+    zet_context_handle_t,
+    zet_device_handle_t,
+    uint32_t,
+    zet_metric_group_handle_t*,
+    zet_metric_tracer_exp_desc_t*,
+    ze_event_handle_t,
+    zet_metric_tracer_exp_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetMetricTracerDestroyExp 
+typedef ze_result_t (ZE_APICALL *zet_pfnMetricTracerDestroyExp_t)(
+    zet_metric_tracer_exp_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetMetricTracerEnableExp 
+typedef ze_result_t (ZE_APICALL *zet_pfnMetricTracerEnableExp_t)(
+    zet_metric_tracer_exp_handle_t,
+    ze_bool_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetMetricTracerDisableExp 
+typedef ze_result_t (ZE_APICALL *zet_pfnMetricTracerDisableExp_t)(
+    zet_metric_tracer_exp_handle_t,
+    ze_bool_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetMetricTracerReadDataExp 
+typedef ze_result_t (ZE_APICALL *zet_pfnMetricTracerReadDataExp_t)(
+    zet_metric_tracer_exp_handle_t,
+    size_t*,
+    uint8_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetMetricTracerDecodeExp 
+typedef ze_result_t (ZE_APICALL *zet_pfnMetricTracerDecodeExp_t)(
+    zet_metric_decoder_exp_handle_t,
+    size_t*,
+    uint8_t*,
+    uint32_t,
+    zet_metric_handle_t*,
+    uint32_t*,
+    uint32_t*,
+    uint32_t*,
+    zet_metric_entry_exp_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of MetricTracerExp functions pointers
+typedef struct _zet_metric_tracer_exp_dditable_t
+{
+    zet_pfnMetricTracerCreateExp_t                              pfnCreateExp;
+    zet_pfnMetricTracerDestroyExp_t                             pfnDestroyExp;
+    zet_pfnMetricTracerEnableExp_t                              pfnEnableExp;
+    zet_pfnMetricTracerDisableExp_t                             pfnDisableExp;
+    zet_pfnMetricTracerReadDataExp_t                            pfnReadDataExp;
+    zet_pfnMetricTracerDecodeExp_t                              pfnDecodeExp;
+} zet_metric_tracer_exp_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's MetricTracerExp table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zetGetMetricTracerExpProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    zet_metric_tracer_exp_dditable_t* pDdiTable                             ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetGetMetricTracerExpProcAddrTable
+typedef ze_result_t (ZE_APICALL *zet_pfnGetMetricTracerExpProcAddrTable_t)(
+    ze_api_version_t,
+    zet_metric_tracer_exp_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetMetricDecoderCreateExp 
+typedef ze_result_t (ZE_APICALL *zet_pfnMetricDecoderCreateExp_t)(
+    zet_metric_tracer_exp_handle_t,
+    zet_metric_decoder_exp_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetMetricDecoderDestroyExp 
+typedef ze_result_t (ZE_APICALL *zet_pfnMetricDecoderDestroyExp_t)(
+    zet_metric_decoder_exp_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetMetricDecoderGetDecodableMetricsExp 
+typedef ze_result_t (ZE_APICALL *zet_pfnMetricDecoderGetDecodableMetricsExp_t)(
+    zet_metric_decoder_exp_handle_t,
+    uint32_t*,
+    zet_metric_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of MetricDecoderExp functions pointers
+typedef struct _zet_metric_decoder_exp_dditable_t
+{
+    zet_pfnMetricDecoderCreateExp_t                             pfnCreateExp;
+    zet_pfnMetricDecoderDestroyExp_t                            pfnDestroyExp;
+    zet_pfnMetricDecoderGetDecodableMetricsExp_t                pfnGetDecodableMetricsExp;
+} zet_metric_decoder_exp_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's MetricDecoderExp table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zetGetMetricDecoderExpProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    zet_metric_decoder_exp_dditable_t* pDdiTable                            ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetGetMetricDecoderExpProcAddrTable
+typedef ze_result_t (ZE_APICALL *zet_pfnGetMetricDecoderExpProcAddrTable_t)(
+    ze_api_version_t,
+    zet_metric_decoder_exp_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetDeviceGetDebugProperties 
+typedef ze_result_t (ZE_APICALL *zet_pfnDeviceGetDebugProperties_t)(
+    zet_device_handle_t,
+    zet_device_debug_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Device functions pointers
+typedef struct _zet_device_dditable_t
+{
+    zet_pfnDeviceGetDebugProperties_t                           pfnGetDebugProperties;
+} zet_device_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Device table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zetGetDeviceProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    zet_device_dditable_t* pDdiTable                                        ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetGetDeviceProcAddrTable
+typedef ze_result_t (ZE_APICALL *zet_pfnGetDeviceProcAddrTable_t)(
+    ze_api_version_t,
+    zet_device_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetDeviceGetConcurrentMetricGroupsExp 
+typedef ze_result_t (ZE_APICALL *zet_pfnDeviceGetConcurrentMetricGroupsExp_t)(
+    zet_device_handle_t,
+    uint32_t,
+    zet_metric_group_handle_t *,
+    uint32_t *,
+    uint32_t *
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetDeviceCreateMetricGroupsFromMetricsExp 
+typedef ze_result_t (ZE_APICALL *zet_pfnDeviceCreateMetricGroupsFromMetricsExp_t)(
+    zet_device_handle_t,
+    uint32_t,
+    zet_metric_handle_t *,
+    const char *,
+    const char *,
+    uint32_t *,
+    zet_metric_group_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of DeviceExp functions pointers
+typedef struct _zet_device_exp_dditable_t
+{
+    zet_pfnDeviceGetConcurrentMetricGroupsExp_t                 pfnGetConcurrentMetricGroupsExp;
+    zet_pfnDeviceCreateMetricGroupsFromMetricsExp_t             pfnCreateMetricGroupsFromMetricsExp;
+} zet_device_exp_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's DeviceExp table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zetGetDeviceExpProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    zet_device_exp_dditable_t* pDdiTable                                    ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetGetDeviceExpProcAddrTable
+typedef ze_result_t (ZE_APICALL *zet_pfnGetDeviceExpProcAddrTable_t)(
+    ze_api_version_t,
+    zet_device_exp_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetContextActivateMetricGroups 
+typedef ze_result_t (ZE_APICALL *zet_pfnContextActivateMetricGroups_t)(
+    zet_context_handle_t,
+    zet_device_handle_t,
+    uint32_t,
+    zet_metric_group_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Context functions pointers
+typedef struct _zet_context_dditable_t
+{
+    zet_pfnContextActivateMetricGroups_t                        pfnActivateMetricGroups;
+} zet_context_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Context table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zetGetContextProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    zet_context_dditable_t* pDdiTable                                       ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetGetContextProcAddrTable
+typedef ze_result_t (ZE_APICALL *zet_pfnGetContextProcAddrTable_t)(
+    ze_api_version_t,
+    zet_context_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetCommandListAppendMetricStreamerMarker 
+typedef ze_result_t (ZE_APICALL *zet_pfnCommandListAppendMetricStreamerMarker_t)(
+    zet_command_list_handle_t,
+    zet_metric_streamer_handle_t,
+    uint32_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetCommandListAppendMetricQueryBegin 
+typedef ze_result_t (ZE_APICALL *zet_pfnCommandListAppendMetricQueryBegin_t)(
+    zet_command_list_handle_t,
+    zet_metric_query_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetCommandListAppendMetricQueryEnd 
+typedef ze_result_t (ZE_APICALL *zet_pfnCommandListAppendMetricQueryEnd_t)(
+    zet_command_list_handle_t,
+    zet_metric_query_handle_t,
+    ze_event_handle_t,
+    uint32_t,
+    ze_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetCommandListAppendMetricMemoryBarrier 
+typedef ze_result_t (ZE_APICALL *zet_pfnCommandListAppendMetricMemoryBarrier_t)(
+    zet_command_list_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of CommandList functions pointers
+typedef struct _zet_command_list_dditable_t
+{
+    zet_pfnCommandListAppendMetricStreamerMarker_t              pfnAppendMetricStreamerMarker;
+    zet_pfnCommandListAppendMetricQueryBegin_t                  pfnAppendMetricQueryBegin;
+    zet_pfnCommandListAppendMetricQueryEnd_t                    pfnAppendMetricQueryEnd;
+    zet_pfnCommandListAppendMetricMemoryBarrier_t               pfnAppendMetricMemoryBarrier;
+} zet_command_list_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's CommandList table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zetGetCommandListProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    zet_command_list_dditable_t* pDdiTable                                  ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetGetCommandListProcAddrTable
+typedef ze_result_t (ZE_APICALL *zet_pfnGetCommandListProcAddrTable_t)(
+    ze_api_version_t,
+    zet_command_list_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetModuleGetDebugInfo 
+typedef ze_result_t (ZE_APICALL *zet_pfnModuleGetDebugInfo_t)(
+    zet_module_handle_t,
+    zet_module_debug_info_format_t,
+    size_t*,
+    uint8_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Module functions pointers
+typedef struct _zet_module_dditable_t
+{
+    zet_pfnModuleGetDebugInfo_t                                 pfnGetDebugInfo;
+} zet_module_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Module table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zetGetModuleProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    zet_module_dditable_t* pDdiTable                                        ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetGetModuleProcAddrTable
+typedef ze_result_t (ZE_APICALL *zet_pfnGetModuleProcAddrTable_t)(
+    ze_api_version_t,
+    zet_module_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetKernelGetProfileInfo 
+typedef ze_result_t (ZE_APICALL *zet_pfnKernelGetProfileInfo_t)(
+    zet_kernel_handle_t,
+    zet_profile_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Kernel functions pointers
+typedef struct _zet_kernel_dditable_t
+{
+    zet_pfnKernelGetProfileInfo_t                               pfnGetProfileInfo;
+} zet_kernel_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Kernel table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zetGetKernelProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    zet_kernel_dditable_t* pDdiTable                                        ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetGetKernelProcAddrTable
+typedef ze_result_t (ZE_APICALL *zet_pfnGetKernelProcAddrTable_t)(
+    ze_api_version_t,
+    zet_kernel_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetMetricGet 
+typedef ze_result_t (ZE_APICALL *zet_pfnMetricGet_t)(
+    zet_metric_group_handle_t,
+    uint32_t*,
+    zet_metric_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetMetricGetProperties 
+typedef ze_result_t (ZE_APICALL *zet_pfnMetricGetProperties_t)(
+    zet_metric_handle_t,
+    zet_metric_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Metric functions pointers
+typedef struct _zet_metric_dditable_t
+{
+    zet_pfnMetricGet_t                                          pfnGet;
+    zet_pfnMetricGetProperties_t                                pfnGetProperties;
+} zet_metric_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Metric table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zetGetMetricProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    zet_metric_dditable_t* pDdiTable                                        ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetGetMetricProcAddrTable
+typedef ze_result_t (ZE_APICALL *zet_pfnGetMetricProcAddrTable_t)(
+    ze_api_version_t,
+    zet_metric_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetMetricCreateFromProgrammableExp 
+typedef ze_result_t (ZE_APICALL *zet_pfnMetricCreateFromProgrammableExp_t)(
+    zet_metric_programmable_exp_handle_t,
+    zet_metric_programmable_param_value_exp_t*,
+    uint32_t,
+    const char*,
+    const char*,
+    uint32_t*,
+    zet_metric_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetMetricDestroyExp 
+typedef ze_result_t (ZE_APICALL *zet_pfnMetricDestroyExp_t)(
+    zet_metric_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetMetricCreateFromProgrammableExp2 
+typedef ze_result_t (ZE_APICALL *zet_pfnMetricCreateFromProgrammableExp2_t)(
+    zet_metric_programmable_exp_handle_t,
+    uint32_t,
+    zet_metric_programmable_param_value_exp_t*,
+    const char*,
+    const char*,
+    uint32_t*,
+    zet_metric_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of MetricExp functions pointers
+typedef struct _zet_metric_exp_dditable_t
+{
+    zet_pfnMetricCreateFromProgrammableExp_t                    pfnCreateFromProgrammableExp;
+    zet_pfnMetricDestroyExp_t                                   pfnDestroyExp;
+    zet_pfnMetricCreateFromProgrammableExp2_t                   pfnCreateFromProgrammableExp2;
+} zet_metric_exp_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's MetricExp table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zetGetMetricExpProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    zet_metric_exp_dditable_t* pDdiTable                                    ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetGetMetricExpProcAddrTable
+typedef ze_result_t (ZE_APICALL *zet_pfnGetMetricExpProcAddrTable_t)(
+    ze_api_version_t,
+    zet_metric_exp_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetMetricGroupGet 
+typedef ze_result_t (ZE_APICALL *zet_pfnMetricGroupGet_t)(
+    zet_device_handle_t,
+    uint32_t*,
+    zet_metric_group_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetMetricGroupGetProperties 
+typedef ze_result_t (ZE_APICALL *zet_pfnMetricGroupGetProperties_t)(
+    zet_metric_group_handle_t,
+    zet_metric_group_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetMetricGroupCalculateMetricValues 
+typedef ze_result_t (ZE_APICALL *zet_pfnMetricGroupCalculateMetricValues_t)(
+    zet_metric_group_handle_t,
+    zet_metric_group_calculation_type_t,
+    size_t,
+    const uint8_t*,
+    uint32_t*,
+    zet_typed_value_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of MetricGroup functions pointers
+typedef struct _zet_metric_group_dditable_t
+{
+    zet_pfnMetricGroupGet_t                                     pfnGet;
+    zet_pfnMetricGroupGetProperties_t                           pfnGetProperties;
+    zet_pfnMetricGroupCalculateMetricValues_t                   pfnCalculateMetricValues;
+} zet_metric_group_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's MetricGroup table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zetGetMetricGroupProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    zet_metric_group_dditable_t* pDdiTable                                  ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetGetMetricGroupProcAddrTable
+typedef ze_result_t (ZE_APICALL *zet_pfnGetMetricGroupProcAddrTable_t)(
+    ze_api_version_t,
+    zet_metric_group_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetMetricGroupCalculateMultipleMetricValuesExp 
+typedef ze_result_t (ZE_APICALL *zet_pfnMetricGroupCalculateMultipleMetricValuesExp_t)(
+    zet_metric_group_handle_t,
+    zet_metric_group_calculation_type_t,
+    size_t,
+    const uint8_t*,
+    uint32_t*,
+    uint32_t*,
+    uint32_t*,
+    zet_typed_value_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetMetricGroupGetGlobalTimestampsExp 
+typedef ze_result_t (ZE_APICALL *zet_pfnMetricGroupGetGlobalTimestampsExp_t)(
+    zet_metric_group_handle_t,
+    ze_bool_t,
+    uint64_t*,
+    uint64_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetMetricGroupGetExportDataExp 
+typedef ze_result_t (ZE_APICALL *zet_pfnMetricGroupGetExportDataExp_t)(
+    zet_metric_group_handle_t,
+    const uint8_t*,
+    size_t,
+    size_t*,
+    uint8_t *
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetMetricGroupCalculateMetricExportDataExp 
+typedef ze_result_t (ZE_APICALL *zet_pfnMetricGroupCalculateMetricExportDataExp_t)(
+    ze_driver_handle_t,
+    zet_metric_group_calculation_type_t,
+    size_t,
+    const uint8_t*,
+    zet_metric_calculate_exp_desc_t*,
+    uint32_t*,
+    uint32_t*,
+    uint32_t*,
+    zet_typed_value_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetMetricGroupCreateExp 
+typedef ze_result_t (ZE_APICALL *zet_pfnMetricGroupCreateExp_t)(
+    zet_device_handle_t,
+    const char*,
+    const char*,
+    zet_metric_group_sampling_type_flags_t,
+    zet_metric_group_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetMetricGroupAddMetricExp 
+typedef ze_result_t (ZE_APICALL *zet_pfnMetricGroupAddMetricExp_t)(
+    zet_metric_group_handle_t,
+    zet_metric_handle_t,
+    size_t *,
+    char*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetMetricGroupRemoveMetricExp 
+typedef ze_result_t (ZE_APICALL *zet_pfnMetricGroupRemoveMetricExp_t)(
+    zet_metric_group_handle_t,
+    zet_metric_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetMetricGroupCloseExp 
+typedef ze_result_t (ZE_APICALL *zet_pfnMetricGroupCloseExp_t)(
+    zet_metric_group_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetMetricGroupDestroyExp 
+typedef ze_result_t (ZE_APICALL *zet_pfnMetricGroupDestroyExp_t)(
+    zet_metric_group_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of MetricGroupExp functions pointers
+typedef struct _zet_metric_group_exp_dditable_t
+{
+    zet_pfnMetricGroupCalculateMultipleMetricValuesExp_t        pfnCalculateMultipleMetricValuesExp;
+    zet_pfnMetricGroupGetGlobalTimestampsExp_t                  pfnGetGlobalTimestampsExp;
+    zet_pfnMetricGroupGetExportDataExp_t                        pfnGetExportDataExp;
+    zet_pfnMetricGroupCalculateMetricExportDataExp_t            pfnCalculateMetricExportDataExp;
+    zet_pfnMetricGroupCreateExp_t                               pfnCreateExp;
+    zet_pfnMetricGroupAddMetricExp_t                            pfnAddMetricExp;
+    zet_pfnMetricGroupRemoveMetricExp_t                         pfnRemoveMetricExp;
+    zet_pfnMetricGroupCloseExp_t                                pfnCloseExp;
+    zet_pfnMetricGroupDestroyExp_t                              pfnDestroyExp;
+} zet_metric_group_exp_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's MetricGroupExp table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zetGetMetricGroupExpProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    zet_metric_group_exp_dditable_t* pDdiTable                              ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetGetMetricGroupExpProcAddrTable
+typedef ze_result_t (ZE_APICALL *zet_pfnGetMetricGroupExpProcAddrTable_t)(
+    ze_api_version_t,
+    zet_metric_group_exp_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetMetricStreamerOpen 
+typedef ze_result_t (ZE_APICALL *zet_pfnMetricStreamerOpen_t)(
+    zet_context_handle_t,
+    zet_device_handle_t,
+    zet_metric_group_handle_t,
+    zet_metric_streamer_desc_t*,
+    ze_event_handle_t,
+    zet_metric_streamer_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetMetricStreamerClose 
+typedef ze_result_t (ZE_APICALL *zet_pfnMetricStreamerClose_t)(
+    zet_metric_streamer_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetMetricStreamerReadData 
+typedef ze_result_t (ZE_APICALL *zet_pfnMetricStreamerReadData_t)(
+    zet_metric_streamer_handle_t,
+    uint32_t,
+    size_t*,
+    uint8_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of MetricStreamer functions pointers
+typedef struct _zet_metric_streamer_dditable_t
+{
+    zet_pfnMetricStreamerOpen_t                                 pfnOpen;
+    zet_pfnMetricStreamerClose_t                                pfnClose;
+    zet_pfnMetricStreamerReadData_t                             pfnReadData;
+} zet_metric_streamer_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's MetricStreamer table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zetGetMetricStreamerProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    zet_metric_streamer_dditable_t* pDdiTable                               ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetGetMetricStreamerProcAddrTable
+typedef ze_result_t (ZE_APICALL *zet_pfnGetMetricStreamerProcAddrTable_t)(
+    ze_api_version_t,
+    zet_metric_streamer_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetMetricQueryPoolCreate 
+typedef ze_result_t (ZE_APICALL *zet_pfnMetricQueryPoolCreate_t)(
+    zet_context_handle_t,
+    zet_device_handle_t,
+    zet_metric_group_handle_t,
+    const zet_metric_query_pool_desc_t*,
+    zet_metric_query_pool_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetMetricQueryPoolDestroy 
+typedef ze_result_t (ZE_APICALL *zet_pfnMetricQueryPoolDestroy_t)(
+    zet_metric_query_pool_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of MetricQueryPool functions pointers
+typedef struct _zet_metric_query_pool_dditable_t
+{
+    zet_pfnMetricQueryPoolCreate_t                              pfnCreate;
+    zet_pfnMetricQueryPoolDestroy_t                             pfnDestroy;
+} zet_metric_query_pool_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's MetricQueryPool table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zetGetMetricQueryPoolProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    zet_metric_query_pool_dditable_t* pDdiTable                             ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetGetMetricQueryPoolProcAddrTable
+typedef ze_result_t (ZE_APICALL *zet_pfnGetMetricQueryPoolProcAddrTable_t)(
+    ze_api_version_t,
+    zet_metric_query_pool_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetMetricQueryCreate 
+typedef ze_result_t (ZE_APICALL *zet_pfnMetricQueryCreate_t)(
+    zet_metric_query_pool_handle_t,
+    uint32_t,
+    zet_metric_query_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetMetricQueryDestroy 
+typedef ze_result_t (ZE_APICALL *zet_pfnMetricQueryDestroy_t)(
+    zet_metric_query_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetMetricQueryReset 
+typedef ze_result_t (ZE_APICALL *zet_pfnMetricQueryReset_t)(
+    zet_metric_query_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetMetricQueryGetData 
+typedef ze_result_t (ZE_APICALL *zet_pfnMetricQueryGetData_t)(
+    zet_metric_query_handle_t,
+    size_t*,
+    uint8_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of MetricQuery functions pointers
+typedef struct _zet_metric_query_dditable_t
+{
+    zet_pfnMetricQueryCreate_t                                  pfnCreate;
+    zet_pfnMetricQueryDestroy_t                                 pfnDestroy;
+    zet_pfnMetricQueryReset_t                                   pfnReset;
+    zet_pfnMetricQueryGetData_t                                 pfnGetData;
+} zet_metric_query_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's MetricQuery table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zetGetMetricQueryProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    zet_metric_query_dditable_t* pDdiTable                                  ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetGetMetricQueryProcAddrTable
+typedef ze_result_t (ZE_APICALL *zet_pfnGetMetricQueryProcAddrTable_t)(
+    ze_api_version_t,
+    zet_metric_query_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetTracerExpCreate 
+typedef ze_result_t (ZE_APICALL *zet_pfnTracerExpCreate_t)(
+    zet_context_handle_t,
+    const zet_tracer_exp_desc_t*,
+    zet_tracer_exp_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetTracerExpDestroy 
+typedef ze_result_t (ZE_APICALL *zet_pfnTracerExpDestroy_t)(
+    zet_tracer_exp_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetTracerExpSetPrologues 
+typedef ze_result_t (ZE_APICALL *zet_pfnTracerExpSetPrologues_t)(
+    zet_tracer_exp_handle_t,
+    zet_core_callbacks_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetTracerExpSetEpilogues 
+typedef ze_result_t (ZE_APICALL *zet_pfnTracerExpSetEpilogues_t)(
+    zet_tracer_exp_handle_t,
+    zet_core_callbacks_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetTracerExpSetEnabled 
+typedef ze_result_t (ZE_APICALL *zet_pfnTracerExpSetEnabled_t)(
+    zet_tracer_exp_handle_t,
+    ze_bool_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of TracerExp functions pointers
+typedef struct _zet_tracer_exp_dditable_t
+{
+    zet_pfnTracerExpCreate_t                                    pfnCreate;
+    zet_pfnTracerExpDestroy_t                                   pfnDestroy;
+    zet_pfnTracerExpSetPrologues_t                              pfnSetPrologues;
+    zet_pfnTracerExpSetEpilogues_t                              pfnSetEpilogues;
+    zet_pfnTracerExpSetEnabled_t                                pfnSetEnabled;
+} zet_tracer_exp_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's TracerExp table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zetGetTracerExpProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    zet_tracer_exp_dditable_t* pDdiTable                                    ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetGetTracerExpProcAddrTable
+typedef ze_result_t (ZE_APICALL *zet_pfnGetTracerExpProcAddrTable_t)(
+    ze_api_version_t,
+    zet_tracer_exp_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetDebugAttach 
+typedef ze_result_t (ZE_APICALL *zet_pfnDebugAttach_t)(
+    zet_device_handle_t,
+    const zet_debug_config_t*,
+    zet_debug_session_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetDebugDetach 
+typedef ze_result_t (ZE_APICALL *zet_pfnDebugDetach_t)(
+    zet_debug_session_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetDebugReadEvent 
+typedef ze_result_t (ZE_APICALL *zet_pfnDebugReadEvent_t)(
+    zet_debug_session_handle_t,
+    uint64_t,
+    zet_debug_event_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetDebugAcknowledgeEvent 
+typedef ze_result_t (ZE_APICALL *zet_pfnDebugAcknowledgeEvent_t)(
+    zet_debug_session_handle_t,
+    const zet_debug_event_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetDebugInterrupt 
+typedef ze_result_t (ZE_APICALL *zet_pfnDebugInterrupt_t)(
+    zet_debug_session_handle_t,
+    ze_device_thread_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetDebugResume 
+typedef ze_result_t (ZE_APICALL *zet_pfnDebugResume_t)(
+    zet_debug_session_handle_t,
+    ze_device_thread_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetDebugReadMemory 
+typedef ze_result_t (ZE_APICALL *zet_pfnDebugReadMemory_t)(
+    zet_debug_session_handle_t,
+    ze_device_thread_t,
+    const zet_debug_memory_space_desc_t*,
+    size_t,
+    void*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetDebugWriteMemory 
+typedef ze_result_t (ZE_APICALL *zet_pfnDebugWriteMemory_t)(
+    zet_debug_session_handle_t,
+    ze_device_thread_t,
+    const zet_debug_memory_space_desc_t*,
+    size_t,
+    const void*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetDebugGetRegisterSetProperties 
+typedef ze_result_t (ZE_APICALL *zet_pfnDebugGetRegisterSetProperties_t)(
+    zet_device_handle_t,
+    uint32_t*,
+    zet_debug_regset_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetDebugReadRegisters 
+typedef ze_result_t (ZE_APICALL *zet_pfnDebugReadRegisters_t)(
+    zet_debug_session_handle_t,
+    ze_device_thread_t,
+    uint32_t,
+    uint32_t,
+    uint32_t,
+    void*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetDebugWriteRegisters 
+typedef ze_result_t (ZE_APICALL *zet_pfnDebugWriteRegisters_t)(
+    zet_debug_session_handle_t,
+    ze_device_thread_t,
+    uint32_t,
+    uint32_t,
+    uint32_t,
+    void*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetDebugGetThreadRegisterSetProperties 
+typedef ze_result_t (ZE_APICALL *zet_pfnDebugGetThreadRegisterSetProperties_t)(
+    zet_debug_session_handle_t,
+    ze_device_thread_t,
+    uint32_t*,
+    zet_debug_regset_properties_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Debug functions pointers
+typedef struct _zet_debug_dditable_t
+{
+    zet_pfnDebugAttach_t                                        pfnAttach;
+    zet_pfnDebugDetach_t                                        pfnDetach;
+    zet_pfnDebugReadEvent_t                                     pfnReadEvent;
+    zet_pfnDebugAcknowledgeEvent_t                              pfnAcknowledgeEvent;
+    zet_pfnDebugInterrupt_t                                     pfnInterrupt;
+    zet_pfnDebugResume_t                                        pfnResume;
+    zet_pfnDebugReadMemory_t                                    pfnReadMemory;
+    zet_pfnDebugWriteMemory_t                                   pfnWriteMemory;
+    zet_pfnDebugGetRegisterSetProperties_t                      pfnGetRegisterSetProperties;
+    zet_pfnDebugReadRegisters_t                                 pfnReadRegisters;
+    zet_pfnDebugWriteRegisters_t                                pfnWriteRegisters;
+    zet_pfnDebugGetThreadRegisterSetProperties_t                pfnGetThreadRegisterSetProperties;
+} zet_debug_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Debug table
+///        with current process' addresses
+///
+/// @returns
+///     - ::ZE_RESULT_SUCCESS
+///     - ::ZE_RESULT_ERROR_UNINITIALIZED
+///     - ::ZE_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::ZE_RESULT_ERROR_UNSUPPORTED_VERSION
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zetGetDebugProcAddrTable(
+    ze_api_version_t version,                                               ///< [in] API version requested
+    zet_debug_dditable_t* pDdiTable                                         ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for zetGetDebugProcAddrTable
+typedef ze_result_t (ZE_APICALL *zet_pfnGetDebugProcAddrTable_t)(
+    ze_api_version_t,
+    zet_debug_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Container for all DDI tables
+typedef struct _zet_dditable_t
+{
+    zet_metric_programmable_exp_dditable_t  MetricProgrammableExp;
+    zet_metric_tracer_exp_dditable_t    MetricTracerExp;
+    zet_metric_decoder_exp_dditable_t   MetricDecoderExp;
+    zet_device_dditable_t               Device;
+    zet_device_exp_dditable_t           DeviceExp;
+    zet_context_dditable_t              Context;
+    zet_command_list_dditable_t         CommandList;
+    zet_module_dditable_t               Module;
+    zet_kernel_dditable_t               Kernel;
+    zet_metric_dditable_t               Metric;
+    zet_metric_exp_dditable_t           MetricExp;
+    zet_metric_group_dditable_t         MetricGroup;
+    zet_metric_group_exp_dditable_t     MetricGroupExp;
+    zet_metric_streamer_dditable_t      MetricStreamer;
+    zet_metric_query_pool_dditable_t    MetricQueryPool;
+    zet_metric_query_dditable_t         MetricQuery;
+    zet_tracer_exp_dditable_t           TracerExp;
+    zet_debug_dditable_t                Debug;
+} zet_dditable_t;
+/// @brief Container for all DDI tables with version and tables set by the Driver
+typedef struct _zet_dditable_driver_t
+{
+    ze_api_version_t    version;
+    uint8_t             isValidFlag;
+    zet_metric_programmable_exp_dditable_t *    MetricProgrammableExp;
+    zet_metric_tracer_exp_dditable_t *  MetricTracerExp;
+    zet_metric_decoder_exp_dditable_t * MetricDecoderExp;
+    zet_device_dditable_t *             Device;
+    zet_device_exp_dditable_t *         DeviceExp;
+    zet_context_dditable_t *            Context;
+    zet_command_list_dditable_t *       CommandList;
+    zet_module_dditable_t *             Module;
+    zet_kernel_dditable_t *             Kernel;
+    zet_metric_dditable_t *             Metric;
+    zet_metric_exp_dditable_t *         MetricExp;
+    zet_metric_group_dditable_t *       MetricGroup;
+    zet_metric_group_exp_dditable_t *   MetricGroupExp;
+    zet_metric_streamer_dditable_t *    MetricStreamer;
+    zet_metric_query_pool_dditable_t *  MetricQueryPool;
+    zet_metric_query_dditable_t *       MetricQuery;
+    zet_tracer_exp_dditable_t *         TracerExp;
+    zet_debug_dditable_t *              Debug;
+} zet_dditable_driver_t;
+
+#if defined(__cplusplus)
+} // extern "C"
+#endif
+
+#endif // _ZET_DDI_H

--- a/scripts/copy_headers.py
+++ b/scripts/copy_headers.py
@@ -1,0 +1,30 @@
+#! /usr/bin/env python3
+"""
+ Copyright (C) 2025 Intel Corporation
+
+ SPDX-License-Identifier: MIT
+
+"""
+import argparse
+import glob
+import os
+import shutil
+import time
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("out_dir", type=str, help="Root of the loader repository.")
+    args = parser.parse_args()
+
+    start = time.time()
+
+    incpath = os.path.join(args.out_dir, "include")
+    extra_incpath = os.path.join(incpath, "level_zero")
+
+    def ignore(thedir, contents):
+        if thedir == incpath:
+            return ["level_zero"]
+        return []
+
+    shutil.copytree(incpath, extra_incpath, ignore=ignore, dirs_exist_ok=True)
+    print("\nCompleted in %.1f seconds!"%(time.time() - start))


### PR DESCRIPTION
This is to allow users consuming the headers from a
clone of the repository to be able to refer to the api headers
the same way as it would be if the level-zero headers were installed.
As in after running this script the following will compile
```c++
#include <level_zero/ze_api.h>
```
when `<path-to-repo>/include` is part of the include directory.

Symlinks or alternatively wrapper header files could be added that would
forward to the previous location, but I stuck with copies, since the
files are generated anyway and any solution outside of full copies might
have corner cases. (Symlinks are not always supported on windows,
the build system might be grepping in the contents of the header etc.).

This PR also does not deprecate the current location of the headers.