### PR TITLE
Address zesInit issues with error handling and driver sorting.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v1.21.7
 * Fix handling of sysman init failure given nullptr
+* Fix driver sorting given zesInit only
 * Update default SDK install path to include Program Files
 ## v1.21.6
 * Fix to pkgconfig during non build installer cmake install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Level zero loader changelog
 
 ## v1.21.7
+* Fix handling of sysman init failure given nullptr
 * Update default SDK install path to include Program Files
 ## v1.21.6
 * Fix to pkgconfig during non build installer cmake install

--- a/scripts/templates/ldrddi.cpp.mako
+++ b/scripts/templates/ldrddi.cpp.mako
@@ -46,17 +46,28 @@ namespace loader
         for( auto& drv : *loader::context->sysmanInstanceDrivers )
         %endif
         {
+            %if re.match(r"Init", obj['name']) and namespace == "zes":
+            if(drv.initStatus != ZE_RESULT_SUCCESS || drv.initSysManStatus != ZE_RESULT_SUCCESS)
+                continue;
+            %else:
             if(drv.initStatus != ZE_RESULT_SUCCESS)
                 continue;
+            %endif
         %if re.match(r"Init", obj['name']) and namespace == "zes":
             if (!drv.dditable.${n}.${th.get_table_name(n, tags, obj)}.${th.make_pfn_name(n, tags, obj)}) {
-                drv.initDriversStatus = ZE_RESULT_ERROR_UNINITIALIZED;
+                drv.initSysManStatus = ZE_RESULT_ERROR_UNINITIALIZED;
                 continue;
             }
         %endif
+            %if re.match(r"Init", obj['name']) and namespace == "zes":
+            drv.initSysManStatus = drv.dditable.${n}.${th.get_table_name(n, tags, obj)}.${th.make_pfn_name(n, tags, obj)}( ${", ".join(th.make_param_lines(n, tags, obj, format=["name"]))} );
+            if(drv.initSysManStatus == ZE_RESULT_SUCCESS)
+                atLeastOneDriverValid = true;
+            %else:
             drv.initStatus = drv.dditable.${n}.${th.get_table_name(n, tags, obj)}.${th.make_pfn_name(n, tags, obj)}( ${", ".join(th.make_param_lines(n, tags, obj, format=["name"]))} );
             if(drv.initStatus == ZE_RESULT_SUCCESS)
                 atLeastOneDriverValid = true;
+            %endif
         }
 
         if(!atLeastOneDriverValid)
@@ -90,8 +101,11 @@ namespace loader
         for( auto& drv : *loader::context->sysmanInstanceDrivers )
         %endif
         {
-            %if not re.match(r"\w+InitDrivers$", th.make_func_name(n, tags, obj)):
+            %if not (re.match(r"\w+InitDrivers$", th.make_func_name(n, tags, obj))) and namespace != "zes":
             if(drv.initStatus != ZE_RESULT_SUCCESS)
+                continue;
+            %elif namespace == "zes":
+            if(drv.initStatus != ZE_RESULT_SUCCESS || drv.initSysManStatus != ZE_RESULT_SUCCESS)
                 continue;
             %else:
             if (!drv.dditable.${n}.${th.get_table_name(n, tags, obj)}.${th.make_pfn_name(n, tags, obj)}) {

--- a/scripts/templates/ldrddi.cpp.mako
+++ b/scripts/templates/ldrddi.cpp.mako
@@ -80,16 +80,16 @@ namespace loader
             %if namespace != "zes":
             %if not re.match(r"\w+InitDrivers$", th.make_func_name(n, tags, obj)):
             std::call_once(loader::context->coreDriverSortOnce, []() {
-                loader::context->driverSorting(&loader::context->zeDrivers, nullptr);
+                loader::context->driverSorting(&loader::context->zeDrivers, nullptr, false);
             });
             %else:
             std::call_once(loader::context->coreDriverSortOnce, [desc]() {
-                loader::context->driverSorting(&loader::context->zeDrivers, desc);
+                loader::context->driverSorting(&loader::context->zeDrivers, desc, false);
             });
             %endif
             %else:
             std::call_once(loader::context->sysmanDriverSortOnce, []() {
-                loader::context->driverSorting(loader::context->sysmanInstanceDrivers, nullptr);
+                loader::context->driverSorting(loader::context->sysmanInstanceDrivers, nullptr, true);
             });
             %endif
             loader::context->sortingInProgress.store(false);

--- a/scripts/templates/ze_loader_internal.h.mako
+++ b/scripts/templates/ze_loader_internal.h.mako
@@ -57,6 +57,7 @@ namespace loader
     {
         HMODULE handle = NULL;
         ze_result_t initStatus = ZE_RESULT_SUCCESS;
+        ze_result_t initSysManStatus = ZE_RESULT_SUCCESS;
         ze_result_t initDriversStatus = ZE_RESULT_SUCCESS;
         dditable_t dditable = {};
         std::string name;

--- a/scripts/templates/ze_loader_internal.h.mako
+++ b/scripts/templates/ze_loader_internal.h.mako
@@ -112,7 +112,7 @@ namespace loader
         ze_result_t init();
         ze_result_t init_driver(driver_t &driver, ze_init_flags_t flags, ze_init_driver_type_desc_t* desc, ze_global_dditable_t *globalInitStored, zes_global_dditable_t *sysmanGlobalInitStored, bool sysmanOnly);
         void add_loader_version();
-        bool driverSorting(driver_vector_t *drivers, ze_init_driver_type_desc_t* desc);
+        bool driverSorting(driver_vector_t *drivers, ze_init_driver_type_desc_t* desc, bool sysmanOnly);
         ~context_t();
         bool intercept_enabled = false;
         bool debugTraceEnabled = false;

--- a/source/loader/ze_ldrddi.cpp
+++ b/source/loader/ze_ldrddi.cpp
@@ -57,7 +57,7 @@ namespace loader
 
         if (!loader::context->sortingInProgress.exchange(true) && !loader::context->instrumentationEnabled) {
             std::call_once(loader::context->coreDriverSortOnce, []() {
-                loader::context->driverSorting(&loader::context->zeDrivers, nullptr);
+                loader::context->driverSorting(&loader::context->zeDrivers, nullptr, false);
             });
             loader::context->sortingInProgress.store(false);
         }
@@ -140,7 +140,7 @@ namespace loader
 
         if (!loader::context->sortingInProgress.exchange(true) && !loader::context->instrumentationEnabled) {
             std::call_once(loader::context->coreDriverSortOnce, [desc]() {
-                loader::context->driverSorting(&loader::context->zeDrivers, desc);
+                loader::context->driverSorting(&loader::context->zeDrivers, desc, false);
             });
             loader::context->sortingInProgress.store(false);
         }

--- a/source/loader/ze_loader.cpp
+++ b/source/loader/ze_loader.cpp
@@ -68,12 +68,34 @@ namespace loader
         return a.driverType < b.driverType;
     }
 
-    bool context_t::driverSorting(driver_vector_t *drivers, ze_init_driver_type_desc_t* desc) {
+    bool context_t::driverSorting(driver_vector_t *drivers, ze_init_driver_type_desc_t* desc, bool sysmanOnly) {
         ze_init_driver_type_desc_t permissiveDesc = {};
         permissiveDesc.stype = ZE_STRUCTURE_TYPE_INIT_DRIVER_TYPE_DESC;
         permissiveDesc.pNext = nullptr;
         permissiveDesc.flags = UINT32_MAX;
         for (auto &driver : *drivers) {
+            if (sysmanOnly) {
+                for (auto &coreDriver : this->zeDrivers) {
+                    if (coreDriver.name == driver.name) {
+                        if (!driver.dditable.ze.Global.pfnInitDrivers) {
+                            driver.dditable.ze.Global.pfnInitDrivers = coreDriver.dditable.ze.Global.pfnInitDrivers;
+                        }
+                        if (!driver.dditable.ze.Driver.pfnGet) {
+                            driver.dditable.ze.Driver.pfnGet = coreDriver.dditable.ze.Driver.pfnGet;
+                        }
+                        if (!driver.dditable.ze.Driver.pfnGetProperties) {
+                            driver.dditable.ze.Driver.pfnGetProperties = coreDriver.dditable.ze.Driver.pfnGetProperties;
+                        }
+                        if (!driver.dditable.ze.Device.pfnGet) {
+                            driver.dditable.ze.Device.pfnGet = coreDriver.dditable.ze.Device.pfnGet;
+                        }
+                        if (!driver.dditable.ze.Device.pfnGetProperties) {
+                            driver.dditable.ze.Device.pfnGetProperties = coreDriver.dditable.ze.Device.pfnGetProperties;
+                        }
+                        break;
+                    }
+                }
+            }
             uint32_t pCount = 0;
             std::vector<ze_driver_handle_t> driverHandles;
             ze_result_t res = ZE_RESULT_SUCCESS;

--- a/source/loader/ze_loader.cpp
+++ b/source/loader/ze_loader.cpp
@@ -356,8 +356,8 @@ namespace loader
             // Use the previously init ddi table pointer to zesInit to allow for intercept of the zesInit calls
             ze_result_t res = sysmanGlobalInitStored->pfnInit(flags);
             // Verify that this driver successfully init in the call above.
-            if (driver.initStatus != ZE_RESULT_SUCCESS) {
-                res = driver.initStatus;
+            if (driver.initSysManStatus != ZE_RESULT_SUCCESS) {
+                res = driver.initSysManStatus;
             }
             if (debugTraceEnabled) {
                 std::string message = "init driver " + driver.name + " zesInit(" + loader::to_string(flags) + ") returning ";

--- a/source/loader/ze_loader_internal.h
+++ b/source/loader/ze_loader_internal.h
@@ -146,7 +146,7 @@ namespace loader
         ze_result_t init();
         ze_result_t init_driver(driver_t &driver, ze_init_flags_t flags, ze_init_driver_type_desc_t* desc, ze_global_dditable_t *globalInitStored, zes_global_dditable_t *sysmanGlobalInitStored, bool sysmanOnly);
         void add_loader_version();
-        bool driverSorting(driver_vector_t *drivers, ze_init_driver_type_desc_t* desc);
+        bool driverSorting(driver_vector_t *drivers, ze_init_driver_type_desc_t* desc, bool sysmanOnly);
         ~context_t();
         bool intercept_enabled = false;
         bool debugTraceEnabled = false;

--- a/source/loader/ze_loader_internal.h
+++ b/source/loader/ze_loader_internal.h
@@ -48,6 +48,7 @@ namespace loader
     {
         HMODULE handle = NULL;
         ze_result_t initStatus = ZE_RESULT_SUCCESS;
+        ze_result_t initSysManStatus = ZE_RESULT_SUCCESS;
         ze_result_t initDriversStatus = ZE_RESULT_SUCCESS;
         dditable_t dditable = {};
         std::string name;

--- a/source/loader/zes_ldrddi.cpp
+++ b/source/loader/zes_ldrddi.cpp
@@ -24,14 +24,14 @@ namespace loader
         bool atLeastOneDriverValid = false;
         for( auto& drv : *loader::context->sysmanInstanceDrivers )
         {
-            if(drv.initStatus != ZE_RESULT_SUCCESS)
+            if(drv.initStatus != ZE_RESULT_SUCCESS || drv.initSysManStatus != ZE_RESULT_SUCCESS)
                 continue;
             if (!drv.dditable.zes.Global.pfnInit) {
-                drv.initDriversStatus = ZE_RESULT_ERROR_UNINITIALIZED;
+                drv.initSysManStatus = ZE_RESULT_ERROR_UNINITIALIZED;
                 continue;
             }
-            drv.initStatus = drv.dditable.zes.Global.pfnInit( flags );
-            if(drv.initStatus == ZE_RESULT_SUCCESS)
+            drv.initSysManStatus = drv.dditable.zes.Global.pfnInit( flags );
+            if(drv.initSysManStatus == ZE_RESULT_SUCCESS)
                 atLeastOneDriverValid = true;
         }
 
@@ -69,7 +69,7 @@ namespace loader
 
         for( auto& drv : *loader::context->sysmanInstanceDrivers )
         {
-            if(drv.initStatus != ZE_RESULT_SUCCESS)
+            if(drv.initStatus != ZE_RESULT_SUCCESS || drv.initSysManStatus != ZE_RESULT_SUCCESS)
                 continue;
 
             if( ( 0 < *pCount ) && ( *pCount == total_driver_handle_count))

--- a/source/loader/zes_ldrddi.cpp
+++ b/source/loader/zes_ldrddi.cpp
@@ -62,7 +62,7 @@ namespace loader
 
         if (!loader::context->sortingInProgress.exchange(true) && !loader::context->instrumentationEnabled) {
             std::call_once(loader::context->sysmanDriverSortOnce, []() {
-                loader::context->driverSorting(loader::context->sysmanInstanceDrivers, nullptr);
+                loader::context->driverSorting(loader::context->sysmanInstanceDrivers, nullptr, true);
             });
             loader::context->sortingInProgress.store(false);
         }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -80,6 +80,13 @@ else()
   set_property(TEST tests_multi_driver_zesdriverget_sort APPEND PROPERTY ENVIRONMENT "ZE_ENABLE_LOADER_DEBUG_TRACE=1;ZE_ENABLE_ALT_DRIVERS=${CMAKE_BINARY_DIR}/lib/libze_null_test1.so,${CMAKE_BINARY_DIR}/lib/libze_null_test2.so")
 endif()
 
+add_test(NAME tests_multi_driver_zeandzesdriverget_sort COMMAND tests --gtest_filter=*GivenLevelZeroLoaderPresentWithMultipleDriversWhenCallingZesInitThenZeInitDriversExpectSuccessForZesDriverGetAndZeInitDrivers)
+if (MSVC)
+  set_property(TEST tests_multi_driver_zeandzesdriverget_sort APPEND PROPERTY ENVIRONMENT "ZE_ENABLE_LOADER_DEBUG_TRACE=1;ZE_ENABLE_ALT_DRIVERS=${CMAKE_BINARY_DIR}/bin/$<CONFIG>/ze_null_test1.dll,${CMAKE_BINARY_DIR}/bin/$<CONFIG>/ze_null_test2.dll")
+else()
+  set_property(TEST tests_multi_driver_zeandzesdriverget_sort APPEND PROPERTY ENVIRONMENT "ZE_ENABLE_LOADER_DEBUG_TRACE=1;ZE_ENABLE_ALT_DRIVERS=${CMAKE_BINARY_DIR}/lib/libze_null_test1.so,${CMAKE_BINARY_DIR}/lib/libze_null_test2.so")
+endif()
+
 # These tests are currently not supported on Windows. The reason is that the std::cerr is not being redirected to a pipe in Windows to be then checked against the expected output.
 if(NOT MSVC)
     add_test(NAME tests_event_deadlock COMMAND tests --gtest_filter=*GivenLevelZeroLoaderPresentWhenCallingzeCommandListAppendMemoryCopyWithCircularDependencyOnEventsThenValidationLayerPrintsWarningOfDeadlock*)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -73,6 +73,13 @@ else()
   set_property(TEST tests_multi_driver_driverget_sort APPEND PROPERTY ENVIRONMENT "ZE_ENABLE_LOADER_DEBUG_TRACE=1;ZE_ENABLE_ALT_DRIVERS=${CMAKE_BINARY_DIR}/lib/libze_null_test1.so,${CMAKE_BINARY_DIR}/lib/libze_null_test2.so")
 endif()
 
+add_test(NAME tests_multi_driver_zesdriverget_sort COMMAND tests --gtest_filter=*GivenLevelZeroLoaderPresentWithMultipleDriversWhenCallingZesInitThenExpectSuccessForZesDriverGet)
+if (MSVC)
+  set_property(TEST tests_multi_driver_zesdriverget_sort APPEND PROPERTY ENVIRONMENT "ZE_ENABLE_LOADER_DEBUG_TRACE=1;ZE_ENABLE_ALT_DRIVERS=${CMAKE_BINARY_DIR}/bin/$<CONFIG>/ze_null_test1.dll,${CMAKE_BINARY_DIR}/bin/$<CONFIG>/ze_null_test2.dll")
+else()
+  set_property(TEST tests_multi_driver_zesdriverget_sort APPEND PROPERTY ENVIRONMENT "ZE_ENABLE_LOADER_DEBUG_TRACE=1;ZE_ENABLE_ALT_DRIVERS=${CMAKE_BINARY_DIR}/lib/libze_null_test1.so,${CMAKE_BINARY_DIR}/lib/libze_null_test2.so")
+endif()
+
 # These tests are currently not supported on Windows. The reason is that the std::cerr is not being redirected to a pipe in Windows to be then checked against the expected output.
 if(NOT MSVC)
     add_test(NAME tests_event_deadlock COMMAND tests --gtest_filter=*GivenLevelZeroLoaderPresentWhenCallingzeCommandListAppendMemoryCopyWithCircularDependencyOnEventsThenValidationLayerPrintsWarningOfDeadlock*)

--- a/test/loader_api.cpp
+++ b/test/loader_api.cpp
@@ -328,4 +328,20 @@ TEST(
   EXPECT_GT(pDriverGetCount, 0);
 }
 
+TEST(
+  LoaderInit,
+  GivenLevelZeroLoaderPresentWithMultipleDriversWhenCallingZesInitThenZeInitDriversExpectSuccessForZesDriverGetAndZeInitDrivers) {
+
+  uint32_t pInitDriversCount = 0;
+  uint32_t pDriverGetCount = 0;
+  ze_init_driver_type_desc_t desc = {ZE_STRUCTURE_TYPE_INIT_DRIVER_TYPE_DESC};
+  desc.flags = UINT32_MAX;
+  desc.pNext = nullptr;
+  EXPECT_EQ(ZE_RESULT_SUCCESS, zesInit(0));
+  EXPECT_EQ(ZE_RESULT_SUCCESS, zeInitDrivers(&pInitDriversCount, nullptr, &desc));
+  EXPECT_GT(pInitDriversCount, 0);
+  EXPECT_EQ(ZE_RESULT_SUCCESS, zesDriverGet(&pDriverGetCount, nullptr));
+  EXPECT_GT(pDriverGetCount, 0);
+}
+
 } // namespace

--- a/test/loader_api.cpp
+++ b/test/loader_api.cpp
@@ -10,6 +10,7 @@
 
 #include "loader/ze_loader.h"
 #include "ze_api.h"
+#include "zes_api.h"
 
 #if defined(_WIN32)
     #define putenv_safe _putenv
@@ -314,6 +315,16 @@ TEST(
   EXPECT_EQ(ZE_RESULT_SUCCESS, zeInitDrivers(&pInitDriversCount, nullptr, &desc));
   EXPECT_GT(pInitDriversCount, 0);
   EXPECT_EQ(ZE_RESULT_SUCCESS, zeDriverGet(&pDriverGetCount, nullptr));
+  EXPECT_GT(pDriverGetCount, 0);
+}
+
+TEST(
+  LoaderInit,
+  GivenLevelZeroLoaderPresentWithMultipleDriversWhenCallingZesInitThenExpectSuccessForZesDriverGet) {
+
+  uint32_t pDriverGetCount = 0;
+  EXPECT_EQ(ZE_RESULT_SUCCESS, zesInit(0));
+  EXPECT_EQ(ZE_RESULT_SUCCESS, zesDriverGet(&pDriverGetCount, nullptr));
   EXPECT_GT(pDriverGetCount, 0);
 }
 


### PR DESCRIPTION
- Fix issues where zesInit failing can cause other driver inits to fail. Sysman Only init is now completely isolated.
- Fixed driver sorting when using zesInit to use matched core driver.