### PR TITLE
Fix driver sorting given driver failures and instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Level zero loader changelog
 
+## v1.21.2
+*  Fix driver sorting given driver failures and instrumentation
 ## v1.21.1
 * Fix stype assignment in zello_world
 * Given static Loader, allocate lib context_t always as dynamic and enable delayed destroy of context

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if(MSVC AND (MSVC_VERSION LESS 1900))
 endif()
 
 # This project follows semantic versioning (https://semver.org/)
-project(level-zero VERSION 1.21.1)
+project(level-zero VERSION 1.21.2)
 
 include(GNUInstallDirs)
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ The ordering of the drivers reported to the user is based on the order of the en
 When additional driver types are added, they should be added to the end of the list to avoid reporting new device types
 before known device types.
 
+NOTE: Due to known issues with Program Instrumentation usecases, when ZET_ENABLE_PROGRAM_INSTRUMENTATION is enabled, driver sorting is not possible in the loader.
 
 # Contributing
 

--- a/scripts/templates/ldrddi.cpp.mako
+++ b/scripts/templates/ldrddi.cpp.mako
@@ -59,7 +59,7 @@ namespace loader
         %elif re.match(r"\w+DriverGet$", th.make_func_name(n, tags, obj)) or re.match(r"\w+InitDrivers$", th.make_func_name(n, tags, obj)):
         uint32_t total_driver_handle_count = 0;
 
-        if (!loader::context->sortingInProgress.exchange(true)) {
+        if (!loader::context->sortingInProgress.exchange(true) && !loader::context->instrumentationEnabled) {
             %if namespace != "zes":
             %if not re.match(r"\w+InitDrivers$", th.make_func_name(n, tags, obj)):
             std::call_once(loader::context->coreDriverSortOnce, []() {

--- a/scripts/templates/ldrddi.cpp.mako
+++ b/scripts/templates/ldrddi.cpp.mako
@@ -60,6 +60,20 @@ namespace loader
         uint32_t total_driver_handle_count = 0;
 
         %if namespace != "zes":
+        if (!loader::context->coredriverSortingCompleted) {
+            %if not re.match(r"\w+InitDrivers$", th.make_func_name(n, tags, obj)):
+            loader::context->coredriverSortingCompleted = loader::context->driverSorting(&loader::context->zeDrivers, nullptr);
+            %else:
+            loader::context->coredriverSortingCompleted = loader::context->driverSorting(&loader::context->zeDrivers, desc);
+            %endif
+        }
+        %else:
+        if (!loader::context->sysmandriverSortingCompleted) {
+            loader::context->sysmandriverSortingCompleted = loader::context->driverSorting(loader::context->sysmanInstanceDrivers, nullptr);
+        }
+        %endif
+
+        %if namespace != "zes":
         for( auto& drv : loader::context->zeDrivers )
         %else:
         for( auto& drv : *loader::context->sysmanInstanceDrivers )

--- a/scripts/templates/ze_loader_internal.h.mako
+++ b/scripts/templates/ze_loader_internal.h.mako
@@ -61,7 +61,7 @@ namespace loader
         dditable_t dditable = {};
         std::string name;
         bool driverInuse = false;
-        zel_driver_type_t driverType;
+        zel_driver_type_t driverType = ZEL_DRIVER_TYPE_FORCE_UINT32;
         ze_driver_properties_t properties;
         bool pciOrderingRequested = false;
     };
@@ -111,10 +111,15 @@ namespace loader
         ze_result_t init();
         ze_result_t init_driver(driver_t &driver, ze_init_flags_t flags, ze_init_driver_type_desc_t* desc, ze_global_dditable_t *globalInitStored, zes_global_dditable_t *sysmanGlobalInitStored, bool sysmanOnly);
         void add_loader_version();
+        bool driverSorting(driver_vector_t *drivers, ze_init_driver_type_desc_t* desc);
         ~context_t();
         bool intercept_enabled = false;
         bool debugTraceEnabled = false;
         bool tracingLayerEnabled = false;
+        std::once_flag coreDriverSortOnce;
+        std::once_flag sysmanDriverSortOnce;
+        std::atomic<bool> sortingInProgress = {false};
+        bool instrumentationEnabled = false;
         dditable_t tracing_dditable = {};
         std::shared_ptr<Logger> zel_logger;
     };

--- a/source/drivers/null/ze_null.cpp
+++ b/source/drivers/null/ze_null.cpp
@@ -8,6 +8,7 @@
  *
  */
 #include "ze_null.h"
+#include <cstring>
 
 namespace driver
 {
@@ -138,6 +139,10 @@ namespace driver
             ze_device_properties_t deviceProperties = {};
             deviceProperties.stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES;
             deviceProperties.type = ZE_DEVICE_TYPE_GPU;
+            auto driver_type = getenv_string( "ZEL_TEST_NULL_DRIVER_TYPE" );
+            if (std::strcmp(driver_type.c_str(), "NPU") == 0) {
+                deviceProperties.type = ZE_DEVICE_TYPE_VPU;
+            }
 #if defined(_WIN32)
             strcpy_s( deviceProperties.name, "Null Device" );
 #else

--- a/source/loader/ze_ldrddi.cpp
+++ b/source/loader/ze_ldrddi.cpp
@@ -55,6 +55,10 @@ namespace loader
 
         uint32_t total_driver_handle_count = 0;
 
+        if (!loader::context->coredriverSortingCompleted) {
+            loader::context->coredriverSortingCompleted = loader::context->driverSorting(&loader::context->zeDrivers, nullptr);
+        }
+
         for( auto& drv : loader::context->zeDrivers )
         {
             if(drv.initStatus != ZE_RESULT_SUCCESS)
@@ -130,6 +134,10 @@ namespace loader
         ze_result_t result = ZE_RESULT_SUCCESS;
 
         uint32_t total_driver_handle_count = 0;
+
+        if (!loader::context->coredriverSortingCompleted) {
+            loader::context->coredriverSortingCompleted = loader::context->driverSorting(&loader::context->zeDrivers, desc);
+        }
 
         for( auto& drv : loader::context->zeDrivers )
         {

--- a/source/loader/ze_ldrddi.cpp
+++ b/source/loader/ze_ldrddi.cpp
@@ -55,7 +55,7 @@ namespace loader
 
         uint32_t total_driver_handle_count = 0;
 
-        if (!loader::context->sortingInProgress.exchange(true)) {
+        if (!loader::context->sortingInProgress.exchange(true) && !loader::context->instrumentationEnabled) {
             std::call_once(loader::context->coreDriverSortOnce, []() {
                 loader::context->driverSorting(&loader::context->zeDrivers, nullptr);
             });
@@ -138,7 +138,7 @@ namespace loader
 
         uint32_t total_driver_handle_count = 0;
 
-        if (!loader::context->sortingInProgress.exchange(true)) {
+        if (!loader::context->sortingInProgress.exchange(true) && !loader::context->instrumentationEnabled) {
             std::call_once(loader::context->coreDriverSortOnce, [desc]() {
                 loader::context->driverSorting(&loader::context->zeDrivers, desc);
             });

--- a/source/loader/ze_ldrddi.cpp
+++ b/source/loader/ze_ldrddi.cpp
@@ -55,8 +55,11 @@ namespace loader
 
         uint32_t total_driver_handle_count = 0;
 
-        if (!loader::context->coredriverSortingCompleted) {
-            loader::context->coredriverSortingCompleted = loader::context->driverSorting(&loader::context->zeDrivers, nullptr);
+        if (!loader::context->sortingInProgress.exchange(true)) {
+            std::call_once(loader::context->coreDriverSortOnce, []() {
+                loader::context->driverSorting(&loader::context->zeDrivers, nullptr);
+            });
+            loader::context->sortingInProgress.store(false);
         }
 
         for( auto& drv : loader::context->zeDrivers )
@@ -135,8 +138,11 @@ namespace loader
 
         uint32_t total_driver_handle_count = 0;
 
-        if (!loader::context->coredriverSortingCompleted) {
-            loader::context->coredriverSortingCompleted = loader::context->driverSorting(&loader::context->zeDrivers, desc);
+        if (!loader::context->sortingInProgress.exchange(true)) {
+            std::call_once(loader::context->coreDriverSortOnce, [desc]() {
+                loader::context->driverSorting(&loader::context->zeDrivers, desc);
+            });
+            loader::context->sortingInProgress.store(false);
         }
 
         for( auto& drv : loader::context->zeDrivers )

--- a/source/loader/ze_loader.cpp
+++ b/source/loader/ze_loader.cpp
@@ -69,29 +69,32 @@ namespace loader
     }
 
     bool context_t::driverSorting(driver_vector_t *drivers, ze_init_driver_type_desc_t* desc) {
-
+        ze_init_driver_type_desc_t permissiveDesc = {};
+        permissiveDesc.stype = ZE_STRUCTURE_TYPE_INIT_DRIVER_TYPE_DESC;
+        permissiveDesc.pNext = nullptr;
+        permissiveDesc.flags = UINT32_MAX;
         for (auto &driver : *drivers) {
             uint32_t pCount = 0;
             std::vector<ze_driver_handle_t> driverHandles;
             ze_result_t res = ZE_RESULT_SUCCESS;
             if (desc) {
                 pCount = 0;
-                res = driver.dditable.ze.Global.pfnInitDrivers(&pCount, nullptr, desc);
+                res = driver.dditable.ze.Global.pfnInitDrivers(&pCount, nullptr, &permissiveDesc);
                 // Verify that this driver successfully init in the call above.
                 if (res != ZE_RESULT_SUCCESS) {
                     if (debugTraceEnabled) {
-                        std::string message = "driverSorting " + driver.name + " zeInitDrivers(" + loader::to_string(desc) + ") returning ";
+                        std::string message = "driverSorting " + driver.name + " zeInitDrivers(" + loader::to_string(&permissiveDesc) + ") returning ";
                         debug_trace_message(message, loader::to_string(res));
                     }
                     continue;
                 }
                 driverHandles.resize(pCount);
                 // Use the driver's init function to query the driver handles and read the properties.
-                res = driver.dditable.ze.Global.pfnInitDrivers(&pCount, driverHandles.data(), desc);
+                res = driver.dditable.ze.Global.pfnInitDrivers(&pCount, driverHandles.data(), &permissiveDesc);
                 // Verify that this driver successfully init in the call above.
                 if (res != ZE_RESULT_SUCCESS) {
                     if (debugTraceEnabled) {
-                        std::string message = "driverSorting " + driver.name + " zeInitDrivers(" + loader::to_string(desc) + ") returning ";
+                        std::string message = "driverSorting " + driver.name + " zeInitDrivers(" + loader::to_string(&permissiveDesc) + ") returning ";
                         debug_trace_message(message, loader::to_string(res));
                     }
                     continue;

--- a/source/loader/ze_loader.cpp
+++ b/source/loader/ze_loader.cpp
@@ -267,6 +267,7 @@ namespace loader
             return_first_driver_result=true;
         }
         bool pciOrderingRequested = getenv_tobool( "ZE_ENABLE_PCI_ID_DEVICE_ORDER" );
+        loader::context->instrumentationEnabled = getenv_tobool( "ZET_ENABLE_PROGRAM_INSTRUMENTATION" );
 
         for(auto it = drivers->begin(); it != drivers->end(); )
         {

--- a/source/loader/ze_loader.cpp
+++ b/source/loader/ze_loader.cpp
@@ -101,7 +101,7 @@ namespace loader
                 // Verify that this driver successfully init in the call above.
                 if (res != ZE_RESULT_SUCCESS) {
                     if (debugTraceEnabled) {
-                        std::string message = "driverSorting " + driver.name + " zeDriverGet(" + loader::to_string(desc) + ") returning ";
+                        std::string message = "driverSorting " + driver.name + " zeDriverGet returning ";
                         debug_trace_message(message, loader::to_string(res));
                     }
                     continue;
@@ -111,7 +111,7 @@ namespace loader
                 // Verify that this driver successfully init in the call above.
                 if (res != ZE_RESULT_SUCCESS) {
                     if (debugTraceEnabled) {
-                        std::string message = "driverSorting " + driver.name + " zeDriverGet(" + loader::to_string(desc) + ") returning ";
+                        std::string message = "driverSorting " + driver.name + " zeDriverGet returning ";
                         debug_trace_message(message, loader::to_string(res));
                     }
                     continue;

--- a/source/loader/ze_loader_internal.h
+++ b/source/loader/ze_loader_internal.h
@@ -153,6 +153,7 @@ namespace loader
         std::once_flag coreDriverSortOnce;
         std::once_flag sysmanDriverSortOnce;
         std::atomic<bool> sortingInProgress = {false};
+        bool instrumentationEnabled = false;
         dditable_t tracing_dditable = {};
         std::shared_ptr<Logger> zel_logger;
     };

--- a/source/loader/ze_loader_internal.h
+++ b/source/loader/ze_loader_internal.h
@@ -52,7 +52,7 @@ namespace loader
         dditable_t dditable = {};
         std::string name;
         bool driverInuse = false;
-        zel_driver_type_t driverType;
+        zel_driver_type_t driverType = ZEL_DRIVER_TYPE_FORCE_UINT32;
         ze_driver_properties_t properties;
         bool pciOrderingRequested = false;
     };
@@ -145,10 +145,13 @@ namespace loader
         ze_result_t init();
         ze_result_t init_driver(driver_t &driver, ze_init_flags_t flags, ze_init_driver_type_desc_t* desc, ze_global_dditable_t *globalInitStored, zes_global_dditable_t *sysmanGlobalInitStored, bool sysmanOnly);
         void add_loader_version();
+        bool driverSorting(driver_vector_t *drivers, ze_init_driver_type_desc_t* desc);
         ~context_t();
         bool intercept_enabled = false;
         bool debugTraceEnabled = false;
         bool tracingLayerEnabled = false;
+        bool coredriverSortingCompleted = false;
+        bool sysmandriverSortingCompleted = false;
         dditable_t tracing_dditable = {};
         std::shared_ptr<Logger> zel_logger;
     };

--- a/source/loader/ze_loader_internal.h
+++ b/source/loader/ze_loader_internal.h
@@ -150,8 +150,9 @@ namespace loader
         bool intercept_enabled = false;
         bool debugTraceEnabled = false;
         bool tracingLayerEnabled = false;
-        bool coredriverSortingCompleted = false;
-        bool sysmandriverSortingCompleted = false;
+        std::once_flag coreDriverSortOnce;
+        std::once_flag sysmanDriverSortOnce;
+        std::atomic<bool> sortingInProgress = {false};
         dditable_t tracing_dditable = {};
         std::shared_ptr<Logger> zel_logger;
     };

--- a/source/loader/zes_ldrddi.cpp
+++ b/source/loader/zes_ldrddi.cpp
@@ -56,7 +56,7 @@ namespace loader
 
         uint32_t total_driver_handle_count = 0;
 
-        if (!loader::context->sortingInProgress.exchange(true)) {
+        if (!loader::context->sortingInProgress.exchange(true) && !loader::context->instrumentationEnabled) {
             std::call_once(loader::context->sysmanDriverSortOnce, []() {
                 loader::context->driverSorting(loader::context->sysmanInstanceDrivers, nullptr);
             });

--- a/source/loader/zes_ldrddi.cpp
+++ b/source/loader/zes_ldrddi.cpp
@@ -56,6 +56,10 @@ namespace loader
 
         uint32_t total_driver_handle_count = 0;
 
+        if (!loader::context->sysmandriverSortingCompleted) {
+            loader::context->sysmandriverSortingCompleted = loader::context->driverSorting(loader::context->sysmanInstanceDrivers, nullptr);
+        }
+
         for( auto& drv : *loader::context->sysmanInstanceDrivers )
         {
             if(drv.initStatus != ZE_RESULT_SUCCESS)

--- a/source/loader/zes_ldrddi.cpp
+++ b/source/loader/zes_ldrddi.cpp
@@ -56,8 +56,11 @@ namespace loader
 
         uint32_t total_driver_handle_count = 0;
 
-        if (!loader::context->sysmandriverSortingCompleted) {
-            loader::context->sysmandriverSortingCompleted = loader::context->driverSorting(loader::context->sysmanInstanceDrivers, nullptr);
+        if (!loader::context->sortingInProgress.exchange(true)) {
+            std::call_once(loader::context->sysmanDriverSortOnce, []() {
+                loader::context->driverSorting(loader::context->sysmanInstanceDrivers, nullptr);
+            });
+            loader::context->sortingInProgress.store(false);
         }
 
         for( auto& drv : *loader::context->sysmanInstanceDrivers )


### PR DESCRIPTION
- To avoid issues when sorting of the drivers can cause an invalid call during instrumentation after driver failures, then the driver sorting has been moved to occur during the call to zeDriverGet or zeinitDrivers.
- In addition, the driver type is not init to UINT32_MAX in the enum such that all failing drivers are forced to the back of the sorted list.