### PR TITLE
Change -Werror handling.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,7 @@ if(NOT MSVC)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpermissive")
     endif()
     if(NOT CMAKE_CXX_COMPILER_ID STREQUAL IntelLLVM)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -Wnon-virtual-dtor")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wnon-virtual-dtor")
     endif()
 endif()
 
@@ -184,6 +184,18 @@ if(USE_ASAN)
     else()
         message(WARNING "Address Sanitizer is not supported on Windows")
     endif()
+endif()
+
+# Enable -Werror only if not building as a subproject. For subprojects, leave
+# this up to the parent project.
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+  if(CMAKE_VERSION VERSION_LESS 3.24)
+    if(NOT MSVC)
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+    endif()
+  else()
+    set(CMAKE_COMPILE_WARNING_AS_ERROR ON)
+  endif()
 endif()
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)


### PR DESCRIPTION
* If building level_zero as a subproject, do not build with warnings as errors, leave it up to the parent project to turn these into errors if desired.
* If building level_zero with CMake 3.24 or newer, use CMAKE_COMPILE_WARNING_AS_ERROR instead of explicitly setting -Werror. This permits users to turn it off with `cmake --compile-no-warning-as-error`.

In both cases, being able to disable -Werror is useful when a parent project or a user wishes to turn on additional warnings that should not be turned into errors.