### PR TITLE
Added zelCheckIsLoaderInTearDown function to check if the loader is i…

### DIFF
--- a/include/loader/ze_loader.h
+++ b/include/loader/ze_loader.h
@@ -89,6 +89,12 @@ ZE_DLLEXPORT ze_result_t ZE_APICALL
 zelEnableTracingLayer();
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for Checking if the Loader is torndown.
+///
+ZE_DLLEXPORT bool ZE_APICALL
+zelCheckIsLoaderInTearDown();
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Exported function for Disabling the Tracing Layer During Runtime.
 ///
 ZE_DLLEXPORT ze_result_t ZE_APICALL

--- a/source/lib/ze_lib.h
+++ b/source/lib/ze_lib.h
@@ -174,6 +174,7 @@ namespace ze_lib
         bool zeInuse = false;
         bool debugTraceEnabled = false;
         bool dynamicTracingSupported = true;
+        ze_pfnDriverGet_t loaderDriverGet = nullptr;
     };
 
     extern bool destruction;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -87,6 +87,9 @@ else()
   set_property(TEST tests_multi_driver_zeandzesdriverget_sort APPEND PROPERTY ENVIRONMENT "ZE_ENABLE_LOADER_DEBUG_TRACE=1;ZE_ENABLE_ALT_DRIVERS=${CMAKE_BINARY_DIR}/lib/libze_null_test1.so,${CMAKE_BINARY_DIR}/lib/libze_null_test2.so")
 endif()
 
+add_test(NAME tests_loader_teardown_check COMMAND tests --gtest_filter=*GivenLoaderNotInDestructionStateWhenCallingzelCheckIsLoaderInTearDownThenFalseIsReturned)
+set_property(TEST tests_loader_teardown_check PROPERTY ENVIRONMENT "ZE_ENABLE_LOADER_DEBUG_TRACE=1;ZE_ENABLE_NULL_DRIVER=1")
+
 # These tests are currently not supported on Windows. The reason is that the std::cerr is not being redirected to a pipe in Windows to be then checked against the expected output.
 if(NOT MSVC)
     add_test(NAME tests_event_deadlock COMMAND tests --gtest_filter=*GivenLevelZeroLoaderPresentWhenCallingzeCommandListAppendMemoryCopyWithCircularDependencyOnEventsThenValidationLayerPrintsWarningOfDeadlock*)

--- a/test/loader_api.cpp
+++ b/test/loader_api.cpp
@@ -344,4 +344,12 @@ TEST(
   EXPECT_GT(pDriverGetCount, 0);
 }
 
+TEST(
+  LoaderTearDown,
+  GivenLoaderNotInDestructionStateWhenCallingzelCheckIsLoaderInTearDownThenFalseIsReturned) {
+
+  EXPECT_EQ(ZE_RESULT_SUCCESS, zeInit(0));
+  EXPECT_FALSE(zelCheckIsLoaderInTearDown());
+}
+
 } // namespace


### PR DESCRIPTION
…n teardown

- To enable verification of the loader teardown process, a new function `zelCheckIsLoaderInTearDown` has been added to the `ze_loader.h` header file.
- This function can be used to check if the loader is in the process of tearing down. It returns a boolean value indicating whether the loader is currently in teardown mode or not.