### PR TITLE
Implement basic leak checker in validation layer

### DIFF
--- a/source/layers/validation/checkers/CMakeLists.txt
+++ b/source/layers/validation/checkers/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_subdirectory(basic_leak)
 add_subdirectory(events_checker)
 add_subdirectory(parameter_validation)
 add_subdirectory(template)

--- a/source/layers/validation/checkers/basic_leak/CMakeLists.txt
+++ b/source/layers/validation/checkers/basic_leak/CMakeLists.txt
@@ -1,0 +1,5 @@
+target_sources(${TARGET_NAME}
+    PRIVATE
+        ${CMAKE_CURRENT_LIST_DIR}/zel_basic_leak_checker.h
+        ${CMAKE_CURRENT_LIST_DIR}/zel_basic_leak_checker.cpp
+)

--- a/source/layers/validation/checkers/basic_leak/zel_basic_leak_checker.cpp
+++ b/source/layers/validation/checkers/basic_leak/zel_basic_leak_checker.cpp
@@ -1,0 +1,297 @@
+/*
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file zel_basic_leak_checker.cpp
+ *
+ */
+#include "zel_basic_leak_checker.h"
+
+#include <cassert>
+#include <iostream>
+#include <sstream>
+#include <iomanip>
+
+namespace validation_layer
+{
+    class basic_leakChecker basic_leak_checker;
+
+    basic_leakChecker::basic_leakChecker() {
+        enablebasic_leak = getenv_tobool( "ZEL_ENABLE_BASIC_LEAK_CHECKER" );
+        if(enablebasic_leak) {
+            basic_leakChecker::ZEbasic_leakChecker *zeChecker = new basic_leakChecker::ZEbasic_leakChecker;
+            basic_leakChecker::ZESbasic_leakChecker *zesChecker = new basic_leakChecker::ZESbasic_leakChecker;
+            basic_leakChecker::ZETbasic_leakChecker *zetChecker = new basic_leakChecker::ZETbasic_leakChecker;
+            basic_leak_checker.zeValidation = zeChecker;
+            basic_leak_checker.zetValidation = zetChecker;
+            basic_leak_checker.zesValidation = zesChecker;
+            validation_layer::context.validationHandlers.push_back(&basic_leak_checker);
+        }
+    }
+
+    basic_leakChecker::~basic_leakChecker() {
+        if(enablebasic_leak) {
+            delete basic_leak_checker.zeValidation;
+            delete basic_leak_checker.zetValidation;
+            delete basic_leak_checker.zesValidation;
+        }
+    }
+
+    // The format of this table is such that each row accounts for a
+    // specific type of objects, and all elements in the raw except the last
+    // one are allocating objects of that type, while the last element is known
+    // to deallocate objects of that type.
+    //
+    static std::vector<std::vector<std::string>> createDestroySet() {
+        return {
+            {"zeContextCreate",      "zeContextDestroy"},
+            {"zeCommandQueueCreate", "zeCommandQueueDestroy"},
+            {"zeModuleCreate",       "zeModuleDestroy"},
+            {"zeKernelCreate",       "zeKernelDestroy"},
+            {"zeEventPoolCreate",    "zeEventPoolDestroy"},
+            {"zeCommandListCreateImmediate", "zeCommandListCreate", "zeCommandListDestroy"},
+            {"zeEventCreate",        "zeEventDestroy"},
+            {"zeFenceCreate",        "zeFenceDestroy"},
+            {"zeImageCreate",        "zeImageDestroy"},
+            {"zeSamplerCreate",      "zeSamplerDestroy"},
+            {"zeMemAllocDevice", "zeMemAllocHost", "zeMemAllocShared", "zeMemFree"}};
+    }
+
+    basic_leakChecker::ZEbasic_leakChecker::ZEbasic_leakChecker() {
+        // initialize counts for all functions that should be tracked
+        for (const auto &row : createDestroySet()) {
+            for (const auto &name : row) {
+                counts[name] = 0;
+            }
+        }
+    }
+
+    ze_result_t basic_leakChecker::ZEbasic_leakChecker::zeContextCreateEpilogue(ze_driver_handle_t, const ze_context_desc_t *, ze_context_handle_t*, ze_result_t result) {
+        if (result == ZE_RESULT_SUCCESS) {
+            countFunctionCall("zeContextCreate");
+        }
+        return result;
+    }
+
+    ze_result_t basic_leakChecker::ZEbasic_leakChecker::zeContextDestroyEpilogue(ze_context_handle_t, ze_result_t result) {
+        if (result == ZE_RESULT_SUCCESS) {
+            countFunctionCall("zeContextDestroy");
+        }
+        return result;
+    }
+
+    ze_result_t basic_leakChecker::ZEbasic_leakChecker::zeCommandQueueCreateEpilogue(ze_context_handle_t, ze_device_handle_t, const ze_command_queue_desc_t *, ze_command_queue_handle_t *, ze_result_t result) {
+        if (result == ZE_RESULT_SUCCESS) {
+            countFunctionCall("zeCommandQueueCreate");
+        }
+        return result;
+    }
+
+    ze_result_t basic_leakChecker::ZEbasic_leakChecker::zeCommandQueueDestroyEpilogue(ze_command_queue_handle_t, ze_result_t result) {
+        if (result == ZE_RESULT_SUCCESS) {
+            countFunctionCall("zeCommandQueueDestroy");
+        }
+        return result;
+    }
+
+    ze_result_t basic_leakChecker::ZEbasic_leakChecker::zeModuleCreateEpilogue(ze_context_handle_t, ze_device_handle_t, const ze_module_desc_t*, ze_module_handle_t*, ze_module_build_log_handle_t*, ze_result_t result) {
+        if (result == ZE_RESULT_SUCCESS) {
+            countFunctionCall("zeModuleCreate");
+        }
+        return result;
+    }
+
+    ze_result_t basic_leakChecker::ZEbasic_leakChecker::zeModuleDestroyEpilogue(ze_module_handle_t, ze_result_t result) {
+        if (result == ZE_RESULT_SUCCESS) {
+            countFunctionCall("zeModuleDestroy");
+        }
+        return result;
+    }
+
+    ze_result_t basic_leakChecker::ZEbasic_leakChecker::zeKernelCreateEpilogue(ze_module_handle_t, const ze_kernel_desc_t*, ze_kernel_handle_t*, ze_result_t result) {
+        if (result == ZE_RESULT_SUCCESS) {
+            countFunctionCall("zeKernelCreate");
+        }
+        return result;
+    }
+
+    ze_result_t basic_leakChecker::ZEbasic_leakChecker::zeKernelDestroyEpilogue(ze_kernel_handle_t, ze_result_t result) {
+        if (result == ZE_RESULT_SUCCESS) {
+            countFunctionCall("zeKernelDestroy");
+        }
+        return result;
+    }
+
+    ze_result_t basic_leakChecker::ZEbasic_leakChecker::zeEventPoolCreateEpilogue(ze_context_handle_t, const ze_event_pool_desc_t*, uint32_t, ze_device_handle_t*, ze_event_pool_handle_t*, ze_result_t result) {
+        if (result == ZE_RESULT_SUCCESS) {
+            countFunctionCall("zeEventPoolCreate");
+        }
+        return result;
+    }
+
+    ze_result_t basic_leakChecker::ZEbasic_leakChecker::zeEventPoolDestroyEpilogue(ze_event_pool_handle_t, ze_result_t result) {
+        if (result == ZE_RESULT_SUCCESS) {
+            countFunctionCall("zeEventPoolDestroy");
+        }
+        return result;
+    }
+
+    ze_result_t basic_leakChecker::ZEbasic_leakChecker::zeCommandListCreateImmediateEpilogue(ze_context_handle_t, ze_device_handle_t, const ze_command_queue_desc_t*, ze_command_list_handle_t*, ze_result_t result) {
+        if (result == ZE_RESULT_SUCCESS) {
+            countFunctionCall("zeCommandListCreateImmediate");
+        }
+        return result;
+    }
+
+    ze_result_t basic_leakChecker::ZEbasic_leakChecker::zeCommandListCreateEpilogue(ze_context_handle_t, ze_device_handle_t, const ze_command_list_desc_t*, ze_command_list_handle_t*, ze_result_t result) {
+        if (result == ZE_RESULT_SUCCESS) {
+            countFunctionCall("zeCommandListCreate");
+        }
+        return result;
+    }
+
+    ze_result_t basic_leakChecker::ZEbasic_leakChecker::zeCommandListDestroyEpilogue(ze_command_list_handle_t, ze_result_t result) {
+        if (result == ZE_RESULT_SUCCESS) {
+            countFunctionCall("zeCommandListDestroy");
+        }
+        return result;
+    }
+
+    ze_result_t basic_leakChecker::ZEbasic_leakChecker::zeEventCreateEpilogue(ze_event_pool_handle_t, const ze_event_desc_t *, ze_event_handle_t *, ze_result_t result) {
+        if (result == ZE_RESULT_SUCCESS) {
+            countFunctionCall("zeEventCreate");
+        }
+        return result;
+    }
+
+    ze_result_t basic_leakChecker::ZEbasic_leakChecker::zeEventDestroyEpilogue(ze_event_handle_t, ze_result_t result) {
+        if (result == ZE_RESULT_SUCCESS) {
+            countFunctionCall("zeEventDestroy");
+        }
+        return result;
+    }
+
+    ze_result_t basic_leakChecker::ZEbasic_leakChecker::zeFenceCreateEpilogue(ze_command_queue_handle_t, const ze_fence_desc_t *, ze_fence_handle_t*, ze_result_t result) {
+        if (result == ZE_RESULT_SUCCESS) {
+            countFunctionCall("zeFenceCreate");
+        }
+        return result;
+    }
+
+    ze_result_t basic_leakChecker::ZEbasic_leakChecker::zeFenceDestroyEpilogue(ze_fence_handle_t, ze_result_t result) {
+        if (result == ZE_RESULT_SUCCESS) {
+            countFunctionCall("zeFenceDestroy");
+        }
+        return result;
+    }
+
+    ze_result_t basic_leakChecker::ZEbasic_leakChecker::zeImageCreateEpilogue(ze_context_handle_t, ze_device_handle_t, const ze_image_desc_t*, ze_image_handle_t*, ze_result_t result) {
+        if (result == ZE_RESULT_SUCCESS) {
+            countFunctionCall("zeImageCreate");
+        }
+        return result;
+    }
+
+    ze_result_t basic_leakChecker::ZEbasic_leakChecker::zeImageDestroyEpilogue(ze_image_handle_t, ze_result_t result) {
+        if (result == ZE_RESULT_SUCCESS) {
+            countFunctionCall("zeImageDestroy");
+        }
+        return result;
+    }
+
+    ze_result_t basic_leakChecker::ZEbasic_leakChecker::zeSamplerCreateEpilogue(ze_context_handle_t, ze_device_handle_t, const ze_sampler_desc_t*, ze_sampler_handle_t*, ze_result_t result) {
+        if (result == ZE_RESULT_SUCCESS) {
+            countFunctionCall("zeSamplerCreate");
+        }
+        return result;
+    }
+
+    ze_result_t basic_leakChecker::ZEbasic_leakChecker::zeSamplerDestroyEpilogue(ze_sampler_handle_t, ze_result_t result) {
+        if (result == ZE_RESULT_SUCCESS) {
+            countFunctionCall("zeSamplerDestroy");
+        }
+        return result;
+    }
+
+    ze_result_t basic_leakChecker::ZEbasic_leakChecker::zeMemAllocDeviceEpilogue(ze_context_handle_t, const ze_device_mem_alloc_desc_t *, size_t, size_t, ze_device_handle_t, void **, ze_result_t result) {
+        if (result == ZE_RESULT_SUCCESS) {
+            countFunctionCall("zeMemAllocDevice");
+        }
+        return result;
+    }
+
+    ze_result_t basic_leakChecker::ZEbasic_leakChecker::zeMemAllocHostEpilogue(ze_context_handle_t, const ze_host_mem_alloc_desc_t *, size_t, size_t, void **, ze_result_t result) {
+        if (result == ZE_RESULT_SUCCESS) {
+            countFunctionCall("zeMemAllocHost");
+        }
+        return result;
+    }
+
+    ze_result_t basic_leakChecker::ZEbasic_leakChecker::zeMemAllocSharedEpilogue(ze_context_handle_t, const ze_device_mem_alloc_desc_t *, const ze_host_mem_alloc_desc_t *, size_t, size_t, ze_device_handle_t, void **, ze_result_t result) {
+        if (result == ZE_RESULT_SUCCESS) {
+            countFunctionCall("zeMemAllocShared");
+        }
+        return result;
+    }
+
+    ze_result_t basic_leakChecker::ZEbasic_leakChecker::zeMemFreeEpilogue(ze_context_handle_t, void *, ze_result_t result) {
+        if (result == ZE_RESULT_SUCCESS) {
+            countFunctionCall("zeMemFree");
+        }
+        return result;
+    }
+
+    void basic_leakChecker::ZEbasic_leakChecker::countFunctionCall(const std::string &functionName)
+    {
+        auto it = counts.find(functionName);
+
+        // make sure there is no insertion happening during program exeuction
+        // as inserting to the map is not thread safe
+        if (it == counts.end()) {
+            return;
+        }
+
+        it->second.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    basic_leakChecker::ZEbasic_leakChecker::~ZEbasic_leakChecker() {
+        std::cerr << "Check balance of create/destroy calls\n";
+        std::cerr << "----------------------------------------------------------\n";
+        std::stringstream ss;
+        for (const auto &Row : createDestroySet()) {
+            int64_t diff = 0;
+            for (auto I = Row.begin(); I != Row.end();) {
+                const char *ZeName = (*I).c_str();
+                const auto &ZeCount = (counts)[*I];
+
+                bool First = (I == Row.begin());
+                bool Last = (++I == Row.end());
+
+                if (Last) {
+                    ss << " \\--->";
+                    diff -= ZeCount;
+                } else {
+                    diff += ZeCount;
+                    if (!First) {
+                    ss << " | ";
+                    std::cerr << ss.str() << "\n";
+                    ss.str("");
+                    ss.clear();
+                    }
+                }
+                ss << std::setw(30) << std::right << ZeName;
+                ss << " = ";
+                ss << std::setw(5) << std::left << ZeCount;
+            }
+
+            if (diff) {
+                ss << " ---> LEAK = " << diff;
+            }
+
+            std::cerr << ss.str() << '\n';
+            ss.str("");
+            ss.clear();
+        }
+    }
+}

--- a/source/layers/validation/checkers/basic_leak/zel_basic_leak_checker.h
+++ b/source/layers/validation/checkers/basic_leak/zel_basic_leak_checker.h
@@ -1,0 +1,90 @@
+/*
+ *
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file zel_basic_leak_checker.h
+ *
+ */
+
+#pragma once
+
+#include <atomic>
+#include <string>
+#include <unordered_map>
+
+#include "ze_api.h"
+#include "ze_validation_layer.h"
+
+namespace validation_layer
+{
+    // Counts the number of calls to each function and reports (in the dtor)
+    // the difference between the number of calls to create and destroy functions
+    // if there is a mismatch.
+    //
+    // The functions to track are passed in the constructor.
+    //
+    // A sample output is this:
+    // ------------------------------------------------------------------------
+    //                zeContextCreate = 1     \--->        zeContextDestroy = 1
+    //           zeCommandQueueCreate = 1     \--->   zeCommandQueueDestroy = 1
+    //                 zeModuleCreate = 1     \--->         zeModuleDestroy = 1
+    //                 zeKernelCreate = 1     \--->         zeKernelDestroy = 1
+    //              zeEventPoolCreate = 1     \--->      zeEventPoolDestroy = 1
+    //   zeCommandListCreateImmediate = 1     |
+    //            zeCommandListCreate = 1     \--->    zeCommandListDestroy = 1  ---> LEAK = 1
+    //                  zeEventCreate = 2     \--->          zeEventDestroy = 2
+    //                  zeFenceCreate = 1     \--->          zeFenceDestroy = 1
+    //                  zeImageCreate = 0     \--->          zeImageDestroy = 0
+    //                zeSamplerCreate = 0     \--->        zeSamplerDestroy = 0
+    //               zeMemAllocDevice = 0     |
+    //                 zeMemAllocHost = 1     |
+    //               zeMemAllocShared = 0     \--->               zeMemFree = 1
+    //
+    class __zedlllocal basic_leakChecker : public validationChecker{
+        public:
+            basic_leakChecker();
+            ~basic_leakChecker();
+
+            class ZEbasic_leakChecker : public ZEValidationEntryPoints {
+            public:
+                ZEbasic_leakChecker();
+                ~ZEbasic_leakChecker();
+
+                ze_result_t zeContextCreateEpilogue(ze_driver_handle_t, const ze_context_desc_t *, ze_context_handle_t*, ze_result_t result) override;
+                ze_result_t zeContextDestroyEpilogue(ze_context_handle_t, ze_result_t result) override;
+                ze_result_t zeCommandQueueCreateEpilogue(ze_context_handle_t, ze_device_handle_t, const ze_command_queue_desc_t *, ze_command_queue_handle_t *, ze_result_t result) override;
+                ze_result_t zeCommandQueueDestroyEpilogue(ze_command_queue_handle_t, ze_result_t result) override;
+                ze_result_t zeModuleCreateEpilogue(ze_context_handle_t, ze_device_handle_t, const ze_module_desc_t*, ze_module_handle_t*, ze_module_build_log_handle_t*, ze_result_t result) override;
+                ze_result_t zeModuleDestroyEpilogue(ze_module_handle_t, ze_result_t result) override;
+                ze_result_t zeKernelCreateEpilogue(ze_module_handle_t, const ze_kernel_desc_t*, ze_kernel_handle_t*, ze_result_t result) override;
+                ze_result_t zeKernelDestroyEpilogue(ze_kernel_handle_t, ze_result_t result) override;
+                ze_result_t zeEventPoolCreateEpilogue(ze_context_handle_t, const ze_event_pool_desc_t*, uint32_t, ze_device_handle_t*, ze_event_pool_handle_t*, ze_result_t result) override;
+                ze_result_t zeEventPoolDestroyEpilogue(ze_event_pool_handle_t, ze_result_t result) override;
+                ze_result_t zeCommandListCreateImmediateEpilogue(ze_context_handle_t, ze_device_handle_t, const ze_command_queue_desc_t*, ze_command_list_handle_t*, ze_result_t result) override;
+                ze_result_t zeCommandListCreateEpilogue(ze_context_handle_t, ze_device_handle_t, const ze_command_list_desc_t*, ze_command_list_handle_t*, ze_result_t result) override;
+                ze_result_t zeCommandListDestroyEpilogue(ze_command_list_handle_t, ze_result_t result) override;
+                ze_result_t zeEventCreateEpilogue(ze_event_pool_handle_t, const ze_event_desc_t *, ze_event_handle_t *, ze_result_t result) override;
+                ze_result_t zeEventDestroyEpilogue(ze_event_handle_t, ze_result_t result) override;
+                ze_result_t zeFenceCreateEpilogue(ze_command_queue_handle_t, const ze_fence_desc_t *, ze_fence_handle_t*, ze_result_t result) override;
+                ze_result_t zeFenceDestroyEpilogue(ze_fence_handle_t, ze_result_t result) override;
+                ze_result_t zeImageCreateEpilogue(ze_context_handle_t, ze_device_handle_t, const ze_image_desc_t*, ze_image_handle_t*, ze_result_t result) override;
+                ze_result_t zeImageDestroyEpilogue(ze_image_handle_t, ze_result_t result) override;
+                ze_result_t zeSamplerCreateEpilogue(ze_context_handle_t, ze_device_handle_t, const ze_sampler_desc_t*, ze_sampler_handle_t*, ze_result_t result) override;
+                ze_result_t zeSamplerDestroyEpilogue(ze_sampler_handle_t, ze_result_t result) override;
+                ze_result_t zeMemAllocDeviceEpilogue(ze_context_handle_t, const ze_device_mem_alloc_desc_t *, size_t, size_t, ze_device_handle_t, void **, ze_result_t result) override;
+                ze_result_t zeMemAllocHostEpilogue(ze_context_handle_t, const ze_host_mem_alloc_desc_t *, size_t, size_t, void **, ze_result_t result) override;
+                ze_result_t zeMemAllocSharedEpilogue(ze_context_handle_t, const ze_device_mem_alloc_desc_t *, const ze_host_mem_alloc_desc_t *, size_t, size_t, ze_device_handle_t, void **, ze_result_t result) override;
+                ze_result_t zeMemFreeEpilogue(ze_context_handle_t, void *, ze_result_t result) override;
+            private:
+                void countFunctionCall(const std::string &functionName);
+                std::unordered_map<std::string, std::atomic<int64_t>> counts;
+            };
+
+            class ZESbasic_leakChecker : public ZESValidationEntryPoints {};
+            class ZETbasic_leakChecker : public ZETValidationEntryPoints {};
+            bool enablebasic_leak = false;
+    };
+    extern class basic_leakChecker basic_leak_checker;
+}


### PR DESCRIPTION
It is based on the ZeCallCount from UR. There are 2 main reasons for moving the leak checker to level-zero:
1. Some calls to L0 are done through UMF (not by UR directly) which means those calls would not be checked.
2. If an application using UR calls L0 directly, those calls will also not be checked. This happens for example in SYCL tests, where special cases need to be made for direct L0 calls.