### PR TITLE
Restrict Intel VPU driver to ze_intel_npu for Android

### DIFF
--- a/source/loader/linux/driver_discovery_lin.cpp
+++ b/source/loader/linux/driver_discovery_lin.cpp
@@ -18,7 +18,9 @@ namespace loader {
 static const char *knownDriverNames[] = {
     MAKE_LIBRARY_NAME("ze_intel_gpu", "1"),
     MAKE_LIBRARY_NAME("ze_intel_gpu_legacy1", "1"),
+#if !defined(ANDROID)
     MAKE_LIBRARY_NAME("ze_intel_vpu", "1"),
+#endif
     MAKE_LIBRARY_NAME("ze_intel_npu", "1"),
 };
 


### PR DESCRIPTION
When both ze_intel_vpu.so and ze_intel_npu.so are present in the file sys at loading time, ze_intel_npu.so will raise an exception and return ZE_RESULT_ERROR_UNINITIALIZED, so let's limit it to single NPU Driver.