### PR TITLE
Fix dynamic tracing support with static loader

### DIFF
--- a/.github/docker/windows.Dockerfile
+++ b/.github/docker/windows.Dockerfile
@@ -4,7 +4,7 @@ ARG BASE_IMAGE=mcr.microsoft.com/dotnet/framework/runtime:4.8
 FROM ${BASE_IMAGE}
 
 SHELL ["powershell"]
-ENV VS_VERSION=2019
+ENV VS_VERSION=2022
 RUN [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; `
     Switch ($env:VS_VERSION) { `
         "2019" {$url_version = "16"} `

--- a/scripts/templates/libddi.cpp.mako
+++ b/scripts/templates/libddi.cpp.mako
@@ -43,6 +43,10 @@ namespace ${x}_lib
                 GET_FUNCTION_PTR(loader, "${tbl['export']['name']}") );
             result = getTableWithCheck(getTable, version, &initial${n}DdiTable.${tbl['name']} );
     %endif
+            %for obj in tbl['functions']:
+            initial${n}DdiTable.${tbl['name']}.${th.make_pfn_name(n, tags, obj)} = reinterpret_cast<${th.make_pfn_type(n, tags, obj)}>(
+                GET_FUNCTION_PTR(loader, "${th.make_func_name(n, tags, obj)}") );
+            %endfor
         }
 
     %endfor

--- a/source/lib/ze_lib.cpp
+++ b/source/lib/ze_lib.cpp
@@ -538,24 +538,42 @@ zelLoaderContextTeardown()
 ze_result_t ZE_APICALL
 zelEnableTracingLayer()
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    if(nullptr == ze_lib::context->loader)
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    typedef ze_result_t (ZE_APICALL *zelEnableTracingLayerInternal_t)();
+    auto enableDynamicTracing = reinterpret_cast<zelEnableTracingLayerInternal_t>(
+            GET_FUNCTION_PTR(ze_lib::context->loader, "zelEnableTracingLayer") );
+    return enableDynamicTracing();
+    #else
     if (ze_lib::context->dynamicTracingSupported == false) {
         return ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
     if (ze_lib::context->tracingLayerEnableCounter.fetch_add(1) == 0) {
         ze_lib::context->zeDdiTable.exchange(ze_lib::context->pTracingZeDdiTable);
     }
+    #endif
     return ZE_RESULT_SUCCESS;
 }
 
 ze_result_t ZE_APICALL
 zelDisableTracingLayer()
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    if(nullptr == ze_lib::context->loader)
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    typedef ze_result_t (ZE_APICALL *zelDisableTracingLayerInternal_t)();
+    auto disableDynamicTracing = reinterpret_cast<zelDisableTracingLayerInternal_t>(
+            GET_FUNCTION_PTR(ze_lib::context->loader, "zelDisableTracingLayer") );
+    return disableDynamicTracing();
+    #else
     if (ze_lib::context->dynamicTracingSupported == false) {
         return ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
     if (ze_lib::context->tracingLayerEnableCounter.fetch_sub(1) <= 1) {
         ze_lib::context->zeDdiTable.exchange(&ze_lib::context->initialzeDdiTable);
     }
+    #endif
     return ZE_RESULT_SUCCESS;
 }
 

--- a/source/lib/ze_libapi.cpp
+++ b/source/lib/ze_libapi.cpp
@@ -120,6 +120,26 @@ zeDriverGet(
                                                     ///< shall only retrieve that number of drivers.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    if (ze_lib::context->zeDdiTable == nullptr) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnDriverGet_t pfnGet = [&result] {
+        auto pfnGet = ze_lib::context->zeDdiTable.load()->Driver.pfnGet;
+        if( nullptr == pfnGet ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGet;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGet( pCount, phDrivers );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -138,6 +158,7 @@ zeDriverGet(
     ze_lib::context->zeInuse = true;
 
     return pfnGet( pCount, phDrivers );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -262,6 +283,23 @@ zeDriverGetApiVersion(
     ze_api_version_t* version                       ///< [out] api version
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnDriverGetApiVersion_t pfnGetApiVersion = [&result] {
+        auto pfnGetApiVersion = ze_lib::context->zeDdiTable.load()->Driver.pfnGetApiVersion;
+        if( nullptr == pfnGetApiVersion ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetApiVersion;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetApiVersion( hDriver, version );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -275,6 +313,7 @@ zeDriverGetApiVersion(
     }
 
     return pfnGetApiVersion( hDriver, version );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -304,6 +343,23 @@ zeDriverGetProperties(
     ze_driver_properties_t* pDriverProperties       ///< [in,out] query result for driver properties
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnDriverGetProperties_t pfnGetProperties = [&result] {
+        auto pfnGetProperties = ze_lib::context->zeDdiTable.load()->Driver.pfnGetProperties;
+        if( nullptr == pfnGetProperties ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetProperties;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetProperties( hDriver, pDriverProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -317,6 +373,7 @@ zeDriverGetProperties(
     }
 
     return pfnGetProperties( hDriver, pDriverProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -342,6 +399,23 @@ zeDriverGetIpcProperties(
     ze_driver_ipc_properties_t* pIpcProperties      ///< [in,out] query result for IPC properties
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnDriverGetIpcProperties_t pfnGetIpcProperties = [&result] {
+        auto pfnGetIpcProperties = ze_lib::context->zeDdiTable.load()->Driver.pfnGetIpcProperties;
+        if( nullptr == pfnGetIpcProperties ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetIpcProperties;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetIpcProperties( hDriver, pIpcProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -355,6 +429,7 @@ zeDriverGetIpcProperties(
     }
 
     return pfnGetIpcProperties( hDriver, pIpcProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -393,6 +468,23 @@ zeDriverGetExtensionProperties(
                                                     ///< then driver shall only retrieve that number of extension properties.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnDriverGetExtensionProperties_t pfnGetExtensionProperties = [&result] {
+        auto pfnGetExtensionProperties = ze_lib::context->zeDdiTable.load()->Driver.pfnGetExtensionProperties;
+        if( nullptr == pfnGetExtensionProperties ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetExtensionProperties;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetExtensionProperties( hDriver, pCount, pExtensionProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -406,6 +498,7 @@ zeDriverGetExtensionProperties(
     }
 
     return pfnGetExtensionProperties( hDriver, pCount, pExtensionProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -434,6 +527,23 @@ zeDriverGetExtensionFunctionAddress(
     void** ppFunctionAddress                        ///< [out] pointer to function pointer
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnDriverGetExtensionFunctionAddress_t pfnGetExtensionFunctionAddress = [&result] {
+        auto pfnGetExtensionFunctionAddress = ze_lib::context->zeDdiTable.load()->Driver.pfnGetExtensionFunctionAddress;
+        if( nullptr == pfnGetExtensionFunctionAddress ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetExtensionFunctionAddress;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetExtensionFunctionAddress( hDriver, name, ppFunctionAddress );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -447,6 +557,7 @@ zeDriverGetExtensionFunctionAddress(
     }
 
     return pfnGetExtensionFunctionAddress( hDriver, name, ppFunctionAddress );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -479,6 +590,23 @@ zeDriverGetLastErrorDescription(
                                                     ///< cause of error.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnDriverGetLastErrorDescription_t pfnGetLastErrorDescription = [&result] {
+        auto pfnGetLastErrorDescription = ze_lib::context->zeDdiTable.load()->Driver.pfnGetLastErrorDescription;
+        if( nullptr == pfnGetLastErrorDescription ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetLastErrorDescription;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetLastErrorDescription( hDriver, ppString );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -492,6 +620,7 @@ zeDriverGetLastErrorDescription(
     }
 
     return pfnGetLastErrorDescription( hDriver, ppString );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -529,6 +658,23 @@ zeDeviceGet(
                                                     ///< shall only retrieve that number of devices.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnDeviceGet_t pfnGet = [&result] {
+        auto pfnGet = ze_lib::context->zeDdiTable.load()->Device.pfnGet;
+        if( nullptr == pfnGet ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGet;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGet( hDriver, pCount, phDevices );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -542,6 +688,7 @@ zeDeviceGet(
     }
 
     return pfnGet( hDriver, pCount, phDevices );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -575,6 +722,23 @@ zeDeviceGetRootDevice(
     ze_device_handle_t* phRootDevice                ///< [in,out] parent root device.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnDeviceGetRootDevice_t pfnGetRootDevice = [&result] {
+        auto pfnGetRootDevice = ze_lib::context->zeDdiTable.load()->Device.pfnGetRootDevice;
+        if( nullptr == pfnGetRootDevice ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetRootDevice;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetRootDevice( hDevice, phRootDevice );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -588,6 +752,7 @@ zeDeviceGetRootDevice(
     }
 
     return pfnGetRootDevice( hDevice, phRootDevice );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -630,6 +795,23 @@ zeDeviceGetSubDevices(
                                                     ///< shall only retrieve that number of sub-devices.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnDeviceGetSubDevices_t pfnGetSubDevices = [&result] {
+        auto pfnGetSubDevices = ze_lib::context->zeDdiTable.load()->Device.pfnGetSubDevices;
+        if( nullptr == pfnGetSubDevices ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetSubDevices;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetSubDevices( hDevice, pCount, phSubdevices );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -643,6 +825,7 @@ zeDeviceGetSubDevices(
     }
 
     return pfnGetSubDevices( hDevice, pCount, phSubdevices );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -672,6 +855,23 @@ zeDeviceGetProperties(
     ze_device_properties_t* pDeviceProperties       ///< [in,out] query result for device properties
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnDeviceGetProperties_t pfnGetProperties = [&result] {
+        auto pfnGetProperties = ze_lib::context->zeDdiTable.load()->Device.pfnGetProperties;
+        if( nullptr == pfnGetProperties ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetProperties;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetProperties( hDevice, pDeviceProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -685,6 +885,7 @@ zeDeviceGetProperties(
     }
 
     return pfnGetProperties( hDevice, pDeviceProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -714,6 +915,23 @@ zeDeviceGetComputeProperties(
     ze_device_compute_properties_t* pComputeProperties  ///< [in,out] query result for compute properties
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnDeviceGetComputeProperties_t pfnGetComputeProperties = [&result] {
+        auto pfnGetComputeProperties = ze_lib::context->zeDdiTable.load()->Device.pfnGetComputeProperties;
+        if( nullptr == pfnGetComputeProperties ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetComputeProperties;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetComputeProperties( hDevice, pComputeProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -727,6 +945,7 @@ zeDeviceGetComputeProperties(
     }
 
     return pfnGetComputeProperties( hDevice, pComputeProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -752,6 +971,23 @@ zeDeviceGetModuleProperties(
     ze_device_module_properties_t* pModuleProperties///< [in,out] query result for module properties
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnDeviceGetModuleProperties_t pfnGetModuleProperties = [&result] {
+        auto pfnGetModuleProperties = ze_lib::context->zeDdiTable.load()->Device.pfnGetModuleProperties;
+        if( nullptr == pfnGetModuleProperties ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetModuleProperties;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetModuleProperties( hDevice, pModuleProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -765,6 +1001,7 @@ zeDeviceGetModuleProperties(
     }
 
     return pfnGetModuleProperties( hDevice, pModuleProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -810,6 +1047,23 @@ zeDeviceGetCommandQueueGroupProperties(
                                                     ///< queue group properties.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnDeviceGetCommandQueueGroupProperties_t pfnGetCommandQueueGroupProperties = [&result] {
+        auto pfnGetCommandQueueGroupProperties = ze_lib::context->zeDdiTable.load()->Device.pfnGetCommandQueueGroupProperties;
+        if( nullptr == pfnGetCommandQueueGroupProperties ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetCommandQueueGroupProperties;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetCommandQueueGroupProperties( hDevice, pCount, pCommandQueueGroupProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -823,6 +1077,7 @@ zeDeviceGetCommandQueueGroupProperties(
     }
 
     return pfnGetCommandQueueGroupProperties( hDevice, pCount, pCommandQueueGroupProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -867,6 +1122,23 @@ zeDeviceGetMemoryProperties(
                                                     ///< driver shall only retrieve that number of memory properties.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnDeviceGetMemoryProperties_t pfnGetMemoryProperties = [&result] {
+        auto pfnGetMemoryProperties = ze_lib::context->zeDdiTable.load()->Device.pfnGetMemoryProperties;
+        if( nullptr == pfnGetMemoryProperties ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetMemoryProperties;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetMemoryProperties( hDevice, pCount, pMemProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -880,6 +1152,7 @@ zeDeviceGetMemoryProperties(
     }
 
     return pfnGetMemoryProperties( hDevice, pCount, pMemProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -909,6 +1182,23 @@ zeDeviceGetMemoryAccessProperties(
     ze_device_memory_access_properties_t* pMemAccessProperties  ///< [in,out] query result for memory access properties
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnDeviceGetMemoryAccessProperties_t pfnGetMemoryAccessProperties = [&result] {
+        auto pfnGetMemoryAccessProperties = ze_lib::context->zeDdiTable.load()->Device.pfnGetMemoryAccessProperties;
+        if( nullptr == pfnGetMemoryAccessProperties ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetMemoryAccessProperties;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetMemoryAccessProperties( hDevice, pMemAccessProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -922,6 +1212,7 @@ zeDeviceGetMemoryAccessProperties(
     }
 
     return pfnGetMemoryAccessProperties( hDevice, pMemAccessProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -959,6 +1250,23 @@ zeDeviceGetCacheProperties(
                                                     ///< driver shall only retrieve that number of cache properties.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnDeviceGetCacheProperties_t pfnGetCacheProperties = [&result] {
+        auto pfnGetCacheProperties = ze_lib::context->zeDdiTable.load()->Device.pfnGetCacheProperties;
+        if( nullptr == pfnGetCacheProperties ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetCacheProperties;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetCacheProperties( hDevice, pCount, pCacheProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -972,6 +1280,7 @@ zeDeviceGetCacheProperties(
     }
 
     return pfnGetCacheProperties( hDevice, pCount, pCacheProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -998,6 +1307,23 @@ zeDeviceGetImageProperties(
     ze_device_image_properties_t* pImageProperties  ///< [in,out] query result for image properties
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnDeviceGetImageProperties_t pfnGetImageProperties = [&result] {
+        auto pfnGetImageProperties = ze_lib::context->zeDdiTable.load()->Device.pfnGetImageProperties;
+        if( nullptr == pfnGetImageProperties ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetImageProperties;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetImageProperties( hDevice, pImageProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1011,6 +1337,7 @@ zeDeviceGetImageProperties(
     }
 
     return pfnGetImageProperties( hDevice, pImageProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1036,6 +1363,23 @@ zeDeviceGetExternalMemoryProperties(
     ze_device_external_memory_properties_t* pExternalMemoryProperties   ///< [in,out] query result for external memory properties
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnDeviceGetExternalMemoryProperties_t pfnGetExternalMemoryProperties = [&result] {
+        auto pfnGetExternalMemoryProperties = ze_lib::context->zeDdiTable.load()->Device.pfnGetExternalMemoryProperties;
+        if( nullptr == pfnGetExternalMemoryProperties ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetExternalMemoryProperties;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetExternalMemoryProperties( hDevice, pExternalMemoryProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1049,6 +1393,7 @@ zeDeviceGetExternalMemoryProperties(
     }
 
     return pfnGetExternalMemoryProperties( hDevice, pExternalMemoryProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1077,6 +1422,23 @@ zeDeviceGetP2PProperties(
     ze_device_p2p_properties_t* pP2PProperties      ///< [in,out] Peer-to-Peer properties between source and peer device
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnDeviceGetP2PProperties_t pfnGetP2PProperties = [&result] {
+        auto pfnGetP2PProperties = ze_lib::context->zeDdiTable.load()->Device.pfnGetP2PProperties;
+        if( nullptr == pfnGetP2PProperties ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetP2PProperties;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetP2PProperties( hDevice, hPeerDevice, pP2PProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1090,6 +1452,7 @@ zeDeviceGetP2PProperties(
     }
 
     return pfnGetP2PProperties( hDevice, hPeerDevice, pP2PProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1131,6 +1494,23 @@ zeDeviceCanAccessPeer(
     ze_bool_t* value                                ///< [out] returned access capability
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnDeviceCanAccessPeer_t pfnCanAccessPeer = [&result] {
+        auto pfnCanAccessPeer = ze_lib::context->zeDdiTable.load()->Device.pfnCanAccessPeer;
+        if( nullptr == pfnCanAccessPeer ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnCanAccessPeer;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnCanAccessPeer( hDevice, hPeerDevice, value );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1144,6 +1524,7 @@ zeDeviceCanAccessPeer(
     }
 
     return pfnCanAccessPeer( hDevice, hPeerDevice, value );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1173,6 +1554,23 @@ zeDeviceGetStatus(
     ze_device_handle_t hDevice                      ///< [in] handle of the device
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnDeviceGetStatus_t pfnGetStatus = [&result] {
+        auto pfnGetStatus = ze_lib::context->zeDdiTable.load()->Device.pfnGetStatus;
+        if( nullptr == pfnGetStatus ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetStatus;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetStatus( hDevice );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1186,6 +1584,7 @@ zeDeviceGetStatus(
     }
 
     return pfnGetStatus( hDevice );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1218,6 +1617,23 @@ zeDeviceGetGlobalTimestamps(
                                                     ///< Host's global timestamp value.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnDeviceGetGlobalTimestamps_t pfnGetGlobalTimestamps = [&result] {
+        auto pfnGetGlobalTimestamps = ze_lib::context->zeDdiTable.load()->Device.pfnGetGlobalTimestamps;
+        if( nullptr == pfnGetGlobalTimestamps ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetGlobalTimestamps;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetGlobalTimestamps( hDevice, hostTimestamp, deviceTimestamp );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1231,6 +1647,7 @@ zeDeviceGetGlobalTimestamps(
     }
 
     return pfnGetGlobalTimestamps( hDevice, hostTimestamp, deviceTimestamp );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1262,6 +1679,23 @@ zeContextCreate(
     ze_context_handle_t* phContext                  ///< [out] pointer to handle of context object created
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnContextCreate_t pfnCreate = [&result] {
+        auto pfnCreate = ze_lib::context->zeDdiTable.load()->Context.pfnCreate;
+        if( nullptr == pfnCreate ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnCreate;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnCreate( hDriver, desc, phContext );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1275,6 +1709,7 @@ zeContextCreate(
     }
 
     return pfnCreate( hDriver, desc, phContext );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1318,6 +1753,23 @@ zeContextCreateEx(
     ze_context_handle_t* phContext                  ///< [out] pointer to handle of context object created
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnContextCreateEx_t pfnCreateEx = [&result] {
+        auto pfnCreateEx = ze_lib::context->zeDdiTable.load()->Context.pfnCreateEx;
+        if( nullptr == pfnCreateEx ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnCreateEx;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnCreateEx( hDriver, desc, numDevices, phDevices, phContext );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1331,6 +1783,7 @@ zeContextCreateEx(
     }
 
     return pfnCreateEx( hDriver, desc, numDevices, phDevices, phContext );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1359,6 +1812,23 @@ zeContextDestroy(
     ze_context_handle_t hContext                    ///< [in][release] handle of context object to destroy
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnContextDestroy_t pfnDestroy = [&result] {
+        auto pfnDestroy = ze_lib::context->zeDdiTable.load()->Context.pfnDestroy;
+        if( nullptr == pfnDestroy ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnDestroy;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnDestroy( hContext );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1372,6 +1842,7 @@ zeContextDestroy(
     }
 
     return pfnDestroy( hContext );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1399,6 +1870,23 @@ zeContextGetStatus(
     ze_context_handle_t hContext                    ///< [in] handle of context object
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnContextGetStatus_t pfnGetStatus = [&result] {
+        auto pfnGetStatus = ze_lib::context->zeDdiTable.load()->Context.pfnGetStatus;
+        if( nullptr == pfnGetStatus ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetStatus;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetStatus( hContext );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1412,6 +1900,7 @@ zeContextGetStatus(
     }
 
     return pfnGetStatus( hContext );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1453,6 +1942,23 @@ zeCommandQueueCreate(
     ze_command_queue_handle_t* phCommandQueue       ///< [out] pointer to handle of command queue object created
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandQueueCreate_t pfnCreate = [&result] {
+        auto pfnCreate = ze_lib::context->zeDdiTable.load()->CommandQueue.pfnCreate;
+        if( nullptr == pfnCreate ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnCreate;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnCreate( hContext, hDevice, desc, phCommandQueue );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1466,6 +1972,7 @@ zeCommandQueueCreate(
     }
 
     return pfnCreate( hContext, hDevice, desc, phCommandQueue );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1500,6 +2007,23 @@ zeCommandQueueDestroy(
     ze_command_queue_handle_t hCommandQueue         ///< [in][release] handle of command queue object to destroy
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandQueueDestroy_t pfnDestroy = [&result] {
+        auto pfnDestroy = ze_lib::context->zeDdiTable.load()->CommandQueue.pfnDestroy;
+        if( nullptr == pfnDestroy ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnDestroy;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnDestroy( hCommandQueue );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1513,6 +2037,7 @@ zeCommandQueueDestroy(
     }
 
     return pfnDestroy( hCommandQueue );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1564,6 +2089,23 @@ zeCommandQueueExecuteCommandLists(
     ze_fence_handle_t hFence                        ///< [in][optional] handle of the fence to signal on completion
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandQueueExecuteCommandLists_t pfnExecuteCommandLists = [&result] {
+        auto pfnExecuteCommandLists = ze_lib::context->zeDdiTable.load()->CommandQueue.pfnExecuteCommandLists;
+        if( nullptr == pfnExecuteCommandLists ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnExecuteCommandLists;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnExecuteCommandLists( hCommandQueue, numCommandLists, phCommandLists, hFence );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1577,6 +2119,7 @@ zeCommandQueueExecuteCommandLists(
     }
 
     return pfnExecuteCommandLists( hCommandQueue, numCommandLists, phCommandLists, hFence );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1608,6 +2151,23 @@ zeCommandQueueSynchronize(
                                                     ///< value allowed by the accuracy of those dependencies.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandQueueSynchronize_t pfnSynchronize = [&result] {
+        auto pfnSynchronize = ze_lib::context->zeDdiTable.load()->CommandQueue.pfnSynchronize;
+        if( nullptr == pfnSynchronize ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnSynchronize;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnSynchronize( hCommandQueue, timeout );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1621,6 +2181,7 @@ zeCommandQueueSynchronize(
     }
 
     return pfnSynchronize( hCommandQueue, timeout );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1646,6 +2207,23 @@ zeCommandQueueGetOrdinal(
     uint32_t* pOrdinal                              ///< [out] command queue group ordinal
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandQueueGetOrdinal_t pfnGetOrdinal = [&result] {
+        auto pfnGetOrdinal = ze_lib::context->zeDdiTable.load()->CommandQueue.pfnGetOrdinal;
+        if( nullptr == pfnGetOrdinal ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetOrdinal;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetOrdinal( hCommandQueue, pOrdinal );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1659,6 +2237,7 @@ zeCommandQueueGetOrdinal(
     }
 
     return pfnGetOrdinal( hCommandQueue, pOrdinal );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1684,6 +2263,23 @@ zeCommandQueueGetIndex(
     uint32_t* pIndex                                ///< [out] command queue index within the group
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandQueueGetIndex_t pfnGetIndex = [&result] {
+        auto pfnGetIndex = ze_lib::context->zeDdiTable.load()->CommandQueue.pfnGetIndex;
+        if( nullptr == pfnGetIndex ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetIndex;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetIndex( hCommandQueue, pIndex );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1697,6 +2293,7 @@ zeCommandQueueGetIndex(
     }
 
     return pfnGetIndex( hCommandQueue, pIndex );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1733,6 +2330,23 @@ zeCommandListCreate(
     ze_command_list_handle_t* phCommandList         ///< [out] pointer to handle of command list object created
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandListCreate_t pfnCreate = [&result] {
+        auto pfnCreate = ze_lib::context->zeDdiTable.load()->CommandList.pfnCreate;
+        if( nullptr == pfnCreate ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnCreate;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnCreate( hContext, hDevice, desc, phCommandList );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1746,6 +2360,7 @@ zeCommandListCreate(
     }
 
     return pfnCreate( hContext, hDevice, desc, phCommandList );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1790,6 +2405,23 @@ zeCommandListCreateImmediate(
     ze_command_list_handle_t* phCommandList         ///< [out] pointer to handle of command list object created
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandListCreateImmediate_t pfnCreateImmediate = [&result] {
+        auto pfnCreateImmediate = ze_lib::context->zeDdiTable.load()->CommandList.pfnCreateImmediate;
+        if( nullptr == pfnCreateImmediate ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnCreateImmediate;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnCreateImmediate( hContext, hDevice, altdesc, phCommandList );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1803,6 +2435,7 @@ zeCommandListCreateImmediate(
     }
 
     return pfnCreateImmediate( hContext, hDevice, altdesc, phCommandList );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1831,6 +2464,23 @@ zeCommandListDestroy(
     ze_command_list_handle_t hCommandList           ///< [in][release] handle of command list object to destroy
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandListDestroy_t pfnDestroy = [&result] {
+        auto pfnDestroy = ze_lib::context->zeDdiTable.load()->CommandList.pfnDestroy;
+        if( nullptr == pfnDestroy ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnDestroy;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnDestroy( hCommandList );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1844,6 +2494,7 @@ zeCommandListDestroy(
     }
 
     return pfnDestroy( hCommandList );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1867,6 +2518,23 @@ zeCommandListClose(
     ze_command_list_handle_t hCommandList           ///< [in] handle of command list object to close
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandListClose_t pfnClose = [&result] {
+        auto pfnClose = ze_lib::context->zeDdiTable.load()->CommandList.pfnClose;
+        if( nullptr == pfnClose ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnClose;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnClose( hCommandList );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1880,6 +2548,7 @@ zeCommandListClose(
     }
 
     return pfnClose( hCommandList );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1906,6 +2575,23 @@ zeCommandListReset(
     ze_command_list_handle_t hCommandList           ///< [in] handle of command list object to reset
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandListReset_t pfnReset = [&result] {
+        auto pfnReset = ze_lib::context->zeDdiTable.load()->CommandList.pfnReset;
+        if( nullptr == pfnReset ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnReset;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnReset( hCommandList );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1919,6 +2605,7 @@ zeCommandListReset(
     }
 
     return pfnReset( hCommandList );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1965,6 +2652,23 @@ zeCommandListAppendWriteGlobalTimestamp(
                                                     ///< on before executing query
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandListAppendWriteGlobalTimestamp_t pfnAppendWriteGlobalTimestamp = [&result] {
+        auto pfnAppendWriteGlobalTimestamp = ze_lib::context->zeDdiTable.load()->CommandList.pfnAppendWriteGlobalTimestamp;
+        if( nullptr == pfnAppendWriteGlobalTimestamp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnAppendWriteGlobalTimestamp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnAppendWriteGlobalTimestamp( hCommandList, dstptr, hSignalEvent, numWaitEvents, phWaitEvents );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1978,6 +2682,7 @@ zeCommandListAppendWriteGlobalTimestamp(
     }
 
     return pfnAppendWriteGlobalTimestamp( hCommandList, dstptr, hSignalEvent, numWaitEvents, phWaitEvents );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2018,6 +2723,23 @@ zeCommandListHostSynchronize(
                                                     ///< value allowed by the accuracy of those dependencies.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandListHostSynchronize_t pfnHostSynchronize = [&result] {
+        auto pfnHostSynchronize = ze_lib::context->zeDdiTable.load()->CommandList.pfnHostSynchronize;
+        if( nullptr == pfnHostSynchronize ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnHostSynchronize;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnHostSynchronize( hCommandList, timeout );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2031,6 +2753,7 @@ zeCommandListHostSynchronize(
     }
 
     return pfnHostSynchronize( hCommandList, timeout );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2056,6 +2779,23 @@ zeCommandListGetDeviceHandle(
     ze_device_handle_t* phDevice                    ///< [out] handle of the device on which the command list was created
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandListGetDeviceHandle_t pfnGetDeviceHandle = [&result] {
+        auto pfnGetDeviceHandle = ze_lib::context->zeDdiTable.load()->CommandList.pfnGetDeviceHandle;
+        if( nullptr == pfnGetDeviceHandle ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetDeviceHandle;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetDeviceHandle( hCommandList, phDevice );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2069,6 +2809,7 @@ zeCommandListGetDeviceHandle(
     }
 
     return pfnGetDeviceHandle( hCommandList, phDevice );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2094,6 +2835,23 @@ zeCommandListGetContextHandle(
     ze_context_handle_t* phContext                  ///< [out] handle of the context on which the command list was created
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandListGetContextHandle_t pfnGetContextHandle = [&result] {
+        auto pfnGetContextHandle = ze_lib::context->zeDdiTable.load()->CommandList.pfnGetContextHandle;
+        if( nullptr == pfnGetContextHandle ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetContextHandle;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetContextHandle( hCommandList, phContext );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2107,6 +2865,7 @@ zeCommandListGetContextHandle(
     }
 
     return pfnGetContextHandle( hCommandList, phContext );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2133,6 +2892,23 @@ zeCommandListGetOrdinal(
     uint32_t* pOrdinal                              ///< [out] command queue group ordinal to which command list is submitted
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandListGetOrdinal_t pfnGetOrdinal = [&result] {
+        auto pfnGetOrdinal = ze_lib::context->zeDdiTable.load()->CommandList.pfnGetOrdinal;
+        if( nullptr == pfnGetOrdinal ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetOrdinal;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetOrdinal( hCommandList, pOrdinal );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2146,6 +2922,7 @@ zeCommandListGetOrdinal(
     }
 
     return pfnGetOrdinal( hCommandList, pOrdinal );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2177,6 +2954,23 @@ zeCommandListImmediateGetIndex(
                                                     ///< command list is submitted
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandListImmediateGetIndex_t pfnImmediateGetIndex = [&result] {
+        auto pfnImmediateGetIndex = ze_lib::context->zeDdiTable.load()->CommandList.pfnImmediateGetIndex;
+        if( nullptr == pfnImmediateGetIndex ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnImmediateGetIndex;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnImmediateGetIndex( hCommandListImmediate, pIndex );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2190,6 +2984,7 @@ zeCommandListImmediateGetIndex(
     }
 
     return pfnImmediateGetIndex( hCommandListImmediate, pIndex );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2216,6 +3011,23 @@ zeCommandListIsImmediate(
                                                     ///< command list (true) or not (false)
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandListIsImmediate_t pfnIsImmediate = [&result] {
+        auto pfnIsImmediate = ze_lib::context->zeDdiTable.load()->CommandList.pfnIsImmediate;
+        if( nullptr == pfnIsImmediate ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnIsImmediate;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnIsImmediate( hCommandList, pIsImmediate );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2229,6 +3041,7 @@ zeCommandListIsImmediate(
     }
 
     return pfnIsImmediate( hCommandList, pIsImmediate );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2274,6 +3087,23 @@ zeCommandListAppendBarrier(
                                                     ///< on before executing barrier
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandListAppendBarrier_t pfnAppendBarrier = [&result] {
+        auto pfnAppendBarrier = ze_lib::context->zeDdiTable.load()->CommandList.pfnAppendBarrier;
+        if( nullptr == pfnAppendBarrier ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnAppendBarrier;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnAppendBarrier( hCommandList, hSignalEvent, numWaitEvents, phWaitEvents );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2287,6 +3117,7 @@ zeCommandListAppendBarrier(
     }
 
     return pfnAppendBarrier( hCommandList, hSignalEvent, numWaitEvents, phWaitEvents );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2332,6 +3163,23 @@ zeCommandListAppendMemoryRangesBarrier(
                                                     ///< on before executing barrier
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandListAppendMemoryRangesBarrier_t pfnAppendMemoryRangesBarrier = [&result] {
+        auto pfnAppendMemoryRangesBarrier = ze_lib::context->zeDdiTable.load()->CommandList.pfnAppendMemoryRangesBarrier;
+        if( nullptr == pfnAppendMemoryRangesBarrier ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnAppendMemoryRangesBarrier;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnAppendMemoryRangesBarrier( hCommandList, numRanges, pRangeSizes, pRanges, hSignalEvent, numWaitEvents, phWaitEvents );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2345,6 +3193,7 @@ zeCommandListAppendMemoryRangesBarrier(
     }
 
     return pfnAppendMemoryRangesBarrier( hCommandList, numRanges, pRangeSizes, pRanges, hSignalEvent, numWaitEvents, phWaitEvents );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2375,6 +3224,23 @@ zeContextSystemBarrier(
     ze_device_handle_t hDevice                      ///< [in] handle of the device
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnContextSystemBarrier_t pfnSystemBarrier = [&result] {
+        auto pfnSystemBarrier = ze_lib::context->zeDdiTable.load()->Context.pfnSystemBarrier;
+        if( nullptr == pfnSystemBarrier ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnSystemBarrier;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnSystemBarrier( hContext, hDevice );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2388,6 +3254,7 @@ zeContextSystemBarrier(
     }
 
     return pfnSystemBarrier( hContext, hDevice );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2441,6 +3308,23 @@ zeCommandListAppendMemoryCopy(
                                                     ///< on before launching
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandListAppendMemoryCopy_t pfnAppendMemoryCopy = [&result] {
+        auto pfnAppendMemoryCopy = ze_lib::context->zeDdiTable.load()->CommandList.pfnAppendMemoryCopy;
+        if( nullptr == pfnAppendMemoryCopy ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnAppendMemoryCopy;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnAppendMemoryCopy( hCommandList, dstptr, srcptr, size, hSignalEvent, numWaitEvents, phWaitEvents );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2454,6 +3338,7 @@ zeCommandListAppendMemoryCopy(
     }
 
     return pfnAppendMemoryCopy( hCommandList, dstptr, srcptr, size, hSignalEvent, numWaitEvents, phWaitEvents );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2511,6 +3396,23 @@ zeCommandListAppendMemoryFill(
                                                     ///< on before launching
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandListAppendMemoryFill_t pfnAppendMemoryFill = [&result] {
+        auto pfnAppendMemoryFill = ze_lib::context->zeDdiTable.load()->CommandList.pfnAppendMemoryFill;
+        if( nullptr == pfnAppendMemoryFill ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnAppendMemoryFill;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnAppendMemoryFill( hCommandList, ptr, pattern, pattern_size, size, hSignalEvent, numWaitEvents, phWaitEvents );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2524,6 +3426,7 @@ zeCommandListAppendMemoryFill(
     }
 
     return pfnAppendMemoryFill( hCommandList, ptr, pattern, pattern_size, size, hSignalEvent, numWaitEvents, phWaitEvents );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2586,6 +3489,23 @@ zeCommandListAppendMemoryCopyRegion(
                                                     ///< on before launching
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandListAppendMemoryCopyRegion_t pfnAppendMemoryCopyRegion = [&result] {
+        auto pfnAppendMemoryCopyRegion = ze_lib::context->zeDdiTable.load()->CommandList.pfnAppendMemoryCopyRegion;
+        if( nullptr == pfnAppendMemoryCopyRegion ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnAppendMemoryCopyRegion;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnAppendMemoryCopyRegion( hCommandList, dstptr, dstRegion, dstPitch, dstSlicePitch, srcptr, srcRegion, srcPitch, srcSlicePitch, hSignalEvent, numWaitEvents, phWaitEvents );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2599,6 +3519,7 @@ zeCommandListAppendMemoryCopyRegion(
     }
 
     return pfnAppendMemoryCopyRegion( hCommandList, dstptr, dstRegion, dstPitch, dstSlicePitch, srcptr, srcRegion, srcPitch, srcSlicePitch, hSignalEvent, numWaitEvents, phWaitEvents );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2648,6 +3569,23 @@ zeCommandListAppendMemoryCopyFromContext(
                                                     ///< on before launching
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandListAppendMemoryCopyFromContext_t pfnAppendMemoryCopyFromContext = [&result] {
+        auto pfnAppendMemoryCopyFromContext = ze_lib::context->zeDdiTable.load()->CommandList.pfnAppendMemoryCopyFromContext;
+        if( nullptr == pfnAppendMemoryCopyFromContext ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnAppendMemoryCopyFromContext;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnAppendMemoryCopyFromContext( hCommandList, dstptr, hContextSrc, srcptr, size, hSignalEvent, numWaitEvents, phWaitEvents );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2661,6 +3599,7 @@ zeCommandListAppendMemoryCopyFromContext(
     }
 
     return pfnAppendMemoryCopyFromContext( hCommandList, dstptr, hContextSrc, srcptr, size, hSignalEvent, numWaitEvents, phWaitEvents );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2706,6 +3645,23 @@ zeCommandListAppendImageCopy(
                                                     ///< on before launching
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandListAppendImageCopy_t pfnAppendImageCopy = [&result] {
+        auto pfnAppendImageCopy = ze_lib::context->zeDdiTable.load()->CommandList.pfnAppendImageCopy;
+        if( nullptr == pfnAppendImageCopy ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnAppendImageCopy;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnAppendImageCopy( hCommandList, hDstImage, hSrcImage, hSignalEvent, numWaitEvents, phWaitEvents );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2719,6 +3675,7 @@ zeCommandListAppendImageCopy(
     }
 
     return pfnAppendImageCopy( hCommandList, hDstImage, hSrcImage, hSignalEvent, numWaitEvents, phWaitEvents );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2766,6 +3723,23 @@ zeCommandListAppendImageCopyRegion(
                                                     ///< on before launching
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandListAppendImageCopyRegion_t pfnAppendImageCopyRegion = [&result] {
+        auto pfnAppendImageCopyRegion = ze_lib::context->zeDdiTable.load()->CommandList.pfnAppendImageCopyRegion;
+        if( nullptr == pfnAppendImageCopyRegion ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnAppendImageCopyRegion;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnAppendImageCopyRegion( hCommandList, hDstImage, hSrcImage, pDstRegion, pSrcRegion, hSignalEvent, numWaitEvents, phWaitEvents );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2779,6 +3753,7 @@ zeCommandListAppendImageCopyRegion(
     }
 
     return pfnAppendImageCopyRegion( hCommandList, hDstImage, hSrcImage, pDstRegion, pSrcRegion, hSignalEvent, numWaitEvents, phWaitEvents );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2831,6 +3806,23 @@ zeCommandListAppendImageCopyToMemory(
                                                     ///< on before launching
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandListAppendImageCopyToMemory_t pfnAppendImageCopyToMemory = [&result] {
+        auto pfnAppendImageCopyToMemory = ze_lib::context->zeDdiTable.load()->CommandList.pfnAppendImageCopyToMemory;
+        if( nullptr == pfnAppendImageCopyToMemory ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnAppendImageCopyToMemory;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnAppendImageCopyToMemory( hCommandList, dstptr, hSrcImage, pSrcRegion, hSignalEvent, numWaitEvents, phWaitEvents );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2844,6 +3836,7 @@ zeCommandListAppendImageCopyToMemory(
     }
 
     return pfnAppendImageCopyToMemory( hCommandList, dstptr, hSrcImage, pSrcRegion, hSignalEvent, numWaitEvents, phWaitEvents );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2896,6 +3889,23 @@ zeCommandListAppendImageCopyFromMemory(
                                                     ///< on before launching
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandListAppendImageCopyFromMemory_t pfnAppendImageCopyFromMemory = [&result] {
+        auto pfnAppendImageCopyFromMemory = ze_lib::context->zeDdiTable.load()->CommandList.pfnAppendImageCopyFromMemory;
+        if( nullptr == pfnAppendImageCopyFromMemory ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnAppendImageCopyFromMemory;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnAppendImageCopyFromMemory( hCommandList, hDstImage, srcptr, pDstRegion, hSignalEvent, numWaitEvents, phWaitEvents );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2909,6 +3919,7 @@ zeCommandListAppendImageCopyFromMemory(
     }
 
     return pfnAppendImageCopyFromMemory( hCommandList, hDstImage, srcptr, pDstRegion, hSignalEvent, numWaitEvents, phWaitEvents );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2957,6 +3968,23 @@ zeCommandListAppendMemoryPrefetch(
     size_t size                                     ///< [in] size in bytes of the memory range to prefetch
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandListAppendMemoryPrefetch_t pfnAppendMemoryPrefetch = [&result] {
+        auto pfnAppendMemoryPrefetch = ze_lib::context->zeDdiTable.load()->CommandList.pfnAppendMemoryPrefetch;
+        if( nullptr == pfnAppendMemoryPrefetch ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnAppendMemoryPrefetch;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnAppendMemoryPrefetch( hCommandList, ptr, size );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2970,6 +3998,7 @@ zeCommandListAppendMemoryPrefetch(
     }
 
     return pfnAppendMemoryPrefetch( hCommandList, ptr, size );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3018,6 +4047,23 @@ zeCommandListAppendMemAdvise(
     ze_memory_advice_t advice                       ///< [in] Memory advice for the memory range
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandListAppendMemAdvise_t pfnAppendMemAdvise = [&result] {
+        auto pfnAppendMemAdvise = ze_lib::context->zeDdiTable.load()->CommandList.pfnAppendMemAdvise;
+        if( nullptr == pfnAppendMemAdvise ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnAppendMemAdvise;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnAppendMemAdvise( hCommandList, hDevice, ptr, size, advice );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3031,6 +4077,7 @@ zeCommandListAppendMemAdvise(
     }
 
     return pfnAppendMemAdvise( hCommandList, hDevice, ptr, size, advice );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3071,6 +4118,23 @@ zeEventPoolCreate(
     ze_event_pool_handle_t* phEventPool             ///< [out] pointer handle of event pool object created
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnEventPoolCreate_t pfnCreate = [&result] {
+        auto pfnCreate = ze_lib::context->zeDdiTable.load()->EventPool.pfnCreate;
+        if( nullptr == pfnCreate ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnCreate;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnCreate( hContext, desc, numDevices, phDevices, phEventPool );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3084,6 +4148,7 @@ zeEventPoolCreate(
     }
 
     return pfnCreate( hContext, desc, numDevices, phDevices, phEventPool );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3114,6 +4179,23 @@ zeEventPoolDestroy(
     ze_event_pool_handle_t hEventPool               ///< [in][release] handle of event pool object to destroy
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnEventPoolDestroy_t pfnDestroy = [&result] {
+        auto pfnDestroy = ze_lib::context->zeDdiTable.load()->EventPool.pfnDestroy;
+        if( nullptr == pfnDestroy ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnDestroy;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnDestroy( hEventPool );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3127,6 +4209,7 @@ zeEventPoolDestroy(
     }
 
     return pfnDestroy( hEventPool );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3167,6 +4250,23 @@ zeEventCreate(
     ze_event_handle_t* phEvent                      ///< [out] pointer to handle of event object created
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnEventCreate_t pfnCreate = [&result] {
+        auto pfnCreate = ze_lib::context->zeDdiTable.load()->Event.pfnCreate;
+        if( nullptr == pfnCreate ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnCreate;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnCreate( hEventPool, desc, phEvent );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3180,6 +4280,7 @@ zeEventCreate(
     }
 
     return pfnCreate( hEventPool, desc, phEvent );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3213,6 +4314,23 @@ zeEventDestroy(
     ze_event_handle_t hEvent                        ///< [in][release] handle of event object to destroy
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnEventDestroy_t pfnDestroy = [&result] {
+        auto pfnDestroy = ze_lib::context->zeDdiTable.load()->Event.pfnDestroy;
+        if( nullptr == pfnDestroy ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnDestroy;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnDestroy( hEvent );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3226,6 +4344,7 @@ zeEventDestroy(
     }
 
     return pfnDestroy( hEvent );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3253,6 +4372,23 @@ zeEventPoolGetIpcHandle(
     ze_ipc_event_pool_handle_t* phIpc               ///< [out] Returned IPC event handle
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnEventPoolGetIpcHandle_t pfnGetIpcHandle = [&result] {
+        auto pfnGetIpcHandle = ze_lib::context->zeDdiTable.load()->EventPool.pfnGetIpcHandle;
+        if( nullptr == pfnGetIpcHandle ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetIpcHandle;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetIpcHandle( hEventPool, phIpc );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3266,6 +4402,7 @@ zeEventPoolGetIpcHandle(
     }
 
     return pfnGetIpcHandle( hEventPool, phIpc );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3299,6 +4436,23 @@ zeEventPoolPutIpcHandle(
     ze_ipc_event_pool_handle_t hIpc                 ///< [in] IPC event pool handle
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnEventPoolPutIpcHandle_t pfnPutIpcHandle = [&result] {
+        auto pfnPutIpcHandle = ze_lib::context->zeDdiTable.load()->EventPool.pfnPutIpcHandle;
+        if( nullptr == pfnPutIpcHandle ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnPutIpcHandle;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnPutIpcHandle( hContext, hIpc );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3312,6 +4466,7 @@ zeEventPoolPutIpcHandle(
     }
 
     return pfnPutIpcHandle( hContext, hIpc );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3355,6 +4510,23 @@ zeEventPoolOpenIpcHandle(
     ze_event_pool_handle_t* phEventPool             ///< [out] pointer handle of event pool object created
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnEventPoolOpenIpcHandle_t pfnOpenIpcHandle = [&result] {
+        auto pfnOpenIpcHandle = ze_lib::context->zeDdiTable.load()->EventPool.pfnOpenIpcHandle;
+        if( nullptr == pfnOpenIpcHandle ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnOpenIpcHandle;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnOpenIpcHandle( hContext, hIpc, phEventPool );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3368,6 +4540,7 @@ zeEventPoolOpenIpcHandle(
     }
 
     return pfnOpenIpcHandle( hContext, hIpc, phEventPool );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3392,6 +4565,23 @@ zeEventPoolCloseIpcHandle(
     ze_event_pool_handle_t hEventPool               ///< [in][release] handle of event pool object
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnEventPoolCloseIpcHandle_t pfnCloseIpcHandle = [&result] {
+        auto pfnCloseIpcHandle = ze_lib::context->zeDdiTable.load()->EventPool.pfnCloseIpcHandle;
+        if( nullptr == pfnCloseIpcHandle ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnCloseIpcHandle;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnCloseIpcHandle( hEventPool );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3405,6 +4595,7 @@ zeEventPoolCloseIpcHandle(
     }
 
     return pfnCloseIpcHandle( hEventPool );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3445,6 +4636,23 @@ zeCommandListAppendSignalEvent(
     ze_event_handle_t hEvent                        ///< [in] handle of the event
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandListAppendSignalEvent_t pfnAppendSignalEvent = [&result] {
+        auto pfnAppendSignalEvent = ze_lib::context->zeDdiTable.load()->CommandList.pfnAppendSignalEvent;
+        if( nullptr == pfnAppendSignalEvent ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnAppendSignalEvent;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnAppendSignalEvent( hCommandList, hEvent );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3458,6 +4666,7 @@ zeCommandListAppendSignalEvent(
     }
 
     return pfnAppendSignalEvent( hCommandList, hEvent );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3491,6 +4700,23 @@ zeCommandListAppendWaitOnEvents(
                                                     ///< continuing
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandListAppendWaitOnEvents_t pfnAppendWaitOnEvents = [&result] {
+        auto pfnAppendWaitOnEvents = ze_lib::context->zeDdiTable.load()->CommandList.pfnAppendWaitOnEvents;
+        if( nullptr == pfnAppendWaitOnEvents ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnAppendWaitOnEvents;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnAppendWaitOnEvents( hCommandList, numEvents, phEvents );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3504,6 +4730,7 @@ zeCommandListAppendWaitOnEvents(
     }
 
     return pfnAppendWaitOnEvents( hCommandList, numEvents, phEvents );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3536,6 +4763,23 @@ zeEventHostSignal(
     ze_event_handle_t hEvent                        ///< [in] handle of the event
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnEventHostSignal_t pfnHostSignal = [&result] {
+        auto pfnHostSignal = ze_lib::context->zeDdiTable.load()->Event.pfnHostSignal;
+        if( nullptr == pfnHostSignal ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnHostSignal;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnHostSignal( hEvent );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3549,6 +4793,7 @@ zeEventHostSignal(
     }
 
     return pfnHostSignal( hEvent );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3585,6 +4830,23 @@ zeEventHostSynchronize(
                                                     ///< value allowed by the accuracy of those dependencies.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnEventHostSynchronize_t pfnHostSynchronize = [&result] {
+        auto pfnHostSynchronize = ze_lib::context->zeDdiTable.load()->Event.pfnHostSynchronize;
+        if( nullptr == pfnHostSynchronize ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnHostSynchronize;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnHostSynchronize( hEvent, timeout );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3598,6 +4860,7 @@ zeEventHostSynchronize(
     }
 
     return pfnHostSynchronize( hEvent, timeout );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3628,6 +4891,23 @@ zeEventQueryStatus(
     ze_event_handle_t hEvent                        ///< [in] handle of the event
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnEventQueryStatus_t pfnQueryStatus = [&result] {
+        auto pfnQueryStatus = ze_lib::context->zeDdiTable.load()->Event.pfnQueryStatus;
+        if( nullptr == pfnQueryStatus ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnQueryStatus;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnQueryStatus( hEvent );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3641,6 +4921,7 @@ zeEventQueryStatus(
     }
 
     return pfnQueryStatus( hEvent );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3676,6 +4957,23 @@ zeCommandListAppendEventReset(
     ze_event_handle_t hEvent                        ///< [in] handle of the event
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandListAppendEventReset_t pfnAppendEventReset = [&result] {
+        auto pfnAppendEventReset = ze_lib::context->zeDdiTable.load()->CommandList.pfnAppendEventReset;
+        if( nullptr == pfnAppendEventReset ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnAppendEventReset;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnAppendEventReset( hCommandList, hEvent );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3689,6 +4987,7 @@ zeCommandListAppendEventReset(
     }
 
     return pfnAppendEventReset( hCommandList, hEvent );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3716,6 +5015,23 @@ zeEventHostReset(
     ze_event_handle_t hEvent                        ///< [in] handle of the event
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnEventHostReset_t pfnHostReset = [&result] {
+        auto pfnHostReset = ze_lib::context->zeDdiTable.load()->Event.pfnHostReset;
+        if( nullptr == pfnHostReset ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnHostReset;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnHostReset( hEvent );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3729,6 +5045,7 @@ zeEventHostReset(
     }
 
     return pfnHostReset( hEvent );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3762,6 +5079,23 @@ zeEventQueryKernelTimestamp(
     ze_kernel_timestamp_result_t* dstptr            ///< [in,out] pointer to memory for where timestamp result will be written.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnEventQueryKernelTimestamp_t pfnQueryKernelTimestamp = [&result] {
+        auto pfnQueryKernelTimestamp = ze_lib::context->zeDdiTable.load()->Event.pfnQueryKernelTimestamp;
+        if( nullptr == pfnQueryKernelTimestamp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnQueryKernelTimestamp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnQueryKernelTimestamp( hEvent, dstptr );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3775,6 +5109,7 @@ zeEventQueryKernelTimestamp(
     }
 
     return pfnQueryKernelTimestamp( hEvent, dstptr );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3829,6 +5164,23 @@ zeCommandListAppendQueryKernelTimestamps(
                                                     ///< on before executing query
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandListAppendQueryKernelTimestamps_t pfnAppendQueryKernelTimestamps = [&result] {
+        auto pfnAppendQueryKernelTimestamps = ze_lib::context->zeDdiTable.load()->CommandList.pfnAppendQueryKernelTimestamps;
+        if( nullptr == pfnAppendQueryKernelTimestamps ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnAppendQueryKernelTimestamps;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnAppendQueryKernelTimestamps( hCommandList, numEvents, phEvents, dstptr, pOffsets, hSignalEvent, numWaitEvents, phWaitEvents );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3842,6 +5194,7 @@ zeCommandListAppendQueryKernelTimestamps(
     }
 
     return pfnAppendQueryKernelTimestamps( hCommandList, numEvents, phEvents, dstptr, pOffsets, hSignalEvent, numWaitEvents, phWaitEvents );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3867,6 +5220,23 @@ zeEventGetEventPool(
     ze_event_pool_handle_t* phEventPool             ///< [out] handle of the event pool for the event
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnEventGetEventPool_t pfnGetEventPool = [&result] {
+        auto pfnGetEventPool = ze_lib::context->zeDdiTable.load()->Event.pfnGetEventPool;
+        if( nullptr == pfnGetEventPool ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetEventPool;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetEventPool( hEvent, phEventPool );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3880,6 +5250,7 @@ zeEventGetEventPool(
     }
 
     return pfnGetEventPool( hEvent, phEventPool );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3907,6 +5278,23 @@ zeEventGetSignalScope(
                                                     ///< triggered. May be 0 or a valid combination of ::ze_event_scope_flag_t.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnEventGetSignalScope_t pfnGetSignalScope = [&result] {
+        auto pfnGetSignalScope = ze_lib::context->zeDdiTable.load()->Event.pfnGetSignalScope;
+        if( nullptr == pfnGetSignalScope ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetSignalScope;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetSignalScope( hEvent, pSignalScope );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3920,6 +5308,7 @@ zeEventGetSignalScope(
     }
 
     return pfnGetSignalScope( hEvent, pSignalScope );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3947,6 +5336,23 @@ zeEventGetWaitScope(
                                                     ///< May be 0 or a valid combination of ::ze_event_scope_flag_t.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnEventGetWaitScope_t pfnGetWaitScope = [&result] {
+        auto pfnGetWaitScope = ze_lib::context->zeDdiTable.load()->Event.pfnGetWaitScope;
+        if( nullptr == pfnGetWaitScope ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetWaitScope;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetWaitScope( hEvent, pWaitScope );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3960,6 +5366,7 @@ zeEventGetWaitScope(
     }
 
     return pfnGetWaitScope( hEvent, pWaitScope );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3985,6 +5392,23 @@ zeEventPoolGetContextHandle(
     ze_context_handle_t* phContext                  ///< [out] handle of the context on which the event pool was created
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnEventPoolGetContextHandle_t pfnGetContextHandle = [&result] {
+        auto pfnGetContextHandle = ze_lib::context->zeDdiTable.load()->EventPool.pfnGetContextHandle;
+        if( nullptr == pfnGetContextHandle ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetContextHandle;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetContextHandle( hEventPool, phContext );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3998,6 +5422,7 @@ zeEventPoolGetContextHandle(
     }
 
     return pfnGetContextHandle( hEventPool, phContext );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4024,6 +5449,23 @@ zeEventPoolGetFlags(
                                                     ///< valid combination of ::ze_event_pool_flag_t
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnEventPoolGetFlags_t pfnGetFlags = [&result] {
+        auto pfnGetFlags = ze_lib::context->zeDdiTable.load()->EventPool.pfnGetFlags;
+        if( nullptr == pfnGetFlags ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetFlags;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetFlags( hEventPool, pFlags );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4037,6 +5479,7 @@ zeEventPoolGetFlags(
     }
 
     return pfnGetFlags( hEventPool, pFlags );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4074,6 +5517,23 @@ zeFenceCreate(
     ze_fence_handle_t* phFence                      ///< [out] pointer to handle of fence object created
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnFenceCreate_t pfnCreate = [&result] {
+        auto pfnCreate = ze_lib::context->zeDdiTable.load()->Fence.pfnCreate;
+        if( nullptr == pfnCreate ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnCreate;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnCreate( hCommandQueue, desc, phFence );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4087,6 +5547,7 @@ zeFenceCreate(
     }
 
     return pfnCreate( hCommandQueue, desc, phFence );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4119,6 +5580,23 @@ zeFenceDestroy(
     ze_fence_handle_t hFence                        ///< [in][release] handle of fence object to destroy
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnFenceDestroy_t pfnDestroy = [&result] {
+        auto pfnDestroy = ze_lib::context->zeDdiTable.load()->Fence.pfnDestroy;
+        if( nullptr == pfnDestroy ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnDestroy;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnDestroy( hFence );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4132,6 +5610,7 @@ zeFenceDestroy(
     }
 
     return pfnDestroy( hFence );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4168,6 +5647,23 @@ zeFenceHostSynchronize(
                                                     ///< value allowed by the accuracy of those dependencies.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnFenceHostSynchronize_t pfnHostSynchronize = [&result] {
+        auto pfnHostSynchronize = ze_lib::context->zeDdiTable.load()->Fence.pfnHostSynchronize;
+        if( nullptr == pfnHostSynchronize ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnHostSynchronize;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnHostSynchronize( hFence, timeout );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4181,6 +5677,7 @@ zeFenceHostSynchronize(
     }
 
     return pfnHostSynchronize( hFence, timeout );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4210,6 +5707,23 @@ zeFenceQueryStatus(
     ze_fence_handle_t hFence                        ///< [in] handle of the fence
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnFenceQueryStatus_t pfnQueryStatus = [&result] {
+        auto pfnQueryStatus = ze_lib::context->zeDdiTable.load()->Fence.pfnQueryStatus;
+        if( nullptr == pfnQueryStatus ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnQueryStatus;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnQueryStatus( hFence );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4223,6 +5737,7 @@ zeFenceQueryStatus(
     }
 
     return pfnQueryStatus( hFence );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4249,6 +5764,23 @@ zeFenceReset(
     ze_fence_handle_t hFence                        ///< [in] handle of the fence
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnFenceReset_t pfnReset = [&result] {
+        auto pfnReset = ze_lib::context->zeDdiTable.load()->Fence.pfnReset;
+        if( nullptr == pfnReset ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnReset;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnReset( hFence );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4262,6 +5794,7 @@ zeFenceReset(
     }
 
     return pfnReset( hFence );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4292,6 +5825,23 @@ zeImageGetProperties(
     ze_image_properties_t* pImageProperties         ///< [out] pointer to image properties
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnImageGetProperties_t pfnGetProperties = [&result] {
+        auto pfnGetProperties = ze_lib::context->zeDdiTable.load()->Image.pfnGetProperties;
+        if( nullptr == pfnGetProperties ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetProperties;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetProperties( hDevice, desc, pImageProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4305,6 +5855,7 @@ zeImageGetProperties(
     }
 
     return pfnGetProperties( hDevice, desc, pImageProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4344,6 +5895,23 @@ zeImageCreate(
     ze_image_handle_t* phImage                      ///< [out] pointer to handle of image object created
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnImageCreate_t pfnCreate = [&result] {
+        auto pfnCreate = ze_lib::context->zeDdiTable.load()->Image.pfnCreate;
+        if( nullptr == pfnCreate ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnCreate;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnCreate( hContext, hDevice, desc, phImage );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4357,6 +5925,7 @@ zeImageCreate(
     }
 
     return pfnCreate( hContext, hDevice, desc, phImage );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4385,6 +5954,23 @@ zeImageDestroy(
     ze_image_handle_t hImage                        ///< [in][release] handle of image object to destroy
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnImageDestroy_t pfnDestroy = [&result] {
+        auto pfnDestroy = ze_lib::context->zeDdiTable.load()->Image.pfnDestroy;
+        if( nullptr == pfnDestroy ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnDestroy;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnDestroy( hImage );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4398,6 +5984,7 @@ zeImageDestroy(
     }
 
     return pfnDestroy( hImage );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4455,6 +6042,23 @@ zeMemAllocShared(
     void** pptr                                     ///< [out] pointer to shared allocation
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnMemAllocShared_t pfnAllocShared = [&result] {
+        auto pfnAllocShared = ze_lib::context->zeDdiTable.load()->Mem.pfnAllocShared;
+        if( nullptr == pfnAllocShared ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnAllocShared;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnAllocShared( hContext, device_desc, host_desc, size, alignment, hDevice, pptr );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4468,6 +6072,7 @@ zeMemAllocShared(
     }
 
     return pfnAllocShared( hContext, device_desc, host_desc, size, alignment, hDevice, pptr );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4513,6 +6118,23 @@ zeMemAllocDevice(
     void** pptr                                     ///< [out] pointer to device allocation
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnMemAllocDevice_t pfnAllocDevice = [&result] {
+        auto pfnAllocDevice = ze_lib::context->zeDdiTable.load()->Mem.pfnAllocDevice;
+        if( nullptr == pfnAllocDevice ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnAllocDevice;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnAllocDevice( hContext, device_desc, size, alignment, hDevice, pptr );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4526,6 +6148,7 @@ zeMemAllocDevice(
     }
 
     return pfnAllocDevice( hContext, device_desc, size, alignment, hDevice, pptr );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4571,6 +6194,23 @@ zeMemAllocHost(
     void** pptr                                     ///< [out] pointer to host allocation
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnMemAllocHost_t pfnAllocHost = [&result] {
+        auto pfnAllocHost = ze_lib::context->zeDdiTable.load()->Mem.pfnAllocHost;
+        if( nullptr == pfnAllocHost ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnAllocHost;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnAllocHost( hContext, host_desc, size, alignment, pptr );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4584,6 +6224,7 @@ zeMemAllocHost(
     }
 
     return pfnAllocHost( hContext, host_desc, size, alignment, pptr );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4615,6 +6256,23 @@ zeMemFree(
     void* ptr                                       ///< [in][release] pointer to memory to free
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnMemFree_t pfnFree = [&result] {
+        auto pfnFree = ze_lib::context->zeDdiTable.load()->Mem.pfnFree;
+        if( nullptr == pfnFree ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnFree;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnFree( hContext, ptr );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4628,6 +6286,7 @@ zeMemFree(
     }
 
     return pfnFree( hContext, ptr );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4660,6 +6319,23 @@ zeMemGetAllocProperties(
     ze_device_handle_t* phDevice                    ///< [out][optional] device associated with this allocation
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnMemGetAllocProperties_t pfnGetAllocProperties = [&result] {
+        auto pfnGetAllocProperties = ze_lib::context->zeDdiTable.load()->Mem.pfnGetAllocProperties;
+        if( nullptr == pfnGetAllocProperties ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetAllocProperties;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetAllocProperties( hContext, ptr, pMemAllocProperties, phDevice );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4673,6 +6349,7 @@ zeMemGetAllocProperties(
     }
 
     return pfnGetAllocProperties( hContext, ptr, pMemAllocProperties, phDevice );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4699,6 +6376,23 @@ zeMemGetAddressRange(
     size_t* pSize                                   ///< [in,out][optional] size of the allocation
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnMemGetAddressRange_t pfnGetAddressRange = [&result] {
+        auto pfnGetAddressRange = ze_lib::context->zeDdiTable.load()->Mem.pfnGetAddressRange;
+        if( nullptr == pfnGetAddressRange ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetAddressRange;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetAddressRange( hContext, ptr, pBase, pSize );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4712,6 +6406,7 @@ zeMemGetAddressRange(
     }
 
     return pfnGetAddressRange( hContext, ptr, pBase, pSize );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4744,6 +6439,23 @@ zeMemGetIpcHandle(
     ze_ipc_mem_handle_t* pIpcHandle                 ///< [out] Returned IPC memory handle
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnMemGetIpcHandle_t pfnGetIpcHandle = [&result] {
+        auto pfnGetIpcHandle = ze_lib::context->zeDdiTable.load()->Mem.pfnGetIpcHandle;
+        if( nullptr == pfnGetIpcHandle ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetIpcHandle;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetIpcHandle( hContext, ptr, pIpcHandle );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4757,6 +6469,7 @@ zeMemGetIpcHandle(
     }
 
     return pfnGetIpcHandle( hContext, ptr, pIpcHandle );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4787,6 +6500,23 @@ zeMemGetIpcHandleFromFileDescriptorExp(
     ze_ipc_mem_handle_t* pIpcHandle                 ///< [out] Returned IPC memory handle
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnMemGetIpcHandleFromFileDescriptorExp_t pfnGetIpcHandleFromFileDescriptorExp = [&result] {
+        auto pfnGetIpcHandleFromFileDescriptorExp = ze_lib::context->zeDdiTable.load()->MemExp.pfnGetIpcHandleFromFileDescriptorExp;
+        if( nullptr == pfnGetIpcHandleFromFileDescriptorExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetIpcHandleFromFileDescriptorExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetIpcHandleFromFileDescriptorExp( hContext, handle, pIpcHandle );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4800,6 +6530,7 @@ zeMemGetIpcHandleFromFileDescriptorExp(
     }
 
     return pfnGetIpcHandleFromFileDescriptorExp( hContext, handle, pIpcHandle );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4828,6 +6559,23 @@ zeMemGetFileDescriptorFromIpcHandleExp(
     uint64_t* pHandle                               ///< [out] Returned file descriptor
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnMemGetFileDescriptorFromIpcHandleExp_t pfnGetFileDescriptorFromIpcHandleExp = [&result] {
+        auto pfnGetFileDescriptorFromIpcHandleExp = ze_lib::context->zeDdiTable.load()->MemExp.pfnGetFileDescriptorFromIpcHandleExp;
+        if( nullptr == pfnGetFileDescriptorFromIpcHandleExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetFileDescriptorFromIpcHandleExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetFileDescriptorFromIpcHandleExp( hContext, ipcHandle, pHandle );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4841,6 +6589,7 @@ zeMemGetFileDescriptorFromIpcHandleExp(
     }
 
     return pfnGetFileDescriptorFromIpcHandleExp( hContext, ipcHandle, pHandle );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4873,6 +6622,23 @@ zeMemPutIpcHandle(
     ze_ipc_mem_handle_t handle                      ///< [in] IPC memory handle
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnMemPutIpcHandle_t pfnPutIpcHandle = [&result] {
+        auto pfnPutIpcHandle = ze_lib::context->zeDdiTable.load()->Mem.pfnPutIpcHandle;
+        if( nullptr == pfnPutIpcHandle ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnPutIpcHandle;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnPutIpcHandle( hContext, handle );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4886,6 +6652,7 @@ zeMemPutIpcHandle(
     }
 
     return pfnPutIpcHandle( hContext, handle );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4925,6 +6692,23 @@ zeMemOpenIpcHandle(
     void** pptr                                     ///< [out] pointer to device allocation in this process
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnMemOpenIpcHandle_t pfnOpenIpcHandle = [&result] {
+        auto pfnOpenIpcHandle = ze_lib::context->zeDdiTable.load()->Mem.pfnOpenIpcHandle;
+        if( nullptr == pfnOpenIpcHandle ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnOpenIpcHandle;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnOpenIpcHandle( hContext, hDevice, handle, flags, pptr );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4938,6 +6722,7 @@ zeMemOpenIpcHandle(
     }
 
     return pfnOpenIpcHandle( hContext, hDevice, handle, flags, pptr );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4966,6 +6751,23 @@ zeMemCloseIpcHandle(
     const void* ptr                                 ///< [in][release] pointer to device allocation in this process
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnMemCloseIpcHandle_t pfnCloseIpcHandle = [&result] {
+        auto pfnCloseIpcHandle = ze_lib::context->zeDdiTable.load()->Mem.pfnCloseIpcHandle;
+        if( nullptr == pfnCloseIpcHandle ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnCloseIpcHandle;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnCloseIpcHandle( hContext, ptr );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4979,6 +6781,7 @@ zeMemCloseIpcHandle(
     }
 
     return pfnCloseIpcHandle( hContext, ptr );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5027,6 +6830,23 @@ zeMemSetAtomicAccessAttributeExp(
                                                     ///< Must be 0 (default) or a valid combination of ::ze_memory_atomic_attr_exp_flag_t.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnMemSetAtomicAccessAttributeExp_t pfnSetAtomicAccessAttributeExp = [&result] {
+        auto pfnSetAtomicAccessAttributeExp = ze_lib::context->zeDdiTable.load()->MemExp.pfnSetAtomicAccessAttributeExp;
+        if( nullptr == pfnSetAtomicAccessAttributeExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnSetAtomicAccessAttributeExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnSetAtomicAccessAttributeExp( hContext, hDevice, ptr, size, attr );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -5040,6 +6860,7 @@ zeMemSetAtomicAccessAttributeExp(
     }
 
     return pfnSetAtomicAccessAttributeExp( hContext, hDevice, ptr, size, attr );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5072,6 +6893,23 @@ zeMemGetAtomicAccessAttributeExp(
     ze_memory_atomic_attr_exp_flags_t* pAttr        ///< [out] Atomic access attributes for the specified range
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnMemGetAtomicAccessAttributeExp_t pfnGetAtomicAccessAttributeExp = [&result] {
+        auto pfnGetAtomicAccessAttributeExp = ze_lib::context->zeDdiTable.load()->MemExp.pfnGetAtomicAccessAttributeExp;
+        if( nullptr == pfnGetAtomicAccessAttributeExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetAtomicAccessAttributeExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetAtomicAccessAttributeExp( hContext, hDevice, ptr, size, pAttr );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -5085,6 +6923,7 @@ zeMemGetAtomicAccessAttributeExp(
     }
 
     return pfnGetAtomicAccessAttributeExp( hContext, hDevice, ptr, size, pAttr );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5131,6 +6970,23 @@ zeModuleCreate(
     ze_module_build_log_handle_t* phBuildLog        ///< [out][optional] pointer to handle of module's build log.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnModuleCreate_t pfnCreate = [&result] {
+        auto pfnCreate = ze_lib::context->zeDdiTable.load()->Module.pfnCreate;
+        if( nullptr == pfnCreate ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnCreate;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnCreate( hContext, hDevice, desc, phModule, phBuildLog );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -5144,6 +7000,7 @@ zeModuleCreate(
     }
 
     return pfnCreate( hContext, hDevice, desc, phModule, phBuildLog );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5174,6 +7031,23 @@ zeModuleDestroy(
     ze_module_handle_t hModule                      ///< [in][release] handle of the module
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnModuleDestroy_t pfnDestroy = [&result] {
+        auto pfnDestroy = ze_lib::context->zeDdiTable.load()->Module.pfnDestroy;
+        if( nullptr == pfnDestroy ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnDestroy;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnDestroy( hModule );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -5187,6 +7061,7 @@ zeModuleDestroy(
     }
 
     return pfnDestroy( hModule );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5239,6 +7114,23 @@ zeModuleDynamicLink(
     ze_module_build_log_handle_t* phLinkLog         ///< [out][optional] pointer to handle of dynamic link log.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnModuleDynamicLink_t pfnDynamicLink = [&result] {
+        auto pfnDynamicLink = ze_lib::context->zeDdiTable.load()->Module.pfnDynamicLink;
+        if( nullptr == pfnDynamicLink ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnDynamicLink;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnDynamicLink( numModules, phModules, phLinkLog );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -5252,6 +7144,7 @@ zeModuleDynamicLink(
     }
 
     return pfnDynamicLink( numModules, phModules, phLinkLog );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5280,6 +7173,23 @@ zeModuleBuildLogDestroy(
     ze_module_build_log_handle_t hModuleBuildLog    ///< [in][release] handle of the module build log object.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnModuleBuildLogDestroy_t pfnDestroy = [&result] {
+        auto pfnDestroy = ze_lib::context->zeDdiTable.load()->ModuleBuildLog.pfnDestroy;
+        if( nullptr == pfnDestroy ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnDestroy;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnDestroy( hModuleBuildLog );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -5293,6 +7203,7 @@ zeModuleBuildLogDestroy(
     }
 
     return pfnDestroy( hModuleBuildLog );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5321,6 +7232,23 @@ zeModuleBuildLogGetString(
     char* pBuildLog                                 ///< [in,out][optional] pointer to null-terminated string of the log.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnModuleBuildLogGetString_t pfnGetString = [&result] {
+        auto pfnGetString = ze_lib::context->zeDdiTable.load()->ModuleBuildLog.pfnGetString;
+        if( nullptr == pfnGetString ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetString;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetString( hModuleBuildLog, pSize, pBuildLog );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -5334,6 +7262,7 @@ zeModuleBuildLogGetString(
     }
 
     return pfnGetString( hModuleBuildLog, pSize, pBuildLog );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5368,6 +7297,23 @@ zeModuleGetNativeBinary(
     uint8_t* pModuleNativeBinary                    ///< [in,out][optional] byte pointer to native binary
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnModuleGetNativeBinary_t pfnGetNativeBinary = [&result] {
+        auto pfnGetNativeBinary = ze_lib::context->zeDdiTable.load()->Module.pfnGetNativeBinary;
+        if( nullptr == pfnGetNativeBinary ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetNativeBinary;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetNativeBinary( hModule, pSize, pModuleNativeBinary );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -5381,6 +7327,7 @@ zeModuleGetNativeBinary(
     }
 
     return pfnGetNativeBinary( hModule, pSize, pModuleNativeBinary );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5413,6 +7360,23 @@ zeModuleGetGlobalPointer(
     void** pptr                                     ///< [in,out][optional] device visible pointer
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnModuleGetGlobalPointer_t pfnGetGlobalPointer = [&result] {
+        auto pfnGetGlobalPointer = ze_lib::context->zeDdiTable.load()->Module.pfnGetGlobalPointer;
+        if( nullptr == pfnGetGlobalPointer ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetGlobalPointer;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetGlobalPointer( hModule, pGlobalName, pSize, pptr );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -5426,6 +7390,7 @@ zeModuleGetGlobalPointer(
     }
 
     return pfnGetGlobalPointer( hModule, pGlobalName, pSize, pptr );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5458,6 +7423,23 @@ zeModuleGetKernelNames(
                                                     ///< only retrieve that number of names.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnModuleGetKernelNames_t pfnGetKernelNames = [&result] {
+        auto pfnGetKernelNames = ze_lib::context->zeDdiTable.load()->Module.pfnGetKernelNames;
+        if( nullptr == pfnGetKernelNames ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetKernelNames;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetKernelNames( hModule, pCount, pNames );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -5471,6 +7453,7 @@ zeModuleGetKernelNames(
     }
 
     return pfnGetKernelNames( hModule, pCount, pNames );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5496,6 +7479,23 @@ zeModuleGetProperties(
     ze_module_properties_t* pModuleProperties       ///< [in,out] query result for module properties.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnModuleGetProperties_t pfnGetProperties = [&result] {
+        auto pfnGetProperties = ze_lib::context->zeDdiTable.load()->Module.pfnGetProperties;
+        if( nullptr == pfnGetProperties ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetProperties;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetProperties( hModule, pModuleProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -5509,6 +7509,7 @@ zeModuleGetProperties(
     }
 
     return pfnGetProperties( hModule, pModuleProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5543,6 +7544,23 @@ zeKernelCreate(
     ze_kernel_handle_t* phKernel                    ///< [out] handle of the Function object
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnKernelCreate_t pfnCreate = [&result] {
+        auto pfnCreate = ze_lib::context->zeDdiTable.load()->Kernel.pfnCreate;
+        if( nullptr == pfnCreate ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnCreate;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnCreate( hModule, desc, phKernel );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -5556,6 +7574,7 @@ zeKernelCreate(
     }
 
     return pfnCreate( hModule, desc, phKernel );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5584,6 +7603,23 @@ zeKernelDestroy(
     ze_kernel_handle_t hKernel                      ///< [in][release] handle of the kernel object
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnKernelDestroy_t pfnDestroy = [&result] {
+        auto pfnDestroy = ze_lib::context->zeDdiTable.load()->Kernel.pfnDestroy;
+        if( nullptr == pfnDestroy ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnDestroy;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnDestroy( hKernel );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -5597,6 +7633,7 @@ zeKernelDestroy(
     }
 
     return pfnDestroy( hKernel );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5630,6 +7667,23 @@ zeModuleGetFunctionPointer(
     void** pfnFunction                              ///< [out] pointer to function.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnModuleGetFunctionPointer_t pfnGetFunctionPointer = [&result] {
+        auto pfnGetFunctionPointer = ze_lib::context->zeDdiTable.load()->Module.pfnGetFunctionPointer;
+        if( nullptr == pfnGetFunctionPointer ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetFunctionPointer;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetFunctionPointer( hModule, pFunctionName, pfnFunction );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -5643,6 +7697,7 @@ zeModuleGetFunctionPointer(
     }
 
     return pfnGetFunctionPointer( hModule, pFunctionName, pfnFunction );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5672,6 +7727,23 @@ zeKernelSetGroupSize(
     uint32_t groupSizeZ                             ///< [in] group size for Z dimension to use for this kernel
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnKernelSetGroupSize_t pfnSetGroupSize = [&result] {
+        auto pfnSetGroupSize = ze_lib::context->zeDdiTable.load()->Kernel.pfnSetGroupSize;
+        if( nullptr == pfnSetGroupSize ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnSetGroupSize;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnSetGroupSize( hKernel, groupSizeX, groupSizeY, groupSizeZ );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -5685,6 +7757,7 @@ zeKernelSetGroupSize(
     }
 
     return pfnSetGroupSize( hKernel, groupSizeX, groupSizeY, groupSizeZ );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5721,6 +7794,23 @@ zeKernelSuggestGroupSize(
     uint32_t* groupSizeZ                            ///< [out] recommended size of group for Z dimension
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnKernelSuggestGroupSize_t pfnSuggestGroupSize = [&result] {
+        auto pfnSuggestGroupSize = ze_lib::context->zeDdiTable.load()->Kernel.pfnSuggestGroupSize;
+        if( nullptr == pfnSuggestGroupSize ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnSuggestGroupSize;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnSuggestGroupSize( hKernel, globalSizeX, globalSizeY, globalSizeZ, groupSizeX, groupSizeY, groupSizeZ );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -5734,6 +7824,7 @@ zeKernelSuggestGroupSize(
     }
 
     return pfnSuggestGroupSize( hKernel, globalSizeX, globalSizeY, globalSizeZ, groupSizeX, groupSizeY, groupSizeZ );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5759,6 +7850,23 @@ zeKernelSuggestMaxCooperativeGroupCount(
     uint32_t* totalGroupCount                       ///< [out] recommended total group count.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnKernelSuggestMaxCooperativeGroupCount_t pfnSuggestMaxCooperativeGroupCount = [&result] {
+        auto pfnSuggestMaxCooperativeGroupCount = ze_lib::context->zeDdiTable.load()->Kernel.pfnSuggestMaxCooperativeGroupCount;
+        if( nullptr == pfnSuggestMaxCooperativeGroupCount ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnSuggestMaxCooperativeGroupCount;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnSuggestMaxCooperativeGroupCount( hKernel, totalGroupCount );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -5772,6 +7880,7 @@ zeKernelSuggestMaxCooperativeGroupCount(
     }
 
     return pfnSuggestMaxCooperativeGroupCount( hKernel, totalGroupCount );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5803,6 +7912,23 @@ zeKernelSetArgumentValue(
                                                     ///< null then argument value is considered null.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnKernelSetArgumentValue_t pfnSetArgumentValue = [&result] {
+        auto pfnSetArgumentValue = ze_lib::context->zeDdiTable.load()->Kernel.pfnSetArgumentValue;
+        if( nullptr == pfnSetArgumentValue ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnSetArgumentValue;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnSetArgumentValue( hKernel, argIndex, argSize, pArgValue );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -5816,6 +7942,7 @@ zeKernelSetArgumentValue(
     }
 
     return pfnSetArgumentValue( hKernel, argIndex, argSize, pArgValue );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5845,6 +7972,23 @@ zeKernelSetIndirectAccess(
     ze_kernel_indirect_access_flags_t flags         ///< [in] kernel indirect access flags
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnKernelSetIndirectAccess_t pfnSetIndirectAccess = [&result] {
+        auto pfnSetIndirectAccess = ze_lib::context->zeDdiTable.load()->Kernel.pfnSetIndirectAccess;
+        if( nullptr == pfnSetIndirectAccess ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnSetIndirectAccess;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnSetIndirectAccess( hKernel, flags );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -5858,6 +8002,7 @@ zeKernelSetIndirectAccess(
     }
 
     return pfnSetIndirectAccess( hKernel, flags );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5884,6 +8029,23 @@ zeKernelGetIndirectAccess(
     ze_kernel_indirect_access_flags_t* pFlags       ///< [out] query result for kernel indirect access flags.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnKernelGetIndirectAccess_t pfnGetIndirectAccess = [&result] {
+        auto pfnGetIndirectAccess = ze_lib::context->zeDdiTable.load()->Kernel.pfnGetIndirectAccess;
+        if( nullptr == pfnGetIndirectAccess ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetIndirectAccess;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetIndirectAccess( hKernel, pFlags );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -5897,6 +8059,7 @@ zeKernelGetIndirectAccess(
     }
 
     return pfnGetIndirectAccess( hKernel, pFlags );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5932,6 +8095,23 @@ zeKernelGetSourceAttributes(
                                                     ///< pointed-to string will contain a space-separated list of kernel source attributes.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnKernelGetSourceAttributes_t pfnGetSourceAttributes = [&result] {
+        auto pfnGetSourceAttributes = ze_lib::context->zeDdiTable.load()->Kernel.pfnGetSourceAttributes;
+        if( nullptr == pfnGetSourceAttributes ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetSourceAttributes;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetSourceAttributes( hKernel, pSize, pString );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -5945,6 +8125,7 @@ zeKernelGetSourceAttributes(
     }
 
     return pfnGetSourceAttributes( hKernel, pSize, pString );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5975,6 +8156,23 @@ zeKernelSetCacheConfig(
                                                     ///< must be 0 (default configuration) or a valid combination of ::ze_cache_config_flag_t.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnKernelSetCacheConfig_t pfnSetCacheConfig = [&result] {
+        auto pfnSetCacheConfig = ze_lib::context->zeDdiTable.load()->Kernel.pfnSetCacheConfig;
+        if( nullptr == pfnSetCacheConfig ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnSetCacheConfig;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnSetCacheConfig( hKernel, flags );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -5988,6 +8186,7 @@ zeKernelSetCacheConfig(
     }
 
     return pfnSetCacheConfig( hKernel, flags );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6013,6 +8212,23 @@ zeKernelGetProperties(
     ze_kernel_properties_t* pKernelProperties       ///< [in,out] query result for kernel properties.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnKernelGetProperties_t pfnGetProperties = [&result] {
+        auto pfnGetProperties = ze_lib::context->zeDdiTable.load()->Kernel.pfnGetProperties;
+        if( nullptr == pfnGetProperties ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetProperties;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetProperties( hKernel, pKernelProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -6026,6 +8242,7 @@ zeKernelGetProperties(
     }
 
     return pfnGetProperties( hKernel, pKernelProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6056,6 +8273,23 @@ zeKernelGetName(
     char* pName                                     ///< [in,out][optional] char pointer to kernel name.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnKernelGetName_t pfnGetName = [&result] {
+        auto pfnGetName = ze_lib::context->zeDdiTable.load()->Kernel.pfnGetName;
+        if( nullptr == pfnGetName ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetName;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetName( hKernel, pSize, pName );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -6069,6 +8303,7 @@ zeKernelGetName(
     }
 
     return pfnGetName( hKernel, pSize, pName );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6111,6 +8346,23 @@ zeCommandListAppendLaunchKernel(
                                                     ///< on before launching
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandListAppendLaunchKernel_t pfnAppendLaunchKernel = [&result] {
+        auto pfnAppendLaunchKernel = ze_lib::context->zeDdiTable.load()->CommandList.pfnAppendLaunchKernel;
+        if( nullptr == pfnAppendLaunchKernel ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnAppendLaunchKernel;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnAppendLaunchKernel( hCommandList, hKernel, pLaunchFuncArgs, hSignalEvent, numWaitEvents, phWaitEvents );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -6124,6 +8376,7 @@ zeCommandListAppendLaunchKernel(
     }
 
     return pfnAppendLaunchKernel( hCommandList, hKernel, pLaunchFuncArgs, hSignalEvent, numWaitEvents, phWaitEvents );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6170,6 +8423,23 @@ zeCommandListAppendLaunchCooperativeKernel(
                                                     ///< on before launching
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandListAppendLaunchCooperativeKernel_t pfnAppendLaunchCooperativeKernel = [&result] {
+        auto pfnAppendLaunchCooperativeKernel = ze_lib::context->zeDdiTable.load()->CommandList.pfnAppendLaunchCooperativeKernel;
+        if( nullptr == pfnAppendLaunchCooperativeKernel ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnAppendLaunchCooperativeKernel;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnAppendLaunchCooperativeKernel( hCommandList, hKernel, pLaunchFuncArgs, hSignalEvent, numWaitEvents, phWaitEvents );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -6183,6 +8453,7 @@ zeCommandListAppendLaunchCooperativeKernel(
     }
 
     return pfnAppendLaunchCooperativeKernel( hCommandList, hKernel, pLaunchFuncArgs, hSignalEvent, numWaitEvents, phWaitEvents );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6231,6 +8502,23 @@ zeCommandListAppendLaunchKernelIndirect(
                                                     ///< on before launching
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandListAppendLaunchKernelIndirect_t pfnAppendLaunchKernelIndirect = [&result] {
+        auto pfnAppendLaunchKernelIndirect = ze_lib::context->zeDdiTable.load()->CommandList.pfnAppendLaunchKernelIndirect;
+        if( nullptr == pfnAppendLaunchKernelIndirect ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnAppendLaunchKernelIndirect;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnAppendLaunchKernelIndirect( hCommandList, hKernel, pLaunchArgumentsBuffer, hSignalEvent, numWaitEvents, phWaitEvents );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -6244,6 +8532,7 @@ zeCommandListAppendLaunchKernelIndirect(
     }
 
     return pfnAppendLaunchKernelIndirect( hCommandList, hKernel, pLaunchArgumentsBuffer, hSignalEvent, numWaitEvents, phWaitEvents );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6299,6 +8588,23 @@ zeCommandListAppendLaunchMultipleKernelsIndirect(
                                                     ///< on before launching
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandListAppendLaunchMultipleKernelsIndirect_t pfnAppendLaunchMultipleKernelsIndirect = [&result] {
+        auto pfnAppendLaunchMultipleKernelsIndirect = ze_lib::context->zeDdiTable.load()->CommandList.pfnAppendLaunchMultipleKernelsIndirect;
+        if( nullptr == pfnAppendLaunchMultipleKernelsIndirect ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnAppendLaunchMultipleKernelsIndirect;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnAppendLaunchMultipleKernelsIndirect( hCommandList, numKernels, phKernels, pCountBuffer, pLaunchArgumentsBuffer, hSignalEvent, numWaitEvents, phWaitEvents );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -6312,6 +8618,7 @@ zeCommandListAppendLaunchMultipleKernelsIndirect(
     }
 
     return pfnAppendLaunchMultipleKernelsIndirect( hCommandList, numKernels, phKernels, pCountBuffer, pLaunchArgumentsBuffer, hSignalEvent, numWaitEvents, phWaitEvents );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6344,6 +8651,23 @@ zeContextMakeMemoryResident(
     size_t size                                     ///< [in] size in bytes to make resident
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnContextMakeMemoryResident_t pfnMakeMemoryResident = [&result] {
+        auto pfnMakeMemoryResident = ze_lib::context->zeDdiTable.load()->Context.pfnMakeMemoryResident;
+        if( nullptr == pfnMakeMemoryResident ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnMakeMemoryResident;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnMakeMemoryResident( hContext, hDevice, ptr, size );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -6357,6 +8681,7 @@ zeContextMakeMemoryResident(
     }
 
     return pfnMakeMemoryResident( hContext, hDevice, ptr, size );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6389,6 +8714,23 @@ zeContextEvictMemory(
     size_t size                                     ///< [in] size in bytes to evict
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnContextEvictMemory_t pfnEvictMemory = [&result] {
+        auto pfnEvictMemory = ze_lib::context->zeDdiTable.load()->Context.pfnEvictMemory;
+        if( nullptr == pfnEvictMemory ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnEvictMemory;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnEvictMemory( hContext, hDevice, ptr, size );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -6402,6 +8744,7 @@ zeContextEvictMemory(
     }
 
     return pfnEvictMemory( hContext, hDevice, ptr, size );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6430,6 +8773,23 @@ zeContextMakeImageResident(
     ze_image_handle_t hImage                        ///< [in] handle of image to make resident
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnContextMakeImageResident_t pfnMakeImageResident = [&result] {
+        auto pfnMakeImageResident = ze_lib::context->zeDdiTable.load()->Context.pfnMakeImageResident;
+        if( nullptr == pfnMakeImageResident ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnMakeImageResident;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnMakeImageResident( hContext, hDevice, hImage );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -6443,6 +8803,7 @@ zeContextMakeImageResident(
     }
 
     return pfnMakeImageResident( hContext, hDevice, hImage );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6473,6 +8834,23 @@ zeContextEvictImage(
     ze_image_handle_t hImage                        ///< [in] handle of image to make evict
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnContextEvictImage_t pfnEvictImage = [&result] {
+        auto pfnEvictImage = ze_lib::context->zeDdiTable.load()->Context.pfnEvictImage;
+        if( nullptr == pfnEvictImage ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnEvictImage;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnEvictImage( hContext, hDevice, hImage );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -6486,6 +8864,7 @@ zeContextEvictImage(
     }
 
     return pfnEvictImage( hContext, hDevice, hImage );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6520,6 +8899,23 @@ zeSamplerCreate(
     ze_sampler_handle_t* phSampler                  ///< [out] handle of the sampler
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnSamplerCreate_t pfnCreate = [&result] {
+        auto pfnCreate = ze_lib::context->zeDdiTable.load()->Sampler.pfnCreate;
+        if( nullptr == pfnCreate ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnCreate;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnCreate( hContext, hDevice, desc, phSampler );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -6533,6 +8929,7 @@ zeSamplerCreate(
     }
 
     return pfnCreate( hContext, hDevice, desc, phSampler );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6561,6 +8958,23 @@ zeSamplerDestroy(
     ze_sampler_handle_t hSampler                    ///< [in][release] handle of the sampler
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnSamplerDestroy_t pfnDestroy = [&result] {
+        auto pfnDestroy = ze_lib::context->zeDdiTable.load()->Sampler.pfnDestroy;
+        if( nullptr == pfnDestroy ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnDestroy;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnDestroy( hSampler );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -6574,6 +8988,7 @@ zeSamplerDestroy(
     }
 
     return pfnDestroy( hSampler );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6613,6 +9028,23 @@ zeVirtualMemReserve(
     void** pptr                                     ///< [out] pointer to virtual reservation.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnVirtualMemReserve_t pfnReserve = [&result] {
+        auto pfnReserve = ze_lib::context->zeDdiTable.load()->VirtualMem.pfnReserve;
+        if( nullptr == pfnReserve ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnReserve;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnReserve( hContext, pStart, size, pptr );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -6626,6 +9058,7 @@ zeVirtualMemReserve(
     }
 
     return pfnReserve( hContext, pStart, size, pptr );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6658,6 +9091,23 @@ zeVirtualMemFree(
     size_t size                                     ///< [in] size in bytes to free; must be page aligned.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnVirtualMemFree_t pfnFree = [&result] {
+        auto pfnFree = ze_lib::context->zeDdiTable.load()->VirtualMem.pfnFree;
+        if( nullptr == pfnFree ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnFree;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnFree( hContext, ptr, size );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -6671,6 +9121,7 @@ zeVirtualMemFree(
     }
 
     return pfnFree( hContext, ptr, size );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6703,6 +9154,23 @@ zeVirtualMemQueryPageSize(
                                                     ///< alignments.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnVirtualMemQueryPageSize_t pfnQueryPageSize = [&result] {
+        auto pfnQueryPageSize = ze_lib::context->zeDdiTable.load()->VirtualMem.pfnQueryPageSize;
+        if( nullptr == pfnQueryPageSize ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnQueryPageSize;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnQueryPageSize( hContext, hDevice, size, pagesize );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -6716,6 +9184,7 @@ zeVirtualMemQueryPageSize(
     }
 
     return pfnQueryPageSize( hContext, hDevice, size, pagesize );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6756,6 +9225,23 @@ zePhysicalMemCreate(
     ze_physical_mem_handle_t* phPhysicalMemory      ///< [out] pointer to handle of physical memory object created
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnPhysicalMemCreate_t pfnCreate = [&result] {
+        auto pfnCreate = ze_lib::context->zeDdiTable.load()->PhysicalMem.pfnCreate;
+        if( nullptr == pfnCreate ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnCreate;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnCreate( hContext, hDevice, desc, phPhysicalMemory );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -6769,6 +9255,7 @@ zePhysicalMemCreate(
     }
 
     return pfnCreate( hContext, hDevice, desc, phPhysicalMemory );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6797,6 +9284,23 @@ zePhysicalMemDestroy(
     ze_physical_mem_handle_t hPhysicalMemory        ///< [in][release] handle of physical memory object to destroy
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnPhysicalMemDestroy_t pfnDestroy = [&result] {
+        auto pfnDestroy = ze_lib::context->zeDdiTable.load()->PhysicalMem.pfnDestroy;
+        if( nullptr == pfnDestroy ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnDestroy;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnDestroy( hContext, hPhysicalMemory );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -6810,6 +9314,7 @@ zePhysicalMemDestroy(
     }
 
     return pfnDestroy( hContext, hPhysicalMemory );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6857,6 +9362,23 @@ zeVirtualMemMap(
                                                     ///< range.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnVirtualMemMap_t pfnMap = [&result] {
+        auto pfnMap = ze_lib::context->zeDdiTable.load()->VirtualMem.pfnMap;
+        if( nullptr == pfnMap ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnMap;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnMap( hContext, ptr, size, hPhysicalMemory, offset, access );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -6870,6 +9392,7 @@ zeVirtualMemMap(
     }
 
     return pfnMap( hContext, ptr, size, hPhysicalMemory, offset, access );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6904,6 +9427,23 @@ zeVirtualMemUnmap(
     size_t size                                     ///< [in] size in bytes to unmap; must be page aligned.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnVirtualMemUnmap_t pfnUnmap = [&result] {
+        auto pfnUnmap = ze_lib::context->zeDdiTable.load()->VirtualMem.pfnUnmap;
+        if( nullptr == pfnUnmap ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnUnmap;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnUnmap( hContext, ptr, size );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -6917,6 +9457,7 @@ zeVirtualMemUnmap(
     }
 
     return pfnUnmap( hContext, ptr, size );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6953,6 +9494,23 @@ zeVirtualMemSetAccessAttribute(
                                                     ///< range.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnVirtualMemSetAccessAttribute_t pfnSetAccessAttribute = [&result] {
+        auto pfnSetAccessAttribute = ze_lib::context->zeDdiTable.load()->VirtualMem.pfnSetAccessAttribute;
+        if( nullptr == pfnSetAccessAttribute ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnSetAccessAttribute;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnSetAccessAttribute( hContext, ptr, size, access );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -6966,6 +9524,7 @@ zeVirtualMemSetAccessAttribute(
     }
 
     return pfnSetAccessAttribute( hContext, ptr, size, access );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7005,6 +9564,23 @@ zeVirtualMemGetAccessAttribute(
                                                     ///< that shares same access attribute.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnVirtualMemGetAccessAttribute_t pfnGetAccessAttribute = [&result] {
+        auto pfnGetAccessAttribute = ze_lib::context->zeDdiTable.load()->VirtualMem.pfnGetAccessAttribute;
+        if( nullptr == pfnGetAccessAttribute ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetAccessAttribute;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetAccessAttribute( hContext, ptr, size, access, outSize );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -7018,6 +9594,7 @@ zeVirtualMemGetAccessAttribute(
     }
 
     return pfnGetAccessAttribute( hContext, ptr, size, access, outSize );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7046,6 +9623,23 @@ zeKernelSetGlobalOffsetExp(
     uint32_t offsetZ                                ///< [in] global offset for Z dimension to use for this kernel
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnKernelSetGlobalOffsetExp_t pfnSetGlobalOffsetExp = [&result] {
+        auto pfnSetGlobalOffsetExp = ze_lib::context->zeDdiTable.load()->KernelExp.pfnSetGlobalOffsetExp;
+        if( nullptr == pfnSetGlobalOffsetExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnSetGlobalOffsetExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnSetGlobalOffsetExp( hKernel, offsetX, offsetY, offsetZ );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -7059,6 +9653,7 @@ zeKernelSetGlobalOffsetExp(
     }
 
     return pfnSetGlobalOffsetExp( hKernel, offsetX, offsetY, offsetZ );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7089,6 +9684,23 @@ zeKernelGetBinaryExp(
     uint8_t* pKernelBinary                          ///< [in,out] pointer to storage area for GEN ISA binary function.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnKernelGetBinaryExp_t pfnGetBinaryExp = [&result] {
+        auto pfnGetBinaryExp = ze_lib::context->zeDdiTable.load()->KernelExp.pfnGetBinaryExp;
+        if( nullptr == pfnGetBinaryExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetBinaryExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetBinaryExp( hKernel, pSize, pKernelBinary );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -7102,6 +9714,7 @@ zeKernelGetBinaryExp(
     }
 
     return pfnGetBinaryExp( hKernel, pSize, pKernelBinary );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7133,6 +9746,23 @@ zeDeviceImportExternalSemaphoreExt(
     ze_external_semaphore_ext_handle_t* phSemaphore ///< [out] The handle of the external semaphore imported.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnDeviceImportExternalSemaphoreExt_t pfnImportExternalSemaphoreExt = [&result] {
+        auto pfnImportExternalSemaphoreExt = ze_lib::context->zeDdiTable.load()->Device.pfnImportExternalSemaphoreExt;
+        if( nullptr == pfnImportExternalSemaphoreExt ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnImportExternalSemaphoreExt;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnImportExternalSemaphoreExt( hDevice, desc, phSemaphore );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -7146,6 +9776,7 @@ zeDeviceImportExternalSemaphoreExt(
     }
 
     return pfnImportExternalSemaphoreExt( hDevice, desc, phSemaphore );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7172,6 +9803,23 @@ zeDeviceReleaseExternalSemaphoreExt(
     ze_external_semaphore_ext_handle_t hSemaphore   ///< [in] The handle of the external semaphore.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnDeviceReleaseExternalSemaphoreExt_t pfnReleaseExternalSemaphoreExt = [&result] {
+        auto pfnReleaseExternalSemaphoreExt = ze_lib::context->zeDdiTable.load()->Device.pfnReleaseExternalSemaphoreExt;
+        if( nullptr == pfnReleaseExternalSemaphoreExt ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnReleaseExternalSemaphoreExt;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnReleaseExternalSemaphoreExt( hSemaphore );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -7185,6 +9833,7 @@ zeDeviceReleaseExternalSemaphoreExt(
     }
 
     return pfnReleaseExternalSemaphoreExt( hSemaphore );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7229,6 +9878,23 @@ zeCommandListAppendSignalExternalSemaphoreExt(
                                                     ///< on before launching
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandListAppendSignalExternalSemaphoreExt_t pfnAppendSignalExternalSemaphoreExt = [&result] {
+        auto pfnAppendSignalExternalSemaphoreExt = ze_lib::context->zeDdiTable.load()->CommandList.pfnAppendSignalExternalSemaphoreExt;
+        if( nullptr == pfnAppendSignalExternalSemaphoreExt ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnAppendSignalExternalSemaphoreExt;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnAppendSignalExternalSemaphoreExt( hCommandList, numSemaphores, phSemaphores, signalParams, hSignalEvent, numWaitEvents, phWaitEvents );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -7242,6 +9908,7 @@ zeCommandListAppendSignalExternalSemaphoreExt(
     }
 
     return pfnAppendSignalExternalSemaphoreExt( hCommandList, numSemaphores, phSemaphores, signalParams, hSignalEvent, numWaitEvents, phWaitEvents );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7286,6 +9953,23 @@ zeCommandListAppendWaitExternalSemaphoreExt(
                                                     ///< on before launching
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandListAppendWaitExternalSemaphoreExt_t pfnAppendWaitExternalSemaphoreExt = [&result] {
+        auto pfnAppendWaitExternalSemaphoreExt = ze_lib::context->zeDdiTable.load()->CommandList.pfnAppendWaitExternalSemaphoreExt;
+        if( nullptr == pfnAppendWaitExternalSemaphoreExt ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnAppendWaitExternalSemaphoreExt;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnAppendWaitExternalSemaphoreExt( hCommandList, numSemaphores, phSemaphores, waitParams, hSignalEvent, numWaitEvents, phWaitEvents );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -7299,6 +9983,7 @@ zeCommandListAppendWaitExternalSemaphoreExt(
     }
 
     return pfnAppendWaitExternalSemaphoreExt( hCommandList, numSemaphores, phSemaphores, waitParams, hSignalEvent, numWaitEvents, phWaitEvents );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7330,6 +10015,23 @@ zeDeviceReserveCacheExt(
                                                     ///< shall remove prior reservation
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnDeviceReserveCacheExt_t pfnReserveCacheExt = [&result] {
+        auto pfnReserveCacheExt = ze_lib::context->zeDdiTable.load()->Device.pfnReserveCacheExt;
+        if( nullptr == pfnReserveCacheExt ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnReserveCacheExt;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnReserveCacheExt( hDevice, cacheLevel, cacheReservationSize );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -7343,6 +10045,7 @@ zeDeviceReserveCacheExt(
     }
 
     return pfnReserveCacheExt( hDevice, cacheLevel, cacheReservationSize );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7372,6 +10075,23 @@ zeDeviceSetCacheAdviceExt(
     ze_cache_ext_region_t cacheRegion               ///< [in] reservation region
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnDeviceSetCacheAdviceExt_t pfnSetCacheAdviceExt = [&result] {
+        auto pfnSetCacheAdviceExt = ze_lib::context->zeDdiTable.load()->Device.pfnSetCacheAdviceExt;
+        if( nullptr == pfnSetCacheAdviceExt ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnSetCacheAdviceExt;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnSetCacheAdviceExt( hDevice, ptr, regionSize, cacheRegion );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -7385,6 +10105,7 @@ zeDeviceSetCacheAdviceExt(
     }
 
     return pfnSetCacheAdviceExt( hDevice, ptr, regionSize, cacheRegion );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7431,6 +10152,23 @@ zeEventQueryTimestampsExp(
                                                     ///< shall only retrieve that number of timestamps.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnEventQueryTimestampsExp_t pfnQueryTimestampsExp = [&result] {
+        auto pfnQueryTimestampsExp = ze_lib::context->zeDdiTable.load()->EventExp.pfnQueryTimestampsExp;
+        if( nullptr == pfnQueryTimestampsExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnQueryTimestampsExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnQueryTimestampsExp( hEvent, hDevice, pCount, pTimestamps );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -7444,6 +10182,7 @@ zeEventQueryTimestampsExp(
     }
 
     return pfnQueryTimestampsExp( hEvent, hDevice, pCount, pTimestamps );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7475,6 +10214,23 @@ zeImageGetMemoryPropertiesExp(
     ze_image_memory_properties_exp_t* pMemoryProperties ///< [in,out] query result for image memory properties.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnImageGetMemoryPropertiesExp_t pfnGetMemoryPropertiesExp = [&result] {
+        auto pfnGetMemoryPropertiesExp = ze_lib::context->zeDdiTable.load()->ImageExp.pfnGetMemoryPropertiesExp;
+        if( nullptr == pfnGetMemoryPropertiesExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetMemoryPropertiesExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetMemoryPropertiesExp( hImage, pMemoryProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -7488,6 +10244,7 @@ zeImageGetMemoryPropertiesExp(
     }
 
     return pfnGetMemoryPropertiesExp( hImage, pMemoryProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7536,6 +10293,23 @@ zeImageViewCreateExt(
     ze_image_handle_t* phImageView                  ///< [out] pointer to handle of image object created for view
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnImageViewCreateExt_t pfnViewCreateExt = [&result] {
+        auto pfnViewCreateExt = ze_lib::context->zeDdiTable.load()->Image.pfnViewCreateExt;
+        if( nullptr == pfnViewCreateExt ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnViewCreateExt;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnViewCreateExt( hContext, hDevice, desc, hImage, phImageView );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -7549,6 +10323,7 @@ zeImageViewCreateExt(
     }
 
     return pfnViewCreateExt( hContext, hDevice, desc, hImage, phImageView );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7600,6 +10375,23 @@ zeImageViewCreateExp(
     ze_image_handle_t* phImageView                  ///< [out] pointer to handle of image object created for view
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnImageViewCreateExp_t pfnViewCreateExp = [&result] {
+        auto pfnViewCreateExp = ze_lib::context->zeDdiTable.load()->ImageExp.pfnViewCreateExp;
+        if( nullptr == pfnViewCreateExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnViewCreateExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnViewCreateExp( hContext, hDevice, desc, hImage, phImageView );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -7613,6 +10405,7 @@ zeImageViewCreateExp(
     }
 
     return pfnViewCreateExp( hContext, hDevice, desc, hImage, phImageView );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7647,6 +10440,23 @@ zeKernelSchedulingHintExp(
     ze_scheduling_hint_exp_desc_t* pHint            ///< [in] pointer to kernel scheduling hint descriptor
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnKernelSchedulingHintExp_t pfnSchedulingHintExp = [&result] {
+        auto pfnSchedulingHintExp = ze_lib::context->zeDdiTable.load()->KernelExp.pfnSchedulingHintExp;
+        if( nullptr == pfnSchedulingHintExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnSchedulingHintExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnSchedulingHintExp( hKernel, pHint );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -7660,6 +10470,7 @@ zeKernelSchedulingHintExp(
     }
 
     return pfnSchedulingHintExp( hKernel, pHint );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7689,6 +10500,23 @@ zeDevicePciGetPropertiesExt(
     ze_pci_ext_properties_t* pPciProperties         ///< [in,out] returns the PCI properties of the device.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnDevicePciGetPropertiesExt_t pfnPciGetPropertiesExt = [&result] {
+        auto pfnPciGetPropertiesExt = ze_lib::context->zeDdiTable.load()->Device.pfnPciGetPropertiesExt;
+        if( nullptr == pfnPciGetPropertiesExt ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnPciGetPropertiesExt;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnPciGetPropertiesExt( hDevice, pPciProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -7702,6 +10530,7 @@ zeDevicePciGetPropertiesExt(
     }
 
     return pfnPciGetPropertiesExt( hDevice, pPciProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7768,6 +10597,23 @@ zeCommandListAppendImageCopyToMemoryExt(
                                                     ///< on before launching
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandListAppendImageCopyToMemoryExt_t pfnAppendImageCopyToMemoryExt = [&result] {
+        auto pfnAppendImageCopyToMemoryExt = ze_lib::context->zeDdiTable.load()->CommandList.pfnAppendImageCopyToMemoryExt;
+        if( nullptr == pfnAppendImageCopyToMemoryExt ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnAppendImageCopyToMemoryExt;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnAppendImageCopyToMemoryExt( hCommandList, dstptr, hSrcImage, pSrcRegion, destRowPitch, destSlicePitch, hSignalEvent, numWaitEvents, phWaitEvents );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -7781,6 +10627,7 @@ zeCommandListAppendImageCopyToMemoryExt(
     }
 
     return pfnAppendImageCopyToMemoryExt( hCommandList, dstptr, hSrcImage, pSrcRegion, destRowPitch, destSlicePitch, hSignalEvent, numWaitEvents, phWaitEvents );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7847,6 +10694,23 @@ zeCommandListAppendImageCopyFromMemoryExt(
                                                     ///< on before launching
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandListAppendImageCopyFromMemoryExt_t pfnAppendImageCopyFromMemoryExt = [&result] {
+        auto pfnAppendImageCopyFromMemoryExt = ze_lib::context->zeDdiTable.load()->CommandList.pfnAppendImageCopyFromMemoryExt;
+        if( nullptr == pfnAppendImageCopyFromMemoryExt ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnAppendImageCopyFromMemoryExt;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnAppendImageCopyFromMemoryExt( hCommandList, hDstImage, srcptr, pDstRegion, srcRowPitch, srcSlicePitch, hSignalEvent, numWaitEvents, phWaitEvents );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -7860,6 +10724,7 @@ zeCommandListAppendImageCopyFromMemoryExt(
     }
 
     return pfnAppendImageCopyFromMemoryExt( hCommandList, hDstImage, srcptr, pDstRegion, srcRowPitch, srcSlicePitch, hSignalEvent, numWaitEvents, phWaitEvents );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7886,6 +10751,23 @@ zeImageGetAllocPropertiesExt(
     ze_image_allocation_ext_properties_t* pImageAllocProperties ///< [in,out] query result for image allocation properties
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnImageGetAllocPropertiesExt_t pfnGetAllocPropertiesExt = [&result] {
+        auto pfnGetAllocPropertiesExt = ze_lib::context->zeDdiTable.load()->Image.pfnGetAllocPropertiesExt;
+        if( nullptr == pfnGetAllocPropertiesExt ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetAllocPropertiesExt;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetAllocPropertiesExt( hContext, hImage, pImageAllocProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -7899,6 +10781,7 @@ zeImageGetAllocPropertiesExt(
     }
 
     return pfnGetAllocPropertiesExt( hContext, hImage, pImageAllocProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7934,6 +10817,23 @@ zeModuleInspectLinkageExt(
                                                     ///< contain separate lists of imports, un-resolvable imports, and exports.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnModuleInspectLinkageExt_t pfnInspectLinkageExt = [&result] {
+        auto pfnInspectLinkageExt = ze_lib::context->zeDdiTable.load()->Module.pfnInspectLinkageExt;
+        if( nullptr == pfnInspectLinkageExt ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnInspectLinkageExt;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnInspectLinkageExt( pInspectDesc, numModules, phModules, phLog );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -7947,6 +10847,7 @@ zeModuleInspectLinkageExt(
     }
 
     return pfnInspectLinkageExt( pInspectDesc, numModules, phModules, phLog );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7979,6 +10880,23 @@ zeMemFreeExt(
     void* ptr                                       ///< [in][release] pointer to memory to free
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnMemFreeExt_t pfnFreeExt = [&result] {
+        auto pfnFreeExt = ze_lib::context->zeDdiTable.load()->Mem.pfnFreeExt;
+        if( nullptr == pfnFreeExt ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnFreeExt;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnFreeExt( hContext, pMemFreeDesc, ptr );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -7992,6 +10910,7 @@ zeMemFreeExt(
     }
 
     return pfnFreeExt( hContext, pMemFreeDesc, ptr );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8027,6 +10946,23 @@ zeFabricVertexGetExp(
                                                     ///< driver shall only retrieve that number of fabric vertices.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnFabricVertexGetExp_t pfnGetExp = [&result] {
+        auto pfnGetExp = ze_lib::context->zeDdiTable.load()->FabricVertexExp.pfnGetExp;
+        if( nullptr == pfnGetExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetExp( hDriver, pCount, phVertices );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -8040,6 +10976,7 @@ zeFabricVertexGetExp(
     }
 
     return pfnGetExp( hDriver, pCount, phVertices );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8077,6 +11014,23 @@ zeFabricVertexGetSubVerticesExp(
                                                     ///< driver shall only retrieve that number of sub-vertices.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnFabricVertexGetSubVerticesExp_t pfnGetSubVerticesExp = [&result] {
+        auto pfnGetSubVerticesExp = ze_lib::context->zeDdiTable.load()->FabricVertexExp.pfnGetSubVerticesExp;
+        if( nullptr == pfnGetSubVerticesExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetSubVerticesExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetSubVerticesExp( hVertex, pCount, phSubvertices );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -8090,6 +11044,7 @@ zeFabricVertexGetSubVerticesExp(
     }
 
     return pfnGetSubVerticesExp( hVertex, pCount, phSubvertices );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8115,6 +11070,23 @@ zeFabricVertexGetPropertiesExp(
     ze_fabric_vertex_exp_properties_t* pVertexProperties///< [in,out] query result for fabric vertex properties
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnFabricVertexGetPropertiesExp_t pfnGetPropertiesExp = [&result] {
+        auto pfnGetPropertiesExp = ze_lib::context->zeDdiTable.load()->FabricVertexExp.pfnGetPropertiesExp;
+        if( nullptr == pfnGetPropertiesExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetPropertiesExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetPropertiesExp( hVertex, pVertexProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -8128,6 +11100,7 @@ zeFabricVertexGetPropertiesExp(
     }
 
     return pfnGetPropertiesExp( hVertex, pVertexProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8157,6 +11130,23 @@ zeFabricVertexGetDeviceExp(
     ze_device_handle_t* phDevice                    ///< [out] device handle corresponding to fabric vertex
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnFabricVertexGetDeviceExp_t pfnGetDeviceExp = [&result] {
+        auto pfnGetDeviceExp = ze_lib::context->zeDdiTable.load()->FabricVertexExp.pfnGetDeviceExp;
+        if( nullptr == pfnGetDeviceExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetDeviceExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetDeviceExp( hVertex, phDevice );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -8170,6 +11160,7 @@ zeFabricVertexGetDeviceExp(
     }
 
     return pfnGetDeviceExp( hVertex, phDevice );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8197,6 +11188,23 @@ zeDeviceGetFabricVertexExp(
     ze_fabric_vertex_handle_t* phVertex             ///< [out] fabric vertex handle corresponding to device
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnDeviceGetFabricVertexExp_t pfnGetFabricVertexExp = [&result] {
+        auto pfnGetFabricVertexExp = ze_lib::context->zeDdiTable.load()->DeviceExp.pfnGetFabricVertexExp;
+        if( nullptr == pfnGetFabricVertexExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetFabricVertexExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetFabricVertexExp( hDevice, phVertex );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -8210,6 +11218,7 @@ zeDeviceGetFabricVertexExp(
     }
 
     return pfnGetFabricVertexExp( hDevice, phVertex );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8247,6 +11256,23 @@ zeFabricEdgeGetExp(
                                                     ///< driver shall only retrieve that number of fabric edges.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnFabricEdgeGetExp_t pfnGetExp = [&result] {
+        auto pfnGetExp = ze_lib::context->zeDdiTable.load()->FabricEdgeExp.pfnGetExp;
+        if( nullptr == pfnGetExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetExp( hVertexA, hVertexB, pCount, phEdges );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -8260,6 +11286,7 @@ zeFabricEdgeGetExp(
     }
 
     return pfnGetExp( hVertexA, hVertexB, pCount, phEdges );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8289,6 +11316,23 @@ zeFabricEdgeGetVerticesExp(
     ze_fabric_vertex_handle_t* phVertexB            ///< [out] fabric vertex connected to other end of the given fabric edge.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnFabricEdgeGetVerticesExp_t pfnGetVerticesExp = [&result] {
+        auto pfnGetVerticesExp = ze_lib::context->zeDdiTable.load()->FabricEdgeExp.pfnGetVerticesExp;
+        if( nullptr == pfnGetVerticesExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetVerticesExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetVerticesExp( hEdge, phVertexA, phVertexB );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -8302,6 +11346,7 @@ zeFabricEdgeGetVerticesExp(
     }
 
     return pfnGetVerticesExp( hEdge, phVertexA, phVertexB );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8327,6 +11372,23 @@ zeFabricEdgeGetPropertiesExp(
     ze_fabric_edge_exp_properties_t* pEdgeProperties///< [in,out] query result for fabric edge properties
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnFabricEdgeGetPropertiesExp_t pfnGetPropertiesExp = [&result] {
+        auto pfnGetPropertiesExp = ze_lib::context->zeDdiTable.load()->FabricEdgeExp.pfnGetPropertiesExp;
+        if( nullptr == pfnGetPropertiesExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetPropertiesExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetPropertiesExp( hEdge, pEdgeProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -8340,6 +11402,7 @@ zeFabricEdgeGetPropertiesExp(
     }
 
     return pfnGetPropertiesExp( hEdge, pEdgeProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8399,6 +11462,23 @@ zeEventQueryKernelTimestampsExt(
                                                     ///< available, the driver may only update the valid elements.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnEventQueryKernelTimestampsExt_t pfnQueryKernelTimestampsExt = [&result] {
+        auto pfnQueryKernelTimestampsExt = ze_lib::context->zeDdiTable.load()->Event.pfnQueryKernelTimestampsExt;
+        if( nullptr == pfnQueryKernelTimestampsExt ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnQueryKernelTimestampsExt;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnQueryKernelTimestampsExt( hEvent, hDevice, pCount, pResults );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -8412,6 +11492,7 @@ zeEventQueryKernelTimestampsExt(
     }
 
     return pfnQueryKernelTimestampsExt( hEvent, hDevice, pCount, pResults );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8443,6 +11524,23 @@ zeRTASBuilderCreateExp(
     ze_rtas_builder_exp_handle_t* phBuilder         ///< [out] handle of builder object
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnRTASBuilderCreateExp_t pfnCreateExp = [&result] {
+        auto pfnCreateExp = ze_lib::context->zeDdiTable.load()->RTASBuilderExp.pfnCreateExp;
+        if( nullptr == pfnCreateExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnCreateExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnCreateExp( hDriver, pDescriptor, phBuilder );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -8456,6 +11554,7 @@ zeRTASBuilderCreateExp(
     }
 
     return pfnCreateExp( hDriver, pDescriptor, phBuilder );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8487,6 +11586,23 @@ zeRTASBuilderGetBuildPropertiesExp(
     ze_rtas_builder_exp_properties_t* pProperties   ///< [in,out] query result for builder properties
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnRTASBuilderGetBuildPropertiesExp_t pfnGetBuildPropertiesExp = [&result] {
+        auto pfnGetBuildPropertiesExp = ze_lib::context->zeDdiTable.load()->RTASBuilderExp.pfnGetBuildPropertiesExp;
+        if( nullptr == pfnGetBuildPropertiesExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetBuildPropertiesExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetBuildPropertiesExp( hBuilder, pBuildOpDescriptor, pProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -8500,6 +11616,7 @@ zeRTASBuilderGetBuildPropertiesExp(
     }
 
     return pfnGetBuildPropertiesExp( hBuilder, pBuildOpDescriptor, pProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8531,6 +11648,23 @@ zeDriverRTASFormatCompatibilityCheckExp(
     ze_rtas_format_exp_t rtasFormatB                ///< [in] operand B
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnDriverRTASFormatCompatibilityCheckExp_t pfnRTASFormatCompatibilityCheckExp = [&result] {
+        auto pfnRTASFormatCompatibilityCheckExp = ze_lib::context->zeDdiTable.load()->DriverExp.pfnRTASFormatCompatibilityCheckExp;
+        if( nullptr == pfnRTASFormatCompatibilityCheckExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnRTASFormatCompatibilityCheckExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnRTASFormatCompatibilityCheckExp( hDriver, rtasFormatA, rtasFormatB );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -8544,6 +11678,7 @@ zeDriverRTASFormatCompatibilityCheckExp(
     }
 
     return pfnRTASFormatCompatibilityCheckExp( hDriver, rtasFormatA, rtasFormatB );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8635,6 +11770,23 @@ zeRTASBuilderBuildExp(
                                                     ///< bytes
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnRTASBuilderBuildExp_t pfnBuildExp = [&result] {
+        auto pfnBuildExp = ze_lib::context->zeDdiTable.load()->RTASBuilderExp.pfnBuildExp;
+        if( nullptr == pfnBuildExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnBuildExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnBuildExp( hBuilder, pBuildOpDescriptor, pScratchBuffer, scratchBufferSizeBytes, pRtasBuffer, rtasBufferSizeBytes, hParallelOperation, pBuildUserPtr, pBounds, pRtasBufferSizeBytes );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -8648,6 +11800,7 @@ zeRTASBuilderBuildExp(
     }
 
     return pfnBuildExp( hBuilder, pBuildOpDescriptor, pScratchBuffer, scratchBufferSizeBytes, pRtasBuffer, rtasBufferSizeBytes, hParallelOperation, pBuildUserPtr, pBounds, pRtasBufferSizeBytes );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8674,6 +11827,23 @@ zeRTASBuilderDestroyExp(
     ze_rtas_builder_exp_handle_t hBuilder           ///< [in][release] handle of builder object to destroy
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnRTASBuilderDestroyExp_t pfnDestroyExp = [&result] {
+        auto pfnDestroyExp = ze_lib::context->zeDdiTable.load()->RTASBuilderExp.pfnDestroyExp;
+        if( nullptr == pfnDestroyExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnDestroyExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnDestroyExp( hBuilder );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -8687,6 +11857,7 @@ zeRTASBuilderDestroyExp(
     }
 
     return pfnDestroyExp( hBuilder );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8715,6 +11886,23 @@ zeRTASParallelOperationCreateExp(
     ze_rtas_parallel_operation_exp_handle_t* phParallelOperation///< [out] handle of parallel operation object
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnRTASParallelOperationCreateExp_t pfnCreateExp = [&result] {
+        auto pfnCreateExp = ze_lib::context->zeDdiTable.load()->RTASParallelOperationExp.pfnCreateExp;
+        if( nullptr == pfnCreateExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnCreateExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnCreateExp( hDriver, phParallelOperation );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -8728,6 +11916,7 @@ zeRTASParallelOperationCreateExp(
     }
 
     return pfnCreateExp( hDriver, phParallelOperation );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8759,6 +11948,23 @@ zeRTASParallelOperationGetPropertiesExp(
     ze_rtas_parallel_operation_exp_properties_t* pProperties///< [in,out] query result for parallel operation properties
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnRTASParallelOperationGetPropertiesExp_t pfnGetPropertiesExp = [&result] {
+        auto pfnGetPropertiesExp = ze_lib::context->zeDdiTable.load()->RTASParallelOperationExp.pfnGetPropertiesExp;
+        if( nullptr == pfnGetPropertiesExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetPropertiesExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetPropertiesExp( hParallelOperation, pProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -8772,6 +11978,7 @@ zeRTASParallelOperationGetPropertiesExp(
     }
 
     return pfnGetPropertiesExp( hParallelOperation, pProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8794,6 +12001,23 @@ zeRTASParallelOperationJoinExp(
     ze_rtas_parallel_operation_exp_handle_t hParallelOperation  ///< [in] handle of parallel operation object
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnRTASParallelOperationJoinExp_t pfnJoinExp = [&result] {
+        auto pfnJoinExp = ze_lib::context->zeDdiTable.load()->RTASParallelOperationExp.pfnJoinExp;
+        if( nullptr == pfnJoinExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnJoinExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnJoinExp( hParallelOperation );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -8807,6 +12031,7 @@ zeRTASParallelOperationJoinExp(
     }
 
     return pfnJoinExp( hParallelOperation );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8834,6 +12059,23 @@ zeRTASParallelOperationDestroyExp(
     ze_rtas_parallel_operation_exp_handle_t hParallelOperation  ///< [in][release] handle of parallel operation object to destroy
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnRTASParallelOperationDestroyExp_t pfnDestroyExp = [&result] {
+        auto pfnDestroyExp = ze_lib::context->zeDdiTable.load()->RTASParallelOperationExp.pfnDestroyExp;
+        if( nullptr == pfnDestroyExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnDestroyExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnDestroyExp( hParallelOperation );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -8847,6 +12089,7 @@ zeRTASParallelOperationDestroyExp(
     }
 
     return pfnDestroyExp( hParallelOperation );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8880,6 +12123,23 @@ zeMemGetPitchFor2dImage(
     size_t * rowPitch                               ///< [out] rowPitch
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnMemGetPitchFor2dImage_t pfnGetPitchFor2dImage = [&result] {
+        auto pfnGetPitchFor2dImage = ze_lib::context->zeDdiTable.load()->Mem.pfnGetPitchFor2dImage;
+        if( nullptr == pfnGetPitchFor2dImage ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetPitchFor2dImage;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetPitchFor2dImage( hContext, hDevice, imageWidth, imageHeight, elementSizeInBytes, rowPitch );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -8893,6 +12153,7 @@ zeMemGetPitchFor2dImage(
     }
 
     return pfnGetPitchFor2dImage( hContext, hDevice, imageWidth, imageHeight, elementSizeInBytes, rowPitch );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8921,6 +12182,23 @@ zeImageGetDeviceOffsetExp(
     uint64_t* pDeviceOffset                         ///< [out] bindless device offset for image
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnImageGetDeviceOffsetExp_t pfnGetDeviceOffsetExp = [&result] {
+        auto pfnGetDeviceOffsetExp = ze_lib::context->zeDdiTable.load()->ImageExp.pfnGetDeviceOffsetExp;
+        if( nullptr == pfnGetDeviceOffsetExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetDeviceOffsetExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetDeviceOffsetExp( hImage, pDeviceOffset );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -8934,6 +12212,7 @@ zeImageGetDeviceOffsetExp(
     }
 
     return pfnGetDeviceOffsetExp( hImage, pDeviceOffset );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8970,6 +12249,23 @@ zeCommandListCreateCloneExp(
     ze_command_list_handle_t* phClonedCommandList   ///< [out] pointer to handle of the cloned command list
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandListCreateCloneExp_t pfnCreateCloneExp = [&result] {
+        auto pfnCreateCloneExp = ze_lib::context->zeDdiTable.load()->CommandListExp.pfnCreateCloneExp;
+        if( nullptr == pfnCreateCloneExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnCreateCloneExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnCreateCloneExp( hCommandList, phClonedCommandList );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -8983,6 +12279,7 @@ zeCommandListCreateCloneExp(
     }
 
     return pfnCreateCloneExp( hCommandList, phClonedCommandList );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -9023,6 +12320,23 @@ zeCommandListImmediateAppendCommandListsExp(
                                                     ///< of any appended command list(s)
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandListImmediateAppendCommandListsExp_t pfnImmediateAppendCommandListsExp = [&result] {
+        auto pfnImmediateAppendCommandListsExp = ze_lib::context->zeDdiTable.load()->CommandListExp.pfnImmediateAppendCommandListsExp;
+        if( nullptr == pfnImmediateAppendCommandListsExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnImmediateAppendCommandListsExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnImmediateAppendCommandListsExp( hCommandListImmediate, numCommandLists, phCommandLists, hSignalEvent, numWaitEvents, phWaitEvents );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -9036,6 +12350,7 @@ zeCommandListImmediateAppendCommandListsExp(
     }
 
     return pfnImmediateAppendCommandListsExp( hCommandListImmediate, numCommandLists, phCommandLists, hSignalEvent, numWaitEvents, phWaitEvents );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -9069,6 +12384,23 @@ zeCommandListGetNextCommandIdExp(
     uint64_t* pCommandId                            ///< [out] pointer to mutable command identifier to be written
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandListGetNextCommandIdExp_t pfnGetNextCommandIdExp = [&result] {
+        auto pfnGetNextCommandIdExp = ze_lib::context->zeDdiTable.load()->CommandListExp.pfnGetNextCommandIdExp;
+        if( nullptr == pfnGetNextCommandIdExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetNextCommandIdExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetNextCommandIdExp( hCommandList, desc, pCommandId );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -9082,6 +12414,7 @@ zeCommandListGetNextCommandIdExp(
     }
 
     return pfnGetNextCommandIdExp( hCommandList, desc, pCommandId );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -9121,6 +12454,23 @@ zeCommandListGetNextCommandIdWithKernelsExp(
     uint64_t* pCommandId                            ///< [out] pointer to mutable command identifier to be written
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandListGetNextCommandIdWithKernelsExp_t pfnGetNextCommandIdWithKernelsExp = [&result] {
+        auto pfnGetNextCommandIdWithKernelsExp = ze_lib::context->zeDdiTable.load()->CommandListExp.pfnGetNextCommandIdWithKernelsExp;
+        if( nullptr == pfnGetNextCommandIdWithKernelsExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetNextCommandIdWithKernelsExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetNextCommandIdWithKernelsExp( hCommandList, desc, numKernels, phKernels, pCommandId );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -9134,6 +12484,7 @@ zeCommandListGetNextCommandIdWithKernelsExp(
     }
 
     return pfnGetNextCommandIdWithKernelsExp( hCommandList, desc, numKernels, phKernels, pCommandId );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -9168,6 +12519,23 @@ zeCommandListUpdateMutableCommandsExp(
                                                     ///< be chained via `pNext` member
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandListUpdateMutableCommandsExp_t pfnUpdateMutableCommandsExp = [&result] {
+        auto pfnUpdateMutableCommandsExp = ze_lib::context->zeDdiTable.load()->CommandListExp.pfnUpdateMutableCommandsExp;
+        if( nullptr == pfnUpdateMutableCommandsExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnUpdateMutableCommandsExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnUpdateMutableCommandsExp( hCommandList, desc );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -9181,6 +12549,7 @@ zeCommandListUpdateMutableCommandsExp(
     }
 
     return pfnUpdateMutableCommandsExp( hCommandList, desc );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -9214,6 +12583,23 @@ zeCommandListUpdateMutableCommandSignalEventExp(
     ze_event_handle_t hSignalEvent                  ///< [in][optional] handle of the event to signal on completion
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandListUpdateMutableCommandSignalEventExp_t pfnUpdateMutableCommandSignalEventExp = [&result] {
+        auto pfnUpdateMutableCommandSignalEventExp = ze_lib::context->zeDdiTable.load()->CommandListExp.pfnUpdateMutableCommandSignalEventExp;
+        if( nullptr == pfnUpdateMutableCommandSignalEventExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnUpdateMutableCommandSignalEventExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnUpdateMutableCommandSignalEventExp( hCommandList, commandId, hSignalEvent );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -9227,6 +12613,7 @@ zeCommandListUpdateMutableCommandSignalEventExp(
     }
 
     return pfnUpdateMutableCommandSignalEventExp( hCommandList, commandId, hSignalEvent );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -9269,6 +12656,23 @@ zeCommandListUpdateMutableCommandWaitEventsExp(
                                                     ///< on before launching
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandListUpdateMutableCommandWaitEventsExp_t pfnUpdateMutableCommandWaitEventsExp = [&result] {
+        auto pfnUpdateMutableCommandWaitEventsExp = ze_lib::context->zeDdiTable.load()->CommandListExp.pfnUpdateMutableCommandWaitEventsExp;
+        if( nullptr == pfnUpdateMutableCommandWaitEventsExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnUpdateMutableCommandWaitEventsExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnUpdateMutableCommandWaitEventsExp( hCommandList, commandId, numWaitEvents, phWaitEvents );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -9282,6 +12686,7 @@ zeCommandListUpdateMutableCommandWaitEventsExp(
     }
 
     return pfnUpdateMutableCommandWaitEventsExp( hCommandList, commandId, numWaitEvents, phWaitEvents );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -9322,6 +12727,23 @@ zeCommandListUpdateMutableCommandKernelsExp(
                                                     ///< identifier to switch to
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const ze_pfnCommandListUpdateMutableCommandKernelsExp_t pfnUpdateMutableCommandKernelsExp = [&result] {
+        auto pfnUpdateMutableCommandKernelsExp = ze_lib::context->zeDdiTable.load()->CommandListExp.pfnUpdateMutableCommandKernelsExp;
+        if( nullptr == pfnUpdateMutableCommandKernelsExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnUpdateMutableCommandKernelsExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnUpdateMutableCommandKernelsExp( hCommandList, numKernels, pCommandId, phKernels );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -9335,6 +12757,7 @@ zeCommandListUpdateMutableCommandKernelsExp(
     }
 
     return pfnUpdateMutableCommandKernelsExp( hCommandList, numKernels, pCommandId, phKernels );
+    #endif
 }
 
 } // extern "C"

--- a/source/lib/ze_libapi.cpp
+++ b/source/lib/ze_libapi.cpp
@@ -149,11 +149,11 @@ zeDriverGet(
 ///       other function. (zeInit is [Deprecated] and is replaced by
 ///       zeInitDrivers)
 ///     - Calls to zeInit[Deprecated] or InitDrivers will not alter the drivers
-///       retrieved thru either api.
-///     - Drivers init thru zeInit[Deprecated] or InitDrivers will not be
+///       retrieved through either api.
+///     - Drivers init through zeInit[Deprecated] or InitDrivers will not be
 ///       reInitialized once init in an application. The Loader will determine
-///       if the already init driver needs to be delivered to the user thru the
-///       init type flags.
+///       if the already init driver needs to be delivered to the user through
+///       the init type flags.
 ///     - Already init Drivers will not be uninitialized if the call to
 ///       InitDrivers does not include that driver's type. Those init drivers
 ///       which don't match the init flags will not have their driver handles

--- a/source/lib/ze_libddi.cpp
+++ b/source/lib/ze_libddi.cpp
@@ -26,6 +26,10 @@ namespace ze_lib
             auto getTable = reinterpret_cast<ze_pfnGetGlobalProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetGlobalProcAddrTable") );
             result = getTableWithCheck(getTable, version, &initialzeDdiTable.Global );
+            initialzeDdiTable.Global.pfnInit = reinterpret_cast<ze_pfnInit_t>(
+                GET_FUNCTION_PTR(loader, "zeInit") );
+            initialzeDdiTable.Global.pfnInitDrivers = reinterpret_cast<ze_pfnInitDrivers_t>(
+                GET_FUNCTION_PTR(loader, "zeInitDrivers") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -34,6 +38,14 @@ namespace ze_lib
             auto getTable = reinterpret_cast<ze_pfnGetRTASBuilderExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetRTASBuilderExpProcAddrTable") );
             getTableWithCheck(getTable, version, &initialzeDdiTable.RTASBuilderExp );
+            initialzeDdiTable.RTASBuilderExp.pfnCreateExp = reinterpret_cast<ze_pfnRTASBuilderCreateExp_t>(
+                GET_FUNCTION_PTR(loader, "zeRTASBuilderCreateExp") );
+            initialzeDdiTable.RTASBuilderExp.pfnGetBuildPropertiesExp = reinterpret_cast<ze_pfnRTASBuilderGetBuildPropertiesExp_t>(
+                GET_FUNCTION_PTR(loader, "zeRTASBuilderGetBuildPropertiesExp") );
+            initialzeDdiTable.RTASBuilderExp.pfnBuildExp = reinterpret_cast<ze_pfnRTASBuilderBuildExp_t>(
+                GET_FUNCTION_PTR(loader, "zeRTASBuilderBuildExp") );
+            initialzeDdiTable.RTASBuilderExp.pfnDestroyExp = reinterpret_cast<ze_pfnRTASBuilderDestroyExp_t>(
+                GET_FUNCTION_PTR(loader, "zeRTASBuilderDestroyExp") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -42,6 +54,14 @@ namespace ze_lib
             auto getTable = reinterpret_cast<ze_pfnGetRTASParallelOperationExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetRTASParallelOperationExpProcAddrTable") );
             getTableWithCheck(getTable, version, &initialzeDdiTable.RTASParallelOperationExp );
+            initialzeDdiTable.RTASParallelOperationExp.pfnCreateExp = reinterpret_cast<ze_pfnRTASParallelOperationCreateExp_t>(
+                GET_FUNCTION_PTR(loader, "zeRTASParallelOperationCreateExp") );
+            initialzeDdiTable.RTASParallelOperationExp.pfnGetPropertiesExp = reinterpret_cast<ze_pfnRTASParallelOperationGetPropertiesExp_t>(
+                GET_FUNCTION_PTR(loader, "zeRTASParallelOperationGetPropertiesExp") );
+            initialzeDdiTable.RTASParallelOperationExp.pfnJoinExp = reinterpret_cast<ze_pfnRTASParallelOperationJoinExp_t>(
+                GET_FUNCTION_PTR(loader, "zeRTASParallelOperationJoinExp") );
+            initialzeDdiTable.RTASParallelOperationExp.pfnDestroyExp = reinterpret_cast<ze_pfnRTASParallelOperationDestroyExp_t>(
+                GET_FUNCTION_PTR(loader, "zeRTASParallelOperationDestroyExp") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -49,6 +69,20 @@ namespace ze_lib
             auto getTable = reinterpret_cast<ze_pfnGetDriverProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetDriverProcAddrTable") );
             result = getTableWithCheck(getTable, version, &initialzeDdiTable.Driver );
+            initialzeDdiTable.Driver.pfnGet = reinterpret_cast<ze_pfnDriverGet_t>(
+                GET_FUNCTION_PTR(loader, "zeDriverGet") );
+            initialzeDdiTable.Driver.pfnGetApiVersion = reinterpret_cast<ze_pfnDriverGetApiVersion_t>(
+                GET_FUNCTION_PTR(loader, "zeDriverGetApiVersion") );
+            initialzeDdiTable.Driver.pfnGetProperties = reinterpret_cast<ze_pfnDriverGetProperties_t>(
+                GET_FUNCTION_PTR(loader, "zeDriverGetProperties") );
+            initialzeDdiTable.Driver.pfnGetIpcProperties = reinterpret_cast<ze_pfnDriverGetIpcProperties_t>(
+                GET_FUNCTION_PTR(loader, "zeDriverGetIpcProperties") );
+            initialzeDdiTable.Driver.pfnGetExtensionProperties = reinterpret_cast<ze_pfnDriverGetExtensionProperties_t>(
+                GET_FUNCTION_PTR(loader, "zeDriverGetExtensionProperties") );
+            initialzeDdiTable.Driver.pfnGetExtensionFunctionAddress = reinterpret_cast<ze_pfnDriverGetExtensionFunctionAddress_t>(
+                GET_FUNCTION_PTR(loader, "zeDriverGetExtensionFunctionAddress") );
+            initialzeDdiTable.Driver.pfnGetLastErrorDescription = reinterpret_cast<ze_pfnDriverGetLastErrorDescription_t>(
+                GET_FUNCTION_PTR(loader, "zeDriverGetLastErrorDescription") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -57,6 +91,8 @@ namespace ze_lib
             auto getTable = reinterpret_cast<ze_pfnGetDriverExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetDriverExpProcAddrTable") );
             getTableWithCheck(getTable, version, &initialzeDdiTable.DriverExp );
+            initialzeDdiTable.DriverExp.pfnRTASFormatCompatibilityCheckExp = reinterpret_cast<ze_pfnDriverRTASFormatCompatibilityCheckExp_t>(
+                GET_FUNCTION_PTR(loader, "zeDriverRTASFormatCompatibilityCheckExp") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -64,6 +100,48 @@ namespace ze_lib
             auto getTable = reinterpret_cast<ze_pfnGetDeviceProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetDeviceProcAddrTable") );
             result = getTableWithCheck(getTable, version, &initialzeDdiTable.Device );
+            initialzeDdiTable.Device.pfnGet = reinterpret_cast<ze_pfnDeviceGet_t>(
+                GET_FUNCTION_PTR(loader, "zeDeviceGet") );
+            initialzeDdiTable.Device.pfnGetSubDevices = reinterpret_cast<ze_pfnDeviceGetSubDevices_t>(
+                GET_FUNCTION_PTR(loader, "zeDeviceGetSubDevices") );
+            initialzeDdiTable.Device.pfnGetProperties = reinterpret_cast<ze_pfnDeviceGetProperties_t>(
+                GET_FUNCTION_PTR(loader, "zeDeviceGetProperties") );
+            initialzeDdiTable.Device.pfnGetComputeProperties = reinterpret_cast<ze_pfnDeviceGetComputeProperties_t>(
+                GET_FUNCTION_PTR(loader, "zeDeviceGetComputeProperties") );
+            initialzeDdiTable.Device.pfnGetModuleProperties = reinterpret_cast<ze_pfnDeviceGetModuleProperties_t>(
+                GET_FUNCTION_PTR(loader, "zeDeviceGetModuleProperties") );
+            initialzeDdiTable.Device.pfnGetCommandQueueGroupProperties = reinterpret_cast<ze_pfnDeviceGetCommandQueueGroupProperties_t>(
+                GET_FUNCTION_PTR(loader, "zeDeviceGetCommandQueueGroupProperties") );
+            initialzeDdiTable.Device.pfnGetMemoryProperties = reinterpret_cast<ze_pfnDeviceGetMemoryProperties_t>(
+                GET_FUNCTION_PTR(loader, "zeDeviceGetMemoryProperties") );
+            initialzeDdiTable.Device.pfnGetMemoryAccessProperties = reinterpret_cast<ze_pfnDeviceGetMemoryAccessProperties_t>(
+                GET_FUNCTION_PTR(loader, "zeDeviceGetMemoryAccessProperties") );
+            initialzeDdiTable.Device.pfnGetCacheProperties = reinterpret_cast<ze_pfnDeviceGetCacheProperties_t>(
+                GET_FUNCTION_PTR(loader, "zeDeviceGetCacheProperties") );
+            initialzeDdiTable.Device.pfnGetImageProperties = reinterpret_cast<ze_pfnDeviceGetImageProperties_t>(
+                GET_FUNCTION_PTR(loader, "zeDeviceGetImageProperties") );
+            initialzeDdiTable.Device.pfnGetExternalMemoryProperties = reinterpret_cast<ze_pfnDeviceGetExternalMemoryProperties_t>(
+                GET_FUNCTION_PTR(loader, "zeDeviceGetExternalMemoryProperties") );
+            initialzeDdiTable.Device.pfnGetP2PProperties = reinterpret_cast<ze_pfnDeviceGetP2PProperties_t>(
+                GET_FUNCTION_PTR(loader, "zeDeviceGetP2PProperties") );
+            initialzeDdiTable.Device.pfnCanAccessPeer = reinterpret_cast<ze_pfnDeviceCanAccessPeer_t>(
+                GET_FUNCTION_PTR(loader, "zeDeviceCanAccessPeer") );
+            initialzeDdiTable.Device.pfnGetStatus = reinterpret_cast<ze_pfnDeviceGetStatus_t>(
+                GET_FUNCTION_PTR(loader, "zeDeviceGetStatus") );
+            initialzeDdiTable.Device.pfnGetGlobalTimestamps = reinterpret_cast<ze_pfnDeviceGetGlobalTimestamps_t>(
+                GET_FUNCTION_PTR(loader, "zeDeviceGetGlobalTimestamps") );
+            initialzeDdiTable.Device.pfnImportExternalSemaphoreExt = reinterpret_cast<ze_pfnDeviceImportExternalSemaphoreExt_t>(
+                GET_FUNCTION_PTR(loader, "zeDeviceImportExternalSemaphoreExt") );
+            initialzeDdiTable.Device.pfnReleaseExternalSemaphoreExt = reinterpret_cast<ze_pfnDeviceReleaseExternalSemaphoreExt_t>(
+                GET_FUNCTION_PTR(loader, "zeDeviceReleaseExternalSemaphoreExt") );
+            initialzeDdiTable.Device.pfnReserveCacheExt = reinterpret_cast<ze_pfnDeviceReserveCacheExt_t>(
+                GET_FUNCTION_PTR(loader, "zeDeviceReserveCacheExt") );
+            initialzeDdiTable.Device.pfnSetCacheAdviceExt = reinterpret_cast<ze_pfnDeviceSetCacheAdviceExt_t>(
+                GET_FUNCTION_PTR(loader, "zeDeviceSetCacheAdviceExt") );
+            initialzeDdiTable.Device.pfnPciGetPropertiesExt = reinterpret_cast<ze_pfnDevicePciGetPropertiesExt_t>(
+                GET_FUNCTION_PTR(loader, "zeDevicePciGetPropertiesExt") );
+            initialzeDdiTable.Device.pfnGetRootDevice = reinterpret_cast<ze_pfnDeviceGetRootDevice_t>(
+                GET_FUNCTION_PTR(loader, "zeDeviceGetRootDevice") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -72,6 +150,8 @@ namespace ze_lib
             auto getTable = reinterpret_cast<ze_pfnGetDeviceExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetDeviceExpProcAddrTable") );
             getTableWithCheck(getTable, version, &initialzeDdiTable.DeviceExp );
+            initialzeDdiTable.DeviceExp.pfnGetFabricVertexExp = reinterpret_cast<ze_pfnDeviceGetFabricVertexExp_t>(
+                GET_FUNCTION_PTR(loader, "zeDeviceGetFabricVertexExp") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -79,6 +159,24 @@ namespace ze_lib
             auto getTable = reinterpret_cast<ze_pfnGetContextProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetContextProcAddrTable") );
             result = getTableWithCheck(getTable, version, &initialzeDdiTable.Context );
+            initialzeDdiTable.Context.pfnCreate = reinterpret_cast<ze_pfnContextCreate_t>(
+                GET_FUNCTION_PTR(loader, "zeContextCreate") );
+            initialzeDdiTable.Context.pfnDestroy = reinterpret_cast<ze_pfnContextDestroy_t>(
+                GET_FUNCTION_PTR(loader, "zeContextDestroy") );
+            initialzeDdiTable.Context.pfnGetStatus = reinterpret_cast<ze_pfnContextGetStatus_t>(
+                GET_FUNCTION_PTR(loader, "zeContextGetStatus") );
+            initialzeDdiTable.Context.pfnSystemBarrier = reinterpret_cast<ze_pfnContextSystemBarrier_t>(
+                GET_FUNCTION_PTR(loader, "zeContextSystemBarrier") );
+            initialzeDdiTable.Context.pfnMakeMemoryResident = reinterpret_cast<ze_pfnContextMakeMemoryResident_t>(
+                GET_FUNCTION_PTR(loader, "zeContextMakeMemoryResident") );
+            initialzeDdiTable.Context.pfnEvictMemory = reinterpret_cast<ze_pfnContextEvictMemory_t>(
+                GET_FUNCTION_PTR(loader, "zeContextEvictMemory") );
+            initialzeDdiTable.Context.pfnMakeImageResident = reinterpret_cast<ze_pfnContextMakeImageResident_t>(
+                GET_FUNCTION_PTR(loader, "zeContextMakeImageResident") );
+            initialzeDdiTable.Context.pfnEvictImage = reinterpret_cast<ze_pfnContextEvictImage_t>(
+                GET_FUNCTION_PTR(loader, "zeContextEvictImage") );
+            initialzeDdiTable.Context.pfnCreateEx = reinterpret_cast<ze_pfnContextCreateEx_t>(
+                GET_FUNCTION_PTR(loader, "zeContextCreateEx") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -86,6 +184,18 @@ namespace ze_lib
             auto getTable = reinterpret_cast<ze_pfnGetCommandQueueProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetCommandQueueProcAddrTable") );
             result = getTableWithCheck(getTable, version, &initialzeDdiTable.CommandQueue );
+            initialzeDdiTable.CommandQueue.pfnCreate = reinterpret_cast<ze_pfnCommandQueueCreate_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandQueueCreate") );
+            initialzeDdiTable.CommandQueue.pfnDestroy = reinterpret_cast<ze_pfnCommandQueueDestroy_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandQueueDestroy") );
+            initialzeDdiTable.CommandQueue.pfnExecuteCommandLists = reinterpret_cast<ze_pfnCommandQueueExecuteCommandLists_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandQueueExecuteCommandLists") );
+            initialzeDdiTable.CommandQueue.pfnSynchronize = reinterpret_cast<ze_pfnCommandQueueSynchronize_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandQueueSynchronize") );
+            initialzeDdiTable.CommandQueue.pfnGetOrdinal = reinterpret_cast<ze_pfnCommandQueueGetOrdinal_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandQueueGetOrdinal") );
+            initialzeDdiTable.CommandQueue.pfnGetIndex = reinterpret_cast<ze_pfnCommandQueueGetIndex_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandQueueGetIndex") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -93,6 +203,78 @@ namespace ze_lib
             auto getTable = reinterpret_cast<ze_pfnGetCommandListProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetCommandListProcAddrTable") );
             result = getTableWithCheck(getTable, version, &initialzeDdiTable.CommandList );
+            initialzeDdiTable.CommandList.pfnCreate = reinterpret_cast<ze_pfnCommandListCreate_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandListCreate") );
+            initialzeDdiTable.CommandList.pfnCreateImmediate = reinterpret_cast<ze_pfnCommandListCreateImmediate_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandListCreateImmediate") );
+            initialzeDdiTable.CommandList.pfnDestroy = reinterpret_cast<ze_pfnCommandListDestroy_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandListDestroy") );
+            initialzeDdiTable.CommandList.pfnClose = reinterpret_cast<ze_pfnCommandListClose_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandListClose") );
+            initialzeDdiTable.CommandList.pfnReset = reinterpret_cast<ze_pfnCommandListReset_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandListReset") );
+            initialzeDdiTable.CommandList.pfnAppendWriteGlobalTimestamp = reinterpret_cast<ze_pfnCommandListAppendWriteGlobalTimestamp_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandListAppendWriteGlobalTimestamp") );
+            initialzeDdiTable.CommandList.pfnAppendBarrier = reinterpret_cast<ze_pfnCommandListAppendBarrier_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandListAppendBarrier") );
+            initialzeDdiTable.CommandList.pfnAppendMemoryRangesBarrier = reinterpret_cast<ze_pfnCommandListAppendMemoryRangesBarrier_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandListAppendMemoryRangesBarrier") );
+            initialzeDdiTable.CommandList.pfnAppendMemoryCopy = reinterpret_cast<ze_pfnCommandListAppendMemoryCopy_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandListAppendMemoryCopy") );
+            initialzeDdiTable.CommandList.pfnAppendMemoryFill = reinterpret_cast<ze_pfnCommandListAppendMemoryFill_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandListAppendMemoryFill") );
+            initialzeDdiTable.CommandList.pfnAppendMemoryCopyRegion = reinterpret_cast<ze_pfnCommandListAppendMemoryCopyRegion_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandListAppendMemoryCopyRegion") );
+            initialzeDdiTable.CommandList.pfnAppendMemoryCopyFromContext = reinterpret_cast<ze_pfnCommandListAppendMemoryCopyFromContext_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandListAppendMemoryCopyFromContext") );
+            initialzeDdiTable.CommandList.pfnAppendImageCopy = reinterpret_cast<ze_pfnCommandListAppendImageCopy_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandListAppendImageCopy") );
+            initialzeDdiTable.CommandList.pfnAppendImageCopyRegion = reinterpret_cast<ze_pfnCommandListAppendImageCopyRegion_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandListAppendImageCopyRegion") );
+            initialzeDdiTable.CommandList.pfnAppendImageCopyToMemory = reinterpret_cast<ze_pfnCommandListAppendImageCopyToMemory_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandListAppendImageCopyToMemory") );
+            initialzeDdiTable.CommandList.pfnAppendImageCopyFromMemory = reinterpret_cast<ze_pfnCommandListAppendImageCopyFromMemory_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandListAppendImageCopyFromMemory") );
+            initialzeDdiTable.CommandList.pfnAppendMemoryPrefetch = reinterpret_cast<ze_pfnCommandListAppendMemoryPrefetch_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandListAppendMemoryPrefetch") );
+            initialzeDdiTable.CommandList.pfnAppendMemAdvise = reinterpret_cast<ze_pfnCommandListAppendMemAdvise_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandListAppendMemAdvise") );
+            initialzeDdiTable.CommandList.pfnAppendSignalEvent = reinterpret_cast<ze_pfnCommandListAppendSignalEvent_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandListAppendSignalEvent") );
+            initialzeDdiTable.CommandList.pfnAppendWaitOnEvents = reinterpret_cast<ze_pfnCommandListAppendWaitOnEvents_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandListAppendWaitOnEvents") );
+            initialzeDdiTable.CommandList.pfnAppendEventReset = reinterpret_cast<ze_pfnCommandListAppendEventReset_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandListAppendEventReset") );
+            initialzeDdiTable.CommandList.pfnAppendQueryKernelTimestamps = reinterpret_cast<ze_pfnCommandListAppendQueryKernelTimestamps_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandListAppendQueryKernelTimestamps") );
+            initialzeDdiTable.CommandList.pfnAppendLaunchKernel = reinterpret_cast<ze_pfnCommandListAppendLaunchKernel_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandListAppendLaunchKernel") );
+            initialzeDdiTable.CommandList.pfnAppendLaunchCooperativeKernel = reinterpret_cast<ze_pfnCommandListAppendLaunchCooperativeKernel_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandListAppendLaunchCooperativeKernel") );
+            initialzeDdiTable.CommandList.pfnAppendLaunchKernelIndirect = reinterpret_cast<ze_pfnCommandListAppendLaunchKernelIndirect_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandListAppendLaunchKernelIndirect") );
+            initialzeDdiTable.CommandList.pfnAppendLaunchMultipleKernelsIndirect = reinterpret_cast<ze_pfnCommandListAppendLaunchMultipleKernelsIndirect_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandListAppendLaunchMultipleKernelsIndirect") );
+            initialzeDdiTable.CommandList.pfnAppendSignalExternalSemaphoreExt = reinterpret_cast<ze_pfnCommandListAppendSignalExternalSemaphoreExt_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandListAppendSignalExternalSemaphoreExt") );
+            initialzeDdiTable.CommandList.pfnAppendWaitExternalSemaphoreExt = reinterpret_cast<ze_pfnCommandListAppendWaitExternalSemaphoreExt_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandListAppendWaitExternalSemaphoreExt") );
+            initialzeDdiTable.CommandList.pfnAppendImageCopyToMemoryExt = reinterpret_cast<ze_pfnCommandListAppendImageCopyToMemoryExt_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandListAppendImageCopyToMemoryExt") );
+            initialzeDdiTable.CommandList.pfnAppendImageCopyFromMemoryExt = reinterpret_cast<ze_pfnCommandListAppendImageCopyFromMemoryExt_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandListAppendImageCopyFromMemoryExt") );
+            initialzeDdiTable.CommandList.pfnHostSynchronize = reinterpret_cast<ze_pfnCommandListHostSynchronize_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandListHostSynchronize") );
+            initialzeDdiTable.CommandList.pfnGetDeviceHandle = reinterpret_cast<ze_pfnCommandListGetDeviceHandle_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandListGetDeviceHandle") );
+            initialzeDdiTable.CommandList.pfnGetContextHandle = reinterpret_cast<ze_pfnCommandListGetContextHandle_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandListGetContextHandle") );
+            initialzeDdiTable.CommandList.pfnGetOrdinal = reinterpret_cast<ze_pfnCommandListGetOrdinal_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandListGetOrdinal") );
+            initialzeDdiTable.CommandList.pfnImmediateGetIndex = reinterpret_cast<ze_pfnCommandListImmediateGetIndex_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandListImmediateGetIndex") );
+            initialzeDdiTable.CommandList.pfnIsImmediate = reinterpret_cast<ze_pfnCommandListIsImmediate_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandListIsImmediate") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -101,6 +283,22 @@ namespace ze_lib
             auto getTable = reinterpret_cast<ze_pfnGetCommandListExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetCommandListExpProcAddrTable") );
             getTableWithCheck(getTable, version, &initialzeDdiTable.CommandListExp );
+            initialzeDdiTable.CommandListExp.pfnGetNextCommandIdWithKernelsExp = reinterpret_cast<ze_pfnCommandListGetNextCommandIdWithKernelsExp_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandListGetNextCommandIdWithKernelsExp") );
+            initialzeDdiTable.CommandListExp.pfnUpdateMutableCommandKernelsExp = reinterpret_cast<ze_pfnCommandListUpdateMutableCommandKernelsExp_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandListUpdateMutableCommandKernelsExp") );
+            initialzeDdiTable.CommandListExp.pfnCreateCloneExp = reinterpret_cast<ze_pfnCommandListCreateCloneExp_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandListCreateCloneExp") );
+            initialzeDdiTable.CommandListExp.pfnImmediateAppendCommandListsExp = reinterpret_cast<ze_pfnCommandListImmediateAppendCommandListsExp_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandListImmediateAppendCommandListsExp") );
+            initialzeDdiTable.CommandListExp.pfnGetNextCommandIdExp = reinterpret_cast<ze_pfnCommandListGetNextCommandIdExp_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandListGetNextCommandIdExp") );
+            initialzeDdiTable.CommandListExp.pfnUpdateMutableCommandsExp = reinterpret_cast<ze_pfnCommandListUpdateMutableCommandsExp_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandListUpdateMutableCommandsExp") );
+            initialzeDdiTable.CommandListExp.pfnUpdateMutableCommandSignalEventExp = reinterpret_cast<ze_pfnCommandListUpdateMutableCommandSignalEventExp_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandListUpdateMutableCommandSignalEventExp") );
+            initialzeDdiTable.CommandListExp.pfnUpdateMutableCommandWaitEventsExp = reinterpret_cast<ze_pfnCommandListUpdateMutableCommandWaitEventsExp_t>(
+                GET_FUNCTION_PTR(loader, "zeCommandListUpdateMutableCommandWaitEventsExp") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -108,6 +306,28 @@ namespace ze_lib
             auto getTable = reinterpret_cast<ze_pfnGetEventProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetEventProcAddrTable") );
             result = getTableWithCheck(getTable, version, &initialzeDdiTable.Event );
+            initialzeDdiTable.Event.pfnCreate = reinterpret_cast<ze_pfnEventCreate_t>(
+                GET_FUNCTION_PTR(loader, "zeEventCreate") );
+            initialzeDdiTable.Event.pfnDestroy = reinterpret_cast<ze_pfnEventDestroy_t>(
+                GET_FUNCTION_PTR(loader, "zeEventDestroy") );
+            initialzeDdiTable.Event.pfnHostSignal = reinterpret_cast<ze_pfnEventHostSignal_t>(
+                GET_FUNCTION_PTR(loader, "zeEventHostSignal") );
+            initialzeDdiTable.Event.pfnHostSynchronize = reinterpret_cast<ze_pfnEventHostSynchronize_t>(
+                GET_FUNCTION_PTR(loader, "zeEventHostSynchronize") );
+            initialzeDdiTable.Event.pfnQueryStatus = reinterpret_cast<ze_pfnEventQueryStatus_t>(
+                GET_FUNCTION_PTR(loader, "zeEventQueryStatus") );
+            initialzeDdiTable.Event.pfnHostReset = reinterpret_cast<ze_pfnEventHostReset_t>(
+                GET_FUNCTION_PTR(loader, "zeEventHostReset") );
+            initialzeDdiTable.Event.pfnQueryKernelTimestamp = reinterpret_cast<ze_pfnEventQueryKernelTimestamp_t>(
+                GET_FUNCTION_PTR(loader, "zeEventQueryKernelTimestamp") );
+            initialzeDdiTable.Event.pfnQueryKernelTimestampsExt = reinterpret_cast<ze_pfnEventQueryKernelTimestampsExt_t>(
+                GET_FUNCTION_PTR(loader, "zeEventQueryKernelTimestampsExt") );
+            initialzeDdiTable.Event.pfnGetEventPool = reinterpret_cast<ze_pfnEventGetEventPool_t>(
+                GET_FUNCTION_PTR(loader, "zeEventGetEventPool") );
+            initialzeDdiTable.Event.pfnGetSignalScope = reinterpret_cast<ze_pfnEventGetSignalScope_t>(
+                GET_FUNCTION_PTR(loader, "zeEventGetSignalScope") );
+            initialzeDdiTable.Event.pfnGetWaitScope = reinterpret_cast<ze_pfnEventGetWaitScope_t>(
+                GET_FUNCTION_PTR(loader, "zeEventGetWaitScope") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -116,6 +336,8 @@ namespace ze_lib
             auto getTable = reinterpret_cast<ze_pfnGetEventExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetEventExpProcAddrTable") );
             getTableWithCheck(getTable, version, &initialzeDdiTable.EventExp );
+            initialzeDdiTable.EventExp.pfnQueryTimestampsExp = reinterpret_cast<ze_pfnEventQueryTimestampsExp_t>(
+                GET_FUNCTION_PTR(loader, "zeEventQueryTimestampsExp") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -123,6 +345,22 @@ namespace ze_lib
             auto getTable = reinterpret_cast<ze_pfnGetEventPoolProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetEventPoolProcAddrTable") );
             result = getTableWithCheck(getTable, version, &initialzeDdiTable.EventPool );
+            initialzeDdiTable.EventPool.pfnCreate = reinterpret_cast<ze_pfnEventPoolCreate_t>(
+                GET_FUNCTION_PTR(loader, "zeEventPoolCreate") );
+            initialzeDdiTable.EventPool.pfnDestroy = reinterpret_cast<ze_pfnEventPoolDestroy_t>(
+                GET_FUNCTION_PTR(loader, "zeEventPoolDestroy") );
+            initialzeDdiTable.EventPool.pfnGetIpcHandle = reinterpret_cast<ze_pfnEventPoolGetIpcHandle_t>(
+                GET_FUNCTION_PTR(loader, "zeEventPoolGetIpcHandle") );
+            initialzeDdiTable.EventPool.pfnOpenIpcHandle = reinterpret_cast<ze_pfnEventPoolOpenIpcHandle_t>(
+                GET_FUNCTION_PTR(loader, "zeEventPoolOpenIpcHandle") );
+            initialzeDdiTable.EventPool.pfnCloseIpcHandle = reinterpret_cast<ze_pfnEventPoolCloseIpcHandle_t>(
+                GET_FUNCTION_PTR(loader, "zeEventPoolCloseIpcHandle") );
+            initialzeDdiTable.EventPool.pfnPutIpcHandle = reinterpret_cast<ze_pfnEventPoolPutIpcHandle_t>(
+                GET_FUNCTION_PTR(loader, "zeEventPoolPutIpcHandle") );
+            initialzeDdiTable.EventPool.pfnGetContextHandle = reinterpret_cast<ze_pfnEventPoolGetContextHandle_t>(
+                GET_FUNCTION_PTR(loader, "zeEventPoolGetContextHandle") );
+            initialzeDdiTable.EventPool.pfnGetFlags = reinterpret_cast<ze_pfnEventPoolGetFlags_t>(
+                GET_FUNCTION_PTR(loader, "zeEventPoolGetFlags") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -130,6 +368,16 @@ namespace ze_lib
             auto getTable = reinterpret_cast<ze_pfnGetFenceProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetFenceProcAddrTable") );
             result = getTableWithCheck(getTable, version, &initialzeDdiTable.Fence );
+            initialzeDdiTable.Fence.pfnCreate = reinterpret_cast<ze_pfnFenceCreate_t>(
+                GET_FUNCTION_PTR(loader, "zeFenceCreate") );
+            initialzeDdiTable.Fence.pfnDestroy = reinterpret_cast<ze_pfnFenceDestroy_t>(
+                GET_FUNCTION_PTR(loader, "zeFenceDestroy") );
+            initialzeDdiTable.Fence.pfnHostSynchronize = reinterpret_cast<ze_pfnFenceHostSynchronize_t>(
+                GET_FUNCTION_PTR(loader, "zeFenceHostSynchronize") );
+            initialzeDdiTable.Fence.pfnQueryStatus = reinterpret_cast<ze_pfnFenceQueryStatus_t>(
+                GET_FUNCTION_PTR(loader, "zeFenceQueryStatus") );
+            initialzeDdiTable.Fence.pfnReset = reinterpret_cast<ze_pfnFenceReset_t>(
+                GET_FUNCTION_PTR(loader, "zeFenceReset") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -137,6 +385,16 @@ namespace ze_lib
             auto getTable = reinterpret_cast<ze_pfnGetImageProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetImageProcAddrTable") );
             result = getTableWithCheck(getTable, version, &initialzeDdiTable.Image );
+            initialzeDdiTable.Image.pfnGetProperties = reinterpret_cast<ze_pfnImageGetProperties_t>(
+                GET_FUNCTION_PTR(loader, "zeImageGetProperties") );
+            initialzeDdiTable.Image.pfnCreate = reinterpret_cast<ze_pfnImageCreate_t>(
+                GET_FUNCTION_PTR(loader, "zeImageCreate") );
+            initialzeDdiTable.Image.pfnDestroy = reinterpret_cast<ze_pfnImageDestroy_t>(
+                GET_FUNCTION_PTR(loader, "zeImageDestroy") );
+            initialzeDdiTable.Image.pfnGetAllocPropertiesExt = reinterpret_cast<ze_pfnImageGetAllocPropertiesExt_t>(
+                GET_FUNCTION_PTR(loader, "zeImageGetAllocPropertiesExt") );
+            initialzeDdiTable.Image.pfnViewCreateExt = reinterpret_cast<ze_pfnImageViewCreateExt_t>(
+                GET_FUNCTION_PTR(loader, "zeImageViewCreateExt") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -145,6 +403,12 @@ namespace ze_lib
             auto getTable = reinterpret_cast<ze_pfnGetImageExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetImageExpProcAddrTable") );
             getTableWithCheck(getTable, version, &initialzeDdiTable.ImageExp );
+            initialzeDdiTable.ImageExp.pfnGetMemoryPropertiesExp = reinterpret_cast<ze_pfnImageGetMemoryPropertiesExp_t>(
+                GET_FUNCTION_PTR(loader, "zeImageGetMemoryPropertiesExp") );
+            initialzeDdiTable.ImageExp.pfnViewCreateExp = reinterpret_cast<ze_pfnImageViewCreateExp_t>(
+                GET_FUNCTION_PTR(loader, "zeImageViewCreateExp") );
+            initialzeDdiTable.ImageExp.pfnGetDeviceOffsetExp = reinterpret_cast<ze_pfnImageGetDeviceOffsetExp_t>(
+                GET_FUNCTION_PTR(loader, "zeImageGetDeviceOffsetExp") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -152,6 +416,30 @@ namespace ze_lib
             auto getTable = reinterpret_cast<ze_pfnGetKernelProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetKernelProcAddrTable") );
             result = getTableWithCheck(getTable, version, &initialzeDdiTable.Kernel );
+            initialzeDdiTable.Kernel.pfnCreate = reinterpret_cast<ze_pfnKernelCreate_t>(
+                GET_FUNCTION_PTR(loader, "zeKernelCreate") );
+            initialzeDdiTable.Kernel.pfnDestroy = reinterpret_cast<ze_pfnKernelDestroy_t>(
+                GET_FUNCTION_PTR(loader, "zeKernelDestroy") );
+            initialzeDdiTable.Kernel.pfnSetCacheConfig = reinterpret_cast<ze_pfnKernelSetCacheConfig_t>(
+                GET_FUNCTION_PTR(loader, "zeKernelSetCacheConfig") );
+            initialzeDdiTable.Kernel.pfnSetGroupSize = reinterpret_cast<ze_pfnKernelSetGroupSize_t>(
+                GET_FUNCTION_PTR(loader, "zeKernelSetGroupSize") );
+            initialzeDdiTable.Kernel.pfnSuggestGroupSize = reinterpret_cast<ze_pfnKernelSuggestGroupSize_t>(
+                GET_FUNCTION_PTR(loader, "zeKernelSuggestGroupSize") );
+            initialzeDdiTable.Kernel.pfnSuggestMaxCooperativeGroupCount = reinterpret_cast<ze_pfnKernelSuggestMaxCooperativeGroupCount_t>(
+                GET_FUNCTION_PTR(loader, "zeKernelSuggestMaxCooperativeGroupCount") );
+            initialzeDdiTable.Kernel.pfnSetArgumentValue = reinterpret_cast<ze_pfnKernelSetArgumentValue_t>(
+                GET_FUNCTION_PTR(loader, "zeKernelSetArgumentValue") );
+            initialzeDdiTable.Kernel.pfnSetIndirectAccess = reinterpret_cast<ze_pfnKernelSetIndirectAccess_t>(
+                GET_FUNCTION_PTR(loader, "zeKernelSetIndirectAccess") );
+            initialzeDdiTable.Kernel.pfnGetIndirectAccess = reinterpret_cast<ze_pfnKernelGetIndirectAccess_t>(
+                GET_FUNCTION_PTR(loader, "zeKernelGetIndirectAccess") );
+            initialzeDdiTable.Kernel.pfnGetSourceAttributes = reinterpret_cast<ze_pfnKernelGetSourceAttributes_t>(
+                GET_FUNCTION_PTR(loader, "zeKernelGetSourceAttributes") );
+            initialzeDdiTable.Kernel.pfnGetProperties = reinterpret_cast<ze_pfnKernelGetProperties_t>(
+                GET_FUNCTION_PTR(loader, "zeKernelGetProperties") );
+            initialzeDdiTable.Kernel.pfnGetName = reinterpret_cast<ze_pfnKernelGetName_t>(
+                GET_FUNCTION_PTR(loader, "zeKernelGetName") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -160,6 +448,12 @@ namespace ze_lib
             auto getTable = reinterpret_cast<ze_pfnGetKernelExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetKernelExpProcAddrTable") );
             getTableWithCheck(getTable, version, &initialzeDdiTable.KernelExp );
+            initialzeDdiTable.KernelExp.pfnSetGlobalOffsetExp = reinterpret_cast<ze_pfnKernelSetGlobalOffsetExp_t>(
+                GET_FUNCTION_PTR(loader, "zeKernelSetGlobalOffsetExp") );
+            initialzeDdiTable.KernelExp.pfnGetBinaryExp = reinterpret_cast<ze_pfnKernelGetBinaryExp_t>(
+                GET_FUNCTION_PTR(loader, "zeKernelGetBinaryExp") );
+            initialzeDdiTable.KernelExp.pfnSchedulingHintExp = reinterpret_cast<ze_pfnKernelSchedulingHintExp_t>(
+                GET_FUNCTION_PTR(loader, "zeKernelSchedulingHintExp") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -167,6 +461,30 @@ namespace ze_lib
             auto getTable = reinterpret_cast<ze_pfnGetMemProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetMemProcAddrTable") );
             result = getTableWithCheck(getTable, version, &initialzeDdiTable.Mem );
+            initialzeDdiTable.Mem.pfnAllocShared = reinterpret_cast<ze_pfnMemAllocShared_t>(
+                GET_FUNCTION_PTR(loader, "zeMemAllocShared") );
+            initialzeDdiTable.Mem.pfnAllocDevice = reinterpret_cast<ze_pfnMemAllocDevice_t>(
+                GET_FUNCTION_PTR(loader, "zeMemAllocDevice") );
+            initialzeDdiTable.Mem.pfnAllocHost = reinterpret_cast<ze_pfnMemAllocHost_t>(
+                GET_FUNCTION_PTR(loader, "zeMemAllocHost") );
+            initialzeDdiTable.Mem.pfnFree = reinterpret_cast<ze_pfnMemFree_t>(
+                GET_FUNCTION_PTR(loader, "zeMemFree") );
+            initialzeDdiTable.Mem.pfnGetAllocProperties = reinterpret_cast<ze_pfnMemGetAllocProperties_t>(
+                GET_FUNCTION_PTR(loader, "zeMemGetAllocProperties") );
+            initialzeDdiTable.Mem.pfnGetAddressRange = reinterpret_cast<ze_pfnMemGetAddressRange_t>(
+                GET_FUNCTION_PTR(loader, "zeMemGetAddressRange") );
+            initialzeDdiTable.Mem.pfnGetIpcHandle = reinterpret_cast<ze_pfnMemGetIpcHandle_t>(
+                GET_FUNCTION_PTR(loader, "zeMemGetIpcHandle") );
+            initialzeDdiTable.Mem.pfnOpenIpcHandle = reinterpret_cast<ze_pfnMemOpenIpcHandle_t>(
+                GET_FUNCTION_PTR(loader, "zeMemOpenIpcHandle") );
+            initialzeDdiTable.Mem.pfnCloseIpcHandle = reinterpret_cast<ze_pfnMemCloseIpcHandle_t>(
+                GET_FUNCTION_PTR(loader, "zeMemCloseIpcHandle") );
+            initialzeDdiTable.Mem.pfnFreeExt = reinterpret_cast<ze_pfnMemFreeExt_t>(
+                GET_FUNCTION_PTR(loader, "zeMemFreeExt") );
+            initialzeDdiTable.Mem.pfnPutIpcHandle = reinterpret_cast<ze_pfnMemPutIpcHandle_t>(
+                GET_FUNCTION_PTR(loader, "zeMemPutIpcHandle") );
+            initialzeDdiTable.Mem.pfnGetPitchFor2dImage = reinterpret_cast<ze_pfnMemGetPitchFor2dImage_t>(
+                GET_FUNCTION_PTR(loader, "zeMemGetPitchFor2dImage") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -175,6 +493,14 @@ namespace ze_lib
             auto getTable = reinterpret_cast<ze_pfnGetMemExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetMemExpProcAddrTable") );
             getTableWithCheck(getTable, version, &initialzeDdiTable.MemExp );
+            initialzeDdiTable.MemExp.pfnGetIpcHandleFromFileDescriptorExp = reinterpret_cast<ze_pfnMemGetIpcHandleFromFileDescriptorExp_t>(
+                GET_FUNCTION_PTR(loader, "zeMemGetIpcHandleFromFileDescriptorExp") );
+            initialzeDdiTable.MemExp.pfnGetFileDescriptorFromIpcHandleExp = reinterpret_cast<ze_pfnMemGetFileDescriptorFromIpcHandleExp_t>(
+                GET_FUNCTION_PTR(loader, "zeMemGetFileDescriptorFromIpcHandleExp") );
+            initialzeDdiTable.MemExp.pfnSetAtomicAccessAttributeExp = reinterpret_cast<ze_pfnMemSetAtomicAccessAttributeExp_t>(
+                GET_FUNCTION_PTR(loader, "zeMemSetAtomicAccessAttributeExp") );
+            initialzeDdiTable.MemExp.pfnGetAtomicAccessAttributeExp = reinterpret_cast<ze_pfnMemGetAtomicAccessAttributeExp_t>(
+                GET_FUNCTION_PTR(loader, "zeMemGetAtomicAccessAttributeExp") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -182,6 +508,24 @@ namespace ze_lib
             auto getTable = reinterpret_cast<ze_pfnGetModuleProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetModuleProcAddrTable") );
             result = getTableWithCheck(getTable, version, &initialzeDdiTable.Module );
+            initialzeDdiTable.Module.pfnCreate = reinterpret_cast<ze_pfnModuleCreate_t>(
+                GET_FUNCTION_PTR(loader, "zeModuleCreate") );
+            initialzeDdiTable.Module.pfnDestroy = reinterpret_cast<ze_pfnModuleDestroy_t>(
+                GET_FUNCTION_PTR(loader, "zeModuleDestroy") );
+            initialzeDdiTable.Module.pfnDynamicLink = reinterpret_cast<ze_pfnModuleDynamicLink_t>(
+                GET_FUNCTION_PTR(loader, "zeModuleDynamicLink") );
+            initialzeDdiTable.Module.pfnGetNativeBinary = reinterpret_cast<ze_pfnModuleGetNativeBinary_t>(
+                GET_FUNCTION_PTR(loader, "zeModuleGetNativeBinary") );
+            initialzeDdiTable.Module.pfnGetGlobalPointer = reinterpret_cast<ze_pfnModuleGetGlobalPointer_t>(
+                GET_FUNCTION_PTR(loader, "zeModuleGetGlobalPointer") );
+            initialzeDdiTable.Module.pfnGetKernelNames = reinterpret_cast<ze_pfnModuleGetKernelNames_t>(
+                GET_FUNCTION_PTR(loader, "zeModuleGetKernelNames") );
+            initialzeDdiTable.Module.pfnGetProperties = reinterpret_cast<ze_pfnModuleGetProperties_t>(
+                GET_FUNCTION_PTR(loader, "zeModuleGetProperties") );
+            initialzeDdiTable.Module.pfnGetFunctionPointer = reinterpret_cast<ze_pfnModuleGetFunctionPointer_t>(
+                GET_FUNCTION_PTR(loader, "zeModuleGetFunctionPointer") );
+            initialzeDdiTable.Module.pfnInspectLinkageExt = reinterpret_cast<ze_pfnModuleInspectLinkageExt_t>(
+                GET_FUNCTION_PTR(loader, "zeModuleInspectLinkageExt") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -189,6 +533,10 @@ namespace ze_lib
             auto getTable = reinterpret_cast<ze_pfnGetModuleBuildLogProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetModuleBuildLogProcAddrTable") );
             result = getTableWithCheck(getTable, version, &initialzeDdiTable.ModuleBuildLog );
+            initialzeDdiTable.ModuleBuildLog.pfnDestroy = reinterpret_cast<ze_pfnModuleBuildLogDestroy_t>(
+                GET_FUNCTION_PTR(loader, "zeModuleBuildLogDestroy") );
+            initialzeDdiTable.ModuleBuildLog.pfnGetString = reinterpret_cast<ze_pfnModuleBuildLogGetString_t>(
+                GET_FUNCTION_PTR(loader, "zeModuleBuildLogGetString") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -196,6 +544,10 @@ namespace ze_lib
             auto getTable = reinterpret_cast<ze_pfnGetPhysicalMemProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetPhysicalMemProcAddrTable") );
             result = getTableWithCheck(getTable, version, &initialzeDdiTable.PhysicalMem );
+            initialzeDdiTable.PhysicalMem.pfnCreate = reinterpret_cast<ze_pfnPhysicalMemCreate_t>(
+                GET_FUNCTION_PTR(loader, "zePhysicalMemCreate") );
+            initialzeDdiTable.PhysicalMem.pfnDestroy = reinterpret_cast<ze_pfnPhysicalMemDestroy_t>(
+                GET_FUNCTION_PTR(loader, "zePhysicalMemDestroy") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -203,6 +555,10 @@ namespace ze_lib
             auto getTable = reinterpret_cast<ze_pfnGetSamplerProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetSamplerProcAddrTable") );
             result = getTableWithCheck(getTable, version, &initialzeDdiTable.Sampler );
+            initialzeDdiTable.Sampler.pfnCreate = reinterpret_cast<ze_pfnSamplerCreate_t>(
+                GET_FUNCTION_PTR(loader, "zeSamplerCreate") );
+            initialzeDdiTable.Sampler.pfnDestroy = reinterpret_cast<ze_pfnSamplerDestroy_t>(
+                GET_FUNCTION_PTR(loader, "zeSamplerDestroy") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -210,6 +566,20 @@ namespace ze_lib
             auto getTable = reinterpret_cast<ze_pfnGetVirtualMemProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetVirtualMemProcAddrTable") );
             result = getTableWithCheck(getTable, version, &initialzeDdiTable.VirtualMem );
+            initialzeDdiTable.VirtualMem.pfnReserve = reinterpret_cast<ze_pfnVirtualMemReserve_t>(
+                GET_FUNCTION_PTR(loader, "zeVirtualMemReserve") );
+            initialzeDdiTable.VirtualMem.pfnFree = reinterpret_cast<ze_pfnVirtualMemFree_t>(
+                GET_FUNCTION_PTR(loader, "zeVirtualMemFree") );
+            initialzeDdiTable.VirtualMem.pfnQueryPageSize = reinterpret_cast<ze_pfnVirtualMemQueryPageSize_t>(
+                GET_FUNCTION_PTR(loader, "zeVirtualMemQueryPageSize") );
+            initialzeDdiTable.VirtualMem.pfnMap = reinterpret_cast<ze_pfnVirtualMemMap_t>(
+                GET_FUNCTION_PTR(loader, "zeVirtualMemMap") );
+            initialzeDdiTable.VirtualMem.pfnUnmap = reinterpret_cast<ze_pfnVirtualMemUnmap_t>(
+                GET_FUNCTION_PTR(loader, "zeVirtualMemUnmap") );
+            initialzeDdiTable.VirtualMem.pfnSetAccessAttribute = reinterpret_cast<ze_pfnVirtualMemSetAccessAttribute_t>(
+                GET_FUNCTION_PTR(loader, "zeVirtualMemSetAccessAttribute") );
+            initialzeDdiTable.VirtualMem.pfnGetAccessAttribute = reinterpret_cast<ze_pfnVirtualMemGetAccessAttribute_t>(
+                GET_FUNCTION_PTR(loader, "zeVirtualMemGetAccessAttribute") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -218,6 +588,12 @@ namespace ze_lib
             auto getTable = reinterpret_cast<ze_pfnGetFabricEdgeExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetFabricEdgeExpProcAddrTable") );
             getTableWithCheck(getTable, version, &initialzeDdiTable.FabricEdgeExp );
+            initialzeDdiTable.FabricEdgeExp.pfnGetExp = reinterpret_cast<ze_pfnFabricEdgeGetExp_t>(
+                GET_FUNCTION_PTR(loader, "zeFabricEdgeGetExp") );
+            initialzeDdiTable.FabricEdgeExp.pfnGetVerticesExp = reinterpret_cast<ze_pfnFabricEdgeGetVerticesExp_t>(
+                GET_FUNCTION_PTR(loader, "zeFabricEdgeGetVerticesExp") );
+            initialzeDdiTable.FabricEdgeExp.pfnGetPropertiesExp = reinterpret_cast<ze_pfnFabricEdgeGetPropertiesExp_t>(
+                GET_FUNCTION_PTR(loader, "zeFabricEdgeGetPropertiesExp") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -226,6 +602,14 @@ namespace ze_lib
             auto getTable = reinterpret_cast<ze_pfnGetFabricVertexExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zeGetFabricVertexExpProcAddrTable") );
             getTableWithCheck(getTable, version, &initialzeDdiTable.FabricVertexExp );
+            initialzeDdiTable.FabricVertexExp.pfnGetExp = reinterpret_cast<ze_pfnFabricVertexGetExp_t>(
+                GET_FUNCTION_PTR(loader, "zeFabricVertexGetExp") );
+            initialzeDdiTable.FabricVertexExp.pfnGetSubVerticesExp = reinterpret_cast<ze_pfnFabricVertexGetSubVerticesExp_t>(
+                GET_FUNCTION_PTR(loader, "zeFabricVertexGetSubVerticesExp") );
+            initialzeDdiTable.FabricVertexExp.pfnGetPropertiesExp = reinterpret_cast<ze_pfnFabricVertexGetPropertiesExp_t>(
+                GET_FUNCTION_PTR(loader, "zeFabricVertexGetPropertiesExp") );
+            initialzeDdiTable.FabricVertexExp.pfnGetDeviceExp = reinterpret_cast<ze_pfnFabricVertexGetDeviceExp_t>(
+                GET_FUNCTION_PTR(loader, "zeFabricVertexGetDeviceExp") );
         }
 
         return result;

--- a/source/lib/zes_libapi.cpp
+++ b/source/lib/zes_libapi.cpp
@@ -110,6 +110,26 @@ zesDriverGet(
                                                     ///< loader shall only retrieve that number of sysman drivers.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    if (ze_lib::context->zesDdiTable == nullptr) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDriverGet_t pfnGet = [&result] {
+        auto pfnGet = ze_lib::context->zesDdiTable.load()->Driver.pfnGet;
+        if( nullptr == pfnGet ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGet;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGet( pCount, phDrivers );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -128,6 +148,7 @@ zesDriverGet(
     ze_lib::context->zesInuse = true;
 
     return pfnGet( pCount, phDrivers );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -162,6 +183,23 @@ zesDriverGetExtensionProperties(
                                                     ///< then driver shall only retrieve that number of extension properties.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDriverGetExtensionProperties_t pfnGetExtensionProperties = [&result] {
+        auto pfnGetExtensionProperties = ze_lib::context->zesDdiTable.load()->Driver.pfnGetExtensionProperties;
+        if( nullptr == pfnGetExtensionProperties ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetExtensionProperties;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetExtensionProperties( hDriver, pCount, pExtensionProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -175,6 +213,7 @@ zesDriverGetExtensionProperties(
     }
 
     return pfnGetExtensionProperties( hDriver, pCount, pExtensionProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -203,6 +242,23 @@ zesDriverGetExtensionFunctionAddress(
     void** ppFunctionAddress                        ///< [out] pointer to function pointer
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDriverGetExtensionFunctionAddress_t pfnGetExtensionFunctionAddress = [&result] {
+        auto pfnGetExtensionFunctionAddress = ze_lib::context->zesDdiTable.load()->Driver.pfnGetExtensionFunctionAddress;
+        if( nullptr == pfnGetExtensionFunctionAddress ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetExtensionFunctionAddress;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetExtensionFunctionAddress( hDriver, name, ppFunctionAddress );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -216,6 +272,7 @@ zesDriverGetExtensionFunctionAddress(
     }
 
     return pfnGetExtensionFunctionAddress( hDriver, name, ppFunctionAddress );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -254,6 +311,23 @@ zesDeviceGet(
                                                     ///< driver shall only retrieve that number of sysman devices.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDeviceGet_t pfnGet = [&result] {
+        auto pfnGet = ze_lib::context->zesDdiTable.load()->Device.pfnGet;
+        if( nullptr == pfnGet ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGet;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGet( hDriver, pCount, phDevices );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -267,6 +341,7 @@ zesDeviceGet(
     }
 
     return pfnGet( hDriver, pCount, phDevices );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -292,6 +367,23 @@ zesDeviceGetProperties(
     zes_device_properties_t* pProperties            ///< [in,out] Structure that will contain information about the device.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDeviceGetProperties_t pfnGetProperties = [&result] {
+        auto pfnGetProperties = ze_lib::context->zesDdiTable.load()->Device.pfnGetProperties;
+        if( nullptr == pfnGetProperties ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetProperties;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetProperties( hDevice, pProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -305,6 +397,7 @@ zesDeviceGetProperties(
     }
 
     return pfnGetProperties( hDevice, pProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -331,6 +424,23 @@ zesDeviceGetState(
     zes_device_state_t* pState                      ///< [in,out] Structure that will contain information about the device.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDeviceGetState_t pfnGetState = [&result] {
+        auto pfnGetState = ze_lib::context->zesDdiTable.load()->Device.pfnGetState;
+        if( nullptr == pfnGetState ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetState;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetState( hDevice, pState );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -344,6 +454,7 @@ zesDeviceGetState(
     }
 
     return pfnGetState( hDevice, pState );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -381,6 +492,23 @@ zesDeviceReset(
                                                     ///< device will be forcibly killed.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDeviceReset_t pfnReset = [&result] {
+        auto pfnReset = ze_lib::context->zesDdiTable.load()->Device.pfnReset;
+        if( nullptr == pfnReset ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnReset;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnReset( hDevice, force );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -394,6 +522,7 @@ zesDeviceReset(
     }
 
     return pfnReset( hDevice, force );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -432,6 +561,23 @@ zesDeviceResetExt(
     zes_reset_properties_t* pProperties             ///< [in] Device reset properties to apply
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDeviceResetExt_t pfnResetExt = [&result] {
+        auto pfnResetExt = ze_lib::context->zesDdiTable.load()->Device.pfnResetExt;
+        if( nullptr == pfnResetExt ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnResetExt;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnResetExt( hDevice, pProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -445,6 +591,7 @@ zesDeviceResetExt(
     }
 
     return pfnResetExt( hDevice, pProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -488,6 +635,23 @@ zesDeviceProcessesGetState(
                                                     ///< number of processes. In this case, the return code will ::ZE_RESULT_ERROR_INVALID_SIZE.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDeviceProcessesGetState_t pfnProcessesGetState = [&result] {
+        auto pfnProcessesGetState = ze_lib::context->zesDdiTable.load()->Device.pfnProcessesGetState;
+        if( nullptr == pfnProcessesGetState ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnProcessesGetState;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnProcessesGetState( hDevice, pCount, pProcesses );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -501,6 +665,7 @@ zesDeviceProcessesGetState(
     }
 
     return pfnProcessesGetState( hDevice, pCount, pProcesses );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -526,6 +691,23 @@ zesDevicePciGetProperties(
     zes_pci_properties_t* pProperties               ///< [in,out] Will contain the PCI properties.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDevicePciGetProperties_t pfnPciGetProperties = [&result] {
+        auto pfnPciGetProperties = ze_lib::context->zesDdiTable.load()->Device.pfnPciGetProperties;
+        if( nullptr == pfnPciGetProperties ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnPciGetProperties;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnPciGetProperties( hDevice, pProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -539,6 +721,7 @@ zesDevicePciGetProperties(
     }
 
     return pfnPciGetProperties( hDevice, pProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -564,6 +747,23 @@ zesDevicePciGetState(
     zes_pci_state_t* pState                         ///< [in,out] Will contain the PCI properties.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDevicePciGetState_t pfnPciGetState = [&result] {
+        auto pfnPciGetState = ze_lib::context->zesDdiTable.load()->Device.pfnPciGetState;
+        if( nullptr == pfnPciGetState ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnPciGetState;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnPciGetState( hDevice, pState );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -577,6 +777,7 @@ zesDevicePciGetState(
     }
 
     return pfnPciGetState( hDevice, pState );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -610,6 +811,23 @@ zesDevicePciGetBars(
                                                     ///< driver shall only retrieve information about that number of PCI bars.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDevicePciGetBars_t pfnPciGetBars = [&result] {
+        auto pfnPciGetBars = ze_lib::context->zesDdiTable.load()->Device.pfnPciGetBars;
+        if( nullptr == pfnPciGetBars ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnPciGetBars;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnPciGetBars( hDevice, pCount, pProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -623,6 +841,7 @@ zesDevicePciGetBars(
     }
 
     return pfnPciGetBars( hDevice, pCount, pProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -650,6 +869,23 @@ zesDevicePciGetStats(
     zes_pci_stats_t* pStats                         ///< [in,out] Will contain a snapshot of the latest stats.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDevicePciGetStats_t pfnPciGetStats = [&result] {
+        auto pfnPciGetStats = ze_lib::context->zesDdiTable.load()->Device.pfnPciGetStats;
+        if( nullptr == pfnPciGetStats ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnPciGetStats;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnPciGetStats( hDevice, pStats );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -663,6 +899,7 @@ zesDevicePciGetStats(
     }
 
     return pfnPciGetStats( hDevice, pStats );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -688,6 +925,23 @@ zesDeviceSetOverclockWaiver(
     zes_device_handle_t hDevice                     ///< [in] Sysman handle of the device.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDeviceSetOverclockWaiver_t pfnSetOverclockWaiver = [&result] {
+        auto pfnSetOverclockWaiver = ze_lib::context->zesDdiTable.load()->Device.pfnSetOverclockWaiver;
+        if( nullptr == pfnSetOverclockWaiver ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnSetOverclockWaiver;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnSetOverclockWaiver( hDevice );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -701,6 +955,7 @@ zesDeviceSetOverclockWaiver(
     }
 
     return pfnSetOverclockWaiver( hDevice );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -730,6 +985,23 @@ zesDeviceGetOverclockDomains(
                                                     ///< doesn't support overclocking.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDeviceGetOverclockDomains_t pfnGetOverclockDomains = [&result] {
+        auto pfnGetOverclockDomains = ze_lib::context->zesDdiTable.load()->Device.pfnGetOverclockDomains;
+        if( nullptr == pfnGetOverclockDomains ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetOverclockDomains;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetOverclockDomains( hDevice, pOverclockDomains );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -743,6 +1015,7 @@ zesDeviceGetOverclockDomains(
     }
 
     return pfnGetOverclockDomains( hDevice, pOverclockDomains );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -776,6 +1049,23 @@ zesDeviceGetOverclockControls(
                                                     ///< ::zes_overclock_control_t).
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDeviceGetOverclockControls_t pfnGetOverclockControls = [&result] {
+        auto pfnGetOverclockControls = ze_lib::context->zesDdiTable.load()->Device.pfnGetOverclockControls;
+        if( nullptr == pfnGetOverclockControls ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetOverclockControls;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetOverclockControls( hDevice, domainType, pAvailableControls );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -789,6 +1079,7 @@ zesDeviceGetOverclockControls(
     }
 
     return pfnGetOverclockControls( hDevice, domainType, pAvailableControls );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -816,6 +1107,23 @@ zesDeviceResetOverclockSettings(
                                                     ///< manufacturing state
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDeviceResetOverclockSettings_t pfnResetOverclockSettings = [&result] {
+        auto pfnResetOverclockSettings = ze_lib::context->zesDdiTable.load()->Device.pfnResetOverclockSettings;
+        if( nullptr == pfnResetOverclockSettings ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnResetOverclockSettings;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnResetOverclockSettings( hDevice, onShippedState );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -829,6 +1137,7 @@ zesDeviceResetOverclockSettings(
     }
 
     return pfnResetOverclockSettings( hDevice, onShippedState );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -865,6 +1174,23 @@ zesDeviceReadOverclockState(
     ze_bool_t* pPendingReset                        ///< [out] Pending reset 0 =manufacturing state, 1= shipped state)..
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDeviceReadOverclockState_t pfnReadOverclockState = [&result] {
+        auto pfnReadOverclockState = ze_lib::context->zesDdiTable.load()->Device.pfnReadOverclockState;
+        if( nullptr == pfnReadOverclockState ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnReadOverclockState;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnReadOverclockState( hDevice, pOverclockMode, pWaiverSetting, pOverclockState, pPendingAction, pPendingReset );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -878,6 +1204,7 @@ zesDeviceReadOverclockState(
     }
 
     return pfnReadOverclockState( hDevice, pOverclockMode, pWaiverSetting, pOverclockState, pPendingAction, pPendingReset );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -913,6 +1240,23 @@ zesDeviceEnumOverclockDomains(
                                                     ///< component handles.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDeviceEnumOverclockDomains_t pfnEnumOverclockDomains = [&result] {
+        auto pfnEnumOverclockDomains = ze_lib::context->zesDdiTable.load()->Device.pfnEnumOverclockDomains;
+        if( nullptr == pfnEnumOverclockDomains ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnEnumOverclockDomains;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnEnumOverclockDomains( hDevice, pCount, phDomainHandle );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -926,6 +1270,7 @@ zesDeviceEnumOverclockDomains(
     }
 
     return pfnEnumOverclockDomains( hDevice, pCount, phDomainHandle );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -953,6 +1298,23 @@ zesOverclockGetDomainProperties(
     zes_overclock_properties_t* pDomainProperties   ///< [in,out] The overclock properties for the specified domain.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnOverclockGetDomainProperties_t pfnGetDomainProperties = [&result] {
+        auto pfnGetDomainProperties = ze_lib::context->zesDdiTable.load()->Overclock.pfnGetDomainProperties;
+        if( nullptr == pfnGetDomainProperties ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetDomainProperties;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetDomainProperties( hDomainHandle, pDomainProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -966,6 +1328,7 @@ zesOverclockGetDomainProperties(
     }
 
     return pfnGetDomainProperties( hDomainHandle, pDomainProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -993,6 +1356,23 @@ zesOverclockGetDomainVFProperties(
     zes_vf_property_t* pVFProperties                ///< [in,out] The VF min,max,step for a specified domain.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnOverclockGetDomainVFProperties_t pfnGetDomainVFProperties = [&result] {
+        auto pfnGetDomainVFProperties = ze_lib::context->zesDdiTable.load()->Overclock.pfnGetDomainVFProperties;
+        if( nullptr == pfnGetDomainVFProperties ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetDomainVFProperties;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetDomainVFProperties( hDomainHandle, pVFProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1006,6 +1386,7 @@ zesOverclockGetDomainVFProperties(
     }
 
     return pfnGetDomainVFProperties( hDomainHandle, pVFProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1036,6 +1417,23 @@ zesOverclockGetDomainControlProperties(
     zes_control_property_t* pControlProperties      ///< [in,out] overclock control values.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnOverclockGetDomainControlProperties_t pfnGetDomainControlProperties = [&result] {
+        auto pfnGetDomainControlProperties = ze_lib::context->zesDdiTable.load()->Overclock.pfnGetDomainControlProperties;
+        if( nullptr == pfnGetDomainControlProperties ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetDomainControlProperties;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetDomainControlProperties( hDomainHandle, DomainControl, pControlProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1049,6 +1447,7 @@ zesOverclockGetDomainControlProperties(
     }
 
     return pfnGetDomainControlProperties( hDomainHandle, DomainControl, pControlProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1079,6 +1478,23 @@ zesOverclockGetControlCurrentValue(
     double* pValue                                  ///< [in,out] Getting overclock control value for the specified control.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnOverclockGetControlCurrentValue_t pfnGetControlCurrentValue = [&result] {
+        auto pfnGetControlCurrentValue = ze_lib::context->zesDdiTable.load()->Overclock.pfnGetControlCurrentValue;
+        if( nullptr == pfnGetControlCurrentValue ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetControlCurrentValue;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetControlCurrentValue( hDomainHandle, DomainControl, pValue );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1092,6 +1508,7 @@ zesOverclockGetControlCurrentValue(
     }
 
     return pfnGetControlCurrentValue( hDomainHandle, DomainControl, pValue );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1123,6 +1540,23 @@ zesOverclockGetControlPendingValue(
                                                     ///< format of the value depend on the control type.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnOverclockGetControlPendingValue_t pfnGetControlPendingValue = [&result] {
+        auto pfnGetControlPendingValue = ze_lib::context->zesDdiTable.load()->Overclock.pfnGetControlPendingValue;
+        if( nullptr == pfnGetControlPendingValue ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetControlPendingValue;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetControlPendingValue( hDomainHandle, DomainControl, pValue );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1136,6 +1570,7 @@ zesOverclockGetControlPendingValue(
     }
 
     return pfnGetControlPendingValue( hDomainHandle, DomainControl, pValue );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1168,6 +1603,23 @@ zesOverclockSetControlUserValue(
     zes_pending_action_t* pPendingAction            ///< [out] Pending overclock setting.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnOverclockSetControlUserValue_t pfnSetControlUserValue = [&result] {
+        auto pfnSetControlUserValue = ze_lib::context->zesDdiTable.load()->Overclock.pfnSetControlUserValue;
+        if( nullptr == pfnSetControlUserValue ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnSetControlUserValue;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnSetControlUserValue( hDomainHandle, DomainControl, pValue, pPendingAction );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1181,6 +1633,7 @@ zesOverclockSetControlUserValue(
     }
 
     return pfnSetControlUserValue( hDomainHandle, DomainControl, pValue, pPendingAction );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1213,6 +1666,23 @@ zesOverclockGetControlState(
     zes_pending_action_t* pPendingAction            ///< [out] Pending overclock setting.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnOverclockGetControlState_t pfnGetControlState = [&result] {
+        auto pfnGetControlState = ze_lib::context->zesDdiTable.load()->Overclock.pfnGetControlState;
+        if( nullptr == pfnGetControlState ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetControlState;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetControlState( hDomainHandle, DomainControl, pControlState, pPendingAction );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1226,6 +1696,7 @@ zesOverclockGetControlState(
     }
 
     return pfnGetControlState( hDomainHandle, DomainControl, pControlState, pPendingAction );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1261,6 +1732,23 @@ zesOverclockGetVFPointValues(
                                                     ///< units from the custom V-F curve at the specified zero-based index 
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnOverclockGetVFPointValues_t pfnGetVFPointValues = [&result] {
+        auto pfnGetVFPointValues = ze_lib::context->zesDdiTable.load()->Overclock.pfnGetVFPointValues;
+        if( nullptr == pfnGetVFPointValues ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetVFPointValues;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetVFPointValues( hDomainHandle, VFType, VFArrayType, PointIndex, PointValue );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1274,6 +1762,7 @@ zesOverclockGetVFPointValues(
     }
 
     return pfnGetVFPointValues( hDomainHandle, VFType, VFArrayType, PointIndex, PointValue );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1304,6 +1793,23 @@ zesOverclockSetVFPointValues(
                                                     ///< custom V-F curve at the specified zero-based index 
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnOverclockSetVFPointValues_t pfnSetVFPointValues = [&result] {
+        auto pfnSetVFPointValues = ze_lib::context->zesDdiTable.load()->Overclock.pfnSetVFPointValues;
+        if( nullptr == pfnSetVFPointValues ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnSetVFPointValues;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnSetVFPointValues( hDomainHandle, VFType, PointIndex, PointValue );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1317,6 +1823,7 @@ zesOverclockSetVFPointValues(
     }
 
     return pfnSetVFPointValues( hDomainHandle, VFType, PointIndex, PointValue );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1352,6 +1859,23 @@ zesDeviceEnumDiagnosticTestSuites(
                                                     ///< component handles.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDeviceEnumDiagnosticTestSuites_t pfnEnumDiagnosticTestSuites = [&result] {
+        auto pfnEnumDiagnosticTestSuites = ze_lib::context->zesDdiTable.load()->Device.pfnEnumDiagnosticTestSuites;
+        if( nullptr == pfnEnumDiagnosticTestSuites ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnEnumDiagnosticTestSuites;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnEnumDiagnosticTestSuites( hDevice, pCount, phDiagnostics );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1365,6 +1889,7 @@ zesDeviceEnumDiagnosticTestSuites(
     }
 
     return pfnEnumDiagnosticTestSuites( hDevice, pCount, phDiagnostics );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1391,6 +1916,23 @@ zesDiagnosticsGetProperties(
                                                     ///< suite
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDiagnosticsGetProperties_t pfnGetProperties = [&result] {
+        auto pfnGetProperties = ze_lib::context->zesDdiTable.load()->Diagnostics.pfnGetProperties;
+        if( nullptr == pfnGetProperties ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetProperties;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetProperties( hDiagnostics, pProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1404,6 +1946,7 @@ zesDiagnosticsGetProperties(
     }
 
     return pfnGetProperties( hDiagnostics, pProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1441,6 +1984,23 @@ zesDiagnosticsGetTests(
                                                     ///< driver shall only retrieve that number of tests.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDiagnosticsGetTests_t pfnGetTests = [&result] {
+        auto pfnGetTests = ze_lib::context->zesDdiTable.load()->Diagnostics.pfnGetTests;
+        if( nullptr == pfnGetTests ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetTests;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetTests( hDiagnostics, pCount, pTests );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1454,6 +2014,7 @@ zesDiagnosticsGetTests(
     }
 
     return pfnGetTests( hDiagnostics, pCount, pTests );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1494,6 +2055,23 @@ zesDiagnosticsRunTests(
     zes_diag_result_t* pResult                      ///< [in,out] The result of the diagnostics
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDiagnosticsRunTests_t pfnRunTests = [&result] {
+        auto pfnRunTests = ze_lib::context->zesDdiTable.load()->Diagnostics.pfnRunTests;
+        if( nullptr == pfnRunTests ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnRunTests;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnRunTests( hDiagnostics, startIndex, endIndex, pResult );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1507,6 +2085,7 @@ zesDiagnosticsRunTests(
     }
 
     return pfnRunTests( hDiagnostics, startIndex, endIndex, pResult );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1532,6 +2111,23 @@ zesDeviceEccAvailable(
     ze_bool_t* pAvailable                           ///< [out] ECC functionality is available (true)/unavailable (false).
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDeviceEccAvailable_t pfnEccAvailable = [&result] {
+        auto pfnEccAvailable = ze_lib::context->zesDdiTable.load()->Device.pfnEccAvailable;
+        if( nullptr == pfnEccAvailable ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnEccAvailable;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnEccAvailable( hDevice, pAvailable );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1545,6 +2141,7 @@ zesDeviceEccAvailable(
     }
 
     return pfnEccAvailable( hDevice, pAvailable );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1570,6 +2167,23 @@ zesDeviceEccConfigurable(
     ze_bool_t* pConfigurable                        ///< [out] ECC can be enabled/disabled (true)/enabled/disabled (false).
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDeviceEccConfigurable_t pfnEccConfigurable = [&result] {
+        auto pfnEccConfigurable = ze_lib::context->zesDdiTable.load()->Device.pfnEccConfigurable;
+        if( nullptr == pfnEccConfigurable ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnEccConfigurable;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnEccConfigurable( hDevice, pConfigurable );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1583,6 +2197,7 @@ zesDeviceEccConfigurable(
     }
 
     return pfnEccConfigurable( hDevice, pConfigurable );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1608,6 +2223,23 @@ zesDeviceGetEccState(
     zes_device_ecc_properties_t* pState             ///< [out] ECC state, pending state, and pending action for state change.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDeviceGetEccState_t pfnGetEccState = [&result] {
+        auto pfnGetEccState = ze_lib::context->zesDdiTable.load()->Device.pfnGetEccState;
+        if( nullptr == pfnGetEccState ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetEccState;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetEccState( hDevice, pState );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1621,6 +2253,7 @@ zesDeviceGetEccState(
     }
 
     return pfnGetEccState( hDevice, pState );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1654,6 +2287,23 @@ zesDeviceSetEccState(
     zes_device_ecc_properties_t* pState             ///< [out] ECC state, pending state, and pending action for state change.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDeviceSetEccState_t pfnSetEccState = [&result] {
+        auto pfnSetEccState = ze_lib::context->zesDdiTable.load()->Device.pfnSetEccState;
+        if( nullptr == pfnSetEccState ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnSetEccState;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnSetEccState( hDevice, newState, pState );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1667,6 +2317,7 @@ zesDeviceSetEccState(
     }
 
     return pfnSetEccState( hDevice, newState, pState );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1702,6 +2353,23 @@ zesDeviceEnumEngineGroups(
                                                     ///< component handles.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDeviceEnumEngineGroups_t pfnEnumEngineGroups = [&result] {
+        auto pfnEnumEngineGroups = ze_lib::context->zesDdiTable.load()->Device.pfnEnumEngineGroups;
+        if( nullptr == pfnEnumEngineGroups ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnEnumEngineGroups;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnEnumEngineGroups( hDevice, pCount, phEngine );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1715,6 +2383,7 @@ zesDeviceEnumEngineGroups(
     }
 
     return pfnEnumEngineGroups( hDevice, pCount, phEngine );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1740,6 +2409,23 @@ zesEngineGetProperties(
     zes_engine_properties_t* pProperties            ///< [in,out] The properties for the specified engine group.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnEngineGetProperties_t pfnGetProperties = [&result] {
+        auto pfnGetProperties = ze_lib::context->zesDdiTable.load()->Engine.pfnGetProperties;
+        if( nullptr == pfnGetProperties ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetProperties;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetProperties( hEngine, pProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1753,6 +2439,7 @@ zesEngineGetProperties(
     }
 
     return pfnGetProperties( hEngine, pProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1781,6 +2468,23 @@ zesEngineGetActivity(
                                                     ///< counters.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnEngineGetActivity_t pfnGetActivity = [&result] {
+        auto pfnGetActivity = ze_lib::context->zesDdiTable.load()->Engine.pfnGetActivity;
+        if( nullptr == pfnGetActivity ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetActivity;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetActivity( hEngine, pStats );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1794,6 +2498,7 @@ zesEngineGetActivity(
     }
 
     return pfnGetActivity( hEngine, pStats );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1819,6 +2524,23 @@ zesDeviceEventRegister(
     zes_event_type_flags_t events                   ///< [in] List of events to listen to.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDeviceEventRegister_t pfnEventRegister = [&result] {
+        auto pfnEventRegister = ze_lib::context->zesDdiTable.load()->Device.pfnEventRegister;
+        if( nullptr == pfnEventRegister ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnEventRegister;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnEventRegister( hDevice, events );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1832,6 +2554,7 @@ zesDeviceEventRegister(
     }
 
     return pfnEventRegister( hDevice, events );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1879,6 +2602,23 @@ zesDriverEventListen(
                                                     ///< entry will be zero.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDriverEventListen_t pfnEventListen = [&result] {
+        auto pfnEventListen = ze_lib::context->zesDdiTable.load()->Driver.pfnEventListen;
+        if( nullptr == pfnEventListen ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnEventListen;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnEventListen( hDriver, timeout, count, phDevices, pNumDeviceEvents, pEvents );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1892,6 +2632,7 @@ zesDriverEventListen(
     }
 
     return pfnEventListen( hDriver, timeout, count, phDevices, pNumDeviceEvents, pEvents );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1939,6 +2680,23 @@ zesDriverEventListenEx(
                                                     ///< entry will be zero.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDriverEventListenEx_t pfnEventListenEx = [&result] {
+        auto pfnEventListenEx = ze_lib::context->zesDdiTable.load()->Driver.pfnEventListenEx;
+        if( nullptr == pfnEventListenEx ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnEventListenEx;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnEventListenEx( hDriver, timeout, count, phDevices, pNumDeviceEvents, pEvents );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1952,6 +2710,7 @@ zesDriverEventListenEx(
     }
 
     return pfnEventListenEx( hDriver, timeout, count, phDevices, pNumDeviceEvents, pEvents );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1987,6 +2746,23 @@ zesDeviceEnumFabricPorts(
                                                     ///< component handles.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDeviceEnumFabricPorts_t pfnEnumFabricPorts = [&result] {
+        auto pfnEnumFabricPorts = ze_lib::context->zesDdiTable.load()->Device.pfnEnumFabricPorts;
+        if( nullptr == pfnEnumFabricPorts ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnEnumFabricPorts;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnEnumFabricPorts( hDevice, pCount, phPort );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2000,6 +2776,7 @@ zesDeviceEnumFabricPorts(
     }
 
     return pfnEnumFabricPorts( hDevice, pCount, phPort );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2025,6 +2802,23 @@ zesFabricPortGetProperties(
     zes_fabric_port_properties_t* pProperties       ///< [in,out] Will contain properties of the Fabric Port.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnFabricPortGetProperties_t pfnGetProperties = [&result] {
+        auto pfnGetProperties = ze_lib::context->zesDdiTable.load()->FabricPort.pfnGetProperties;
+        if( nullptr == pfnGetProperties ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetProperties;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetProperties( hPort, pProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2038,6 +2832,7 @@ zesFabricPortGetProperties(
     }
 
     return pfnGetProperties( hPort, pProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2064,6 +2859,23 @@ zesFabricPortGetLinkType(
                                                     ///< port.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnFabricPortGetLinkType_t pfnGetLinkType = [&result] {
+        auto pfnGetLinkType = ze_lib::context->zesDdiTable.load()->FabricPort.pfnGetLinkType;
+        if( nullptr == pfnGetLinkType ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetLinkType;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetLinkType( hPort, pLinkType );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2077,6 +2889,7 @@ zesFabricPortGetLinkType(
     }
 
     return pfnGetLinkType( hPort, pLinkType );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2102,6 +2915,23 @@ zesFabricPortGetConfig(
     zes_fabric_port_config_t* pConfig               ///< [in,out] Will contain configuration of the Fabric Port.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnFabricPortGetConfig_t pfnGetConfig = [&result] {
+        auto pfnGetConfig = ze_lib::context->zesDdiTable.load()->FabricPort.pfnGetConfig;
+        if( nullptr == pfnGetConfig ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetConfig;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetConfig( hPort, pConfig );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2115,6 +2945,7 @@ zesFabricPortGetConfig(
     }
 
     return pfnGetConfig( hPort, pConfig );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2142,6 +2973,23 @@ zesFabricPortSetConfig(
     const zes_fabric_port_config_t* pConfig         ///< [in] Contains new configuration of the Fabric Port.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnFabricPortSetConfig_t pfnSetConfig = [&result] {
+        auto pfnSetConfig = ze_lib::context->zesDdiTable.load()->FabricPort.pfnSetConfig;
+        if( nullptr == pfnSetConfig ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnSetConfig;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnSetConfig( hPort, pConfig );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2155,6 +3003,7 @@ zesFabricPortSetConfig(
     }
 
     return pfnSetConfig( hPort, pConfig );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2181,6 +3030,23 @@ zesFabricPortGetState(
     zes_fabric_port_state_t* pState                 ///< [in,out] Will contain the current state of the Fabric Port
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnFabricPortGetState_t pfnGetState = [&result] {
+        auto pfnGetState = ze_lib::context->zesDdiTable.load()->FabricPort.pfnGetState;
+        if( nullptr == pfnGetState ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetState;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetState( hPort, pState );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2194,6 +3060,7 @@ zesFabricPortGetState(
     }
 
     return pfnGetState( hPort, pState );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2221,6 +3088,23 @@ zesFabricPortGetThroughput(
     zes_fabric_port_throughput_t* pThroughput       ///< [in,out] Will contain the Fabric port throughput counters.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnFabricPortGetThroughput_t pfnGetThroughput = [&result] {
+        auto pfnGetThroughput = ze_lib::context->zesDdiTable.load()->FabricPort.pfnGetThroughput;
+        if( nullptr == pfnGetThroughput ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetThroughput;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetThroughput( hPort, pThroughput );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2234,6 +3118,7 @@ zesFabricPortGetThroughput(
     }
 
     return pfnGetThroughput( hPort, pThroughput );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2264,6 +3149,23 @@ zesFabricPortGetFabricErrorCounters(
     zes_fabric_port_error_counters_t* pErrors       ///< [in,out] Will contain the Fabric port Error counters.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnFabricPortGetFabricErrorCounters_t pfnGetFabricErrorCounters = [&result] {
+        auto pfnGetFabricErrorCounters = ze_lib::context->zesDdiTable.load()->FabricPort.pfnGetFabricErrorCounters;
+        if( nullptr == pfnGetFabricErrorCounters ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetFabricErrorCounters;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetFabricErrorCounters( hPort, pErrors );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2277,6 +3179,7 @@ zesFabricPortGetFabricErrorCounters(
     }
 
     return pfnGetFabricErrorCounters( hPort, pErrors );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2307,6 +3210,23 @@ zesFabricPortGetMultiPortThroughput(
                                                     ///< from multiple ports of type ::zes_fabric_port_throughput_t.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnFabricPortGetMultiPortThroughput_t pfnGetMultiPortThroughput = [&result] {
+        auto pfnGetMultiPortThroughput = ze_lib::context->zesDdiTable.load()->FabricPort.pfnGetMultiPortThroughput;
+        if( nullptr == pfnGetMultiPortThroughput ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetMultiPortThroughput;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetMultiPortThroughput( hDevice, numPorts, phPort, pThroughput );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2320,6 +3240,7 @@ zesFabricPortGetMultiPortThroughput(
     }
 
     return pfnGetMultiPortThroughput( hDevice, numPorts, phPort, pThroughput );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2355,6 +3276,23 @@ zesDeviceEnumFans(
                                                     ///< component handles.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDeviceEnumFans_t pfnEnumFans = [&result] {
+        auto pfnEnumFans = ze_lib::context->zesDdiTable.load()->Device.pfnEnumFans;
+        if( nullptr == pfnEnumFans ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnEnumFans;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnEnumFans( hDevice, pCount, phFan );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2368,6 +3306,7 @@ zesDeviceEnumFans(
     }
 
     return pfnEnumFans( hDevice, pCount, phFan );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2393,6 +3332,23 @@ zesFanGetProperties(
     zes_fan_properties_t* pProperties               ///< [in,out] Will contain the properties of the fan.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnFanGetProperties_t pfnGetProperties = [&result] {
+        auto pfnGetProperties = ze_lib::context->zesDdiTable.load()->Fan.pfnGetProperties;
+        if( nullptr == pfnGetProperties ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetProperties;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetProperties( hFan, pProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2406,6 +3362,7 @@ zesFanGetProperties(
     }
 
     return pfnGetProperties( hFan, pProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2432,6 +3389,23 @@ zesFanGetConfig(
     zes_fan_config_t* pConfig                       ///< [in,out] Will contain the current configuration of the fan.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnFanGetConfig_t pfnGetConfig = [&result] {
+        auto pfnGetConfig = ze_lib::context->zesDdiTable.load()->Fan.pfnGetConfig;
+        if( nullptr == pfnGetConfig ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetConfig;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetConfig( hFan, pConfig );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2445,6 +3419,7 @@ zesFanGetConfig(
     }
 
     return pfnGetConfig( hFan, pConfig );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2470,6 +3445,23 @@ zesFanSetDefaultMode(
     zes_fan_handle_t hFan                           ///< [in] Handle for the component.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnFanSetDefaultMode_t pfnSetDefaultMode = [&result] {
+        auto pfnSetDefaultMode = ze_lib::context->zesDdiTable.load()->Fan.pfnSetDefaultMode;
+        if( nullptr == pfnSetDefaultMode ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnSetDefaultMode;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnSetDefaultMode( hFan );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2483,6 +3475,7 @@ zesFanSetDefaultMode(
     }
 
     return pfnSetDefaultMode( hFan );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2513,6 +3506,23 @@ zesFanSetFixedSpeedMode(
     const zes_fan_speed_t* speed                    ///< [in] The fixed fan speed setting
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnFanSetFixedSpeedMode_t pfnSetFixedSpeedMode = [&result] {
+        auto pfnSetFixedSpeedMode = ze_lib::context->zesDdiTable.load()->Fan.pfnSetFixedSpeedMode;
+        if( nullptr == pfnSetFixedSpeedMode ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnSetFixedSpeedMode;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnSetFixedSpeedMode( hFan, speed );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2526,6 +3536,7 @@ zesFanSetFixedSpeedMode(
     }
 
     return pfnSetFixedSpeedMode( hFan, speed );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2558,6 +3569,23 @@ zesFanSetSpeedTableMode(
     const zes_fan_speed_table_t* speedTable         ///< [in] A table containing temperature/speed pairs.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnFanSetSpeedTableMode_t pfnSetSpeedTableMode = [&result] {
+        auto pfnSetSpeedTableMode = ze_lib::context->zesDdiTable.load()->Fan.pfnSetSpeedTableMode;
+        if( nullptr == pfnSetSpeedTableMode ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnSetSpeedTableMode;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnSetSpeedTableMode( hFan, speedTable );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2571,6 +3599,7 @@ zesFanSetSpeedTableMode(
     }
 
     return pfnSetSpeedTableMode( hFan, speedTable );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2603,6 +3632,23 @@ zesFanGetState(
                                                     ///< measured.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnFanGetState_t pfnGetState = [&result] {
+        auto pfnGetState = ze_lib::context->zesDdiTable.load()->Fan.pfnGetState;
+        if( nullptr == pfnGetState ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetState;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetState( hFan, units, pSpeed );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2616,6 +3662,7 @@ zesFanGetState(
     }
 
     return pfnGetState( hFan, units, pSpeed );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2651,6 +3698,23 @@ zesDeviceEnumFirmwares(
                                                     ///< component handles.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDeviceEnumFirmwares_t pfnEnumFirmwares = [&result] {
+        auto pfnEnumFirmwares = ze_lib::context->zesDdiTable.load()->Device.pfnEnumFirmwares;
+        if( nullptr == pfnEnumFirmwares ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnEnumFirmwares;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnEnumFirmwares( hDevice, pCount, phFirmware );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2664,6 +3728,7 @@ zesDeviceEnumFirmwares(
     }
 
     return pfnEnumFirmwares( hDevice, pCount, phFirmware );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2690,6 +3755,23 @@ zesFirmwareGetProperties(
                                                     ///< firmware
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnFirmwareGetProperties_t pfnGetProperties = [&result] {
+        auto pfnGetProperties = ze_lib::context->zesDdiTable.load()->Firmware.pfnGetProperties;
+        if( nullptr == pfnGetProperties ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetProperties;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetProperties( hFirmware, pProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2703,6 +3785,7 @@ zesFirmwareGetProperties(
     }
 
     return pfnGetProperties( hFirmware, pProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2735,6 +3818,23 @@ zesFirmwareFlash(
     uint32_t size                                   ///< [in] Size of the flash image.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnFirmwareFlash_t pfnFlash = [&result] {
+        auto pfnFlash = ze_lib::context->zesDdiTable.load()->Firmware.pfnFlash;
+        if( nullptr == pfnFlash ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnFlash;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnFlash( hFirmware, pImage, size );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2748,6 +3848,7 @@ zesFirmwareFlash(
     }
 
     return pfnFlash( hFirmware, pImage, size );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2773,6 +3874,23 @@ zesFirmwareGetFlashProgress(
     uint32_t* pCompletionPercent                    ///< [in,out] Pointer to the Completion Percentage of Firmware Update
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnFirmwareGetFlashProgress_t pfnGetFlashProgress = [&result] {
+        auto pfnGetFlashProgress = ze_lib::context->zesDdiTable.load()->Firmware.pfnGetFlashProgress;
+        if( nullptr == pfnGetFlashProgress ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetFlashProgress;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetFlashProgress( hFirmware, pCompletionPercent );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2786,6 +3904,7 @@ zesFirmwareGetFlashProgress(
     }
 
     return pfnGetFlashProgress( hFirmware, pCompletionPercent );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2815,6 +3934,23 @@ zesFirmwareGetConsoleLogs(
     char* pFirmwareLog                              ///< [in,out][optional] pointer to null-terminated string of the log.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnFirmwareGetConsoleLogs_t pfnGetConsoleLogs = [&result] {
+        auto pfnGetConsoleLogs = ze_lib::context->zesDdiTable.load()->Firmware.pfnGetConsoleLogs;
+        if( nullptr == pfnGetConsoleLogs ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetConsoleLogs;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetConsoleLogs( hFirmware, pSize, pFirmwareLog );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2828,6 +3964,7 @@ zesFirmwareGetConsoleLogs(
     }
 
     return pfnGetConsoleLogs( hFirmware, pSize, pFirmwareLog );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2863,6 +4000,23 @@ zesDeviceEnumFrequencyDomains(
                                                     ///< component handles.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDeviceEnumFrequencyDomains_t pfnEnumFrequencyDomains = [&result] {
+        auto pfnEnumFrequencyDomains = ze_lib::context->zesDdiTable.load()->Device.pfnEnumFrequencyDomains;
+        if( nullptr == pfnEnumFrequencyDomains ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnEnumFrequencyDomains;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnEnumFrequencyDomains( hDevice, pCount, phFrequency );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2876,6 +4030,7 @@ zesDeviceEnumFrequencyDomains(
     }
 
     return pfnEnumFrequencyDomains( hDevice, pCount, phFrequency );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2901,6 +4056,23 @@ zesFrequencyGetProperties(
     zes_freq_properties_t* pProperties              ///< [in,out] The frequency properties for the specified domain.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnFrequencyGetProperties_t pfnGetProperties = [&result] {
+        auto pfnGetProperties = ze_lib::context->zesDdiTable.load()->Frequency.pfnGetProperties;
+        if( nullptr == pfnGetProperties ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetProperties;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetProperties( hFrequency, pProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2914,6 +4086,7 @@ zesFrequencyGetProperties(
     }
 
     return pfnGetProperties( hFrequency, pProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2950,6 +4123,23 @@ zesFrequencyGetAvailableClocks(
                                                     ///< then the driver shall only retrieve that number of frequencies.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnFrequencyGetAvailableClocks_t pfnGetAvailableClocks = [&result] {
+        auto pfnGetAvailableClocks = ze_lib::context->zesDdiTable.load()->Frequency.pfnGetAvailableClocks;
+        if( nullptr == pfnGetAvailableClocks ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetAvailableClocks;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetAvailableClocks( hFrequency, pCount, phFrequency );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2963,6 +4153,7 @@ zesFrequencyGetAvailableClocks(
     }
 
     return pfnGetAvailableClocks( hFrequency, pCount, phFrequency );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2989,6 +4180,23 @@ zesFrequencyGetRange(
                                                     ///< specified domain.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnFrequencyGetRange_t pfnGetRange = [&result] {
+        auto pfnGetRange = ze_lib::context->zesDdiTable.load()->Frequency.pfnGetRange;
+        if( nullptr == pfnGetRange ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetRange;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetRange( hFrequency, pLimits );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3002,6 +4210,7 @@ zesFrequencyGetRange(
     }
 
     return pfnGetRange( hFrequency, pLimits );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3033,6 +4242,23 @@ zesFrequencySetRange(
                                                     ///< specified domain.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnFrequencySetRange_t pfnSetRange = [&result] {
+        auto pfnSetRange = ze_lib::context->zesDdiTable.load()->Frequency.pfnSetRange;
+        if( nullptr == pfnSetRange ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnSetRange;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnSetRange( hFrequency, pLimits );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3046,6 +4272,7 @@ zesFrequencySetRange(
     }
 
     return pfnSetRange( hFrequency, pLimits );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3072,6 +4299,23 @@ zesFrequencyGetState(
     zes_freq_state_t* pState                        ///< [in,out] Frequency state for the specified domain.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnFrequencyGetState_t pfnGetState = [&result] {
+        auto pfnGetState = ze_lib::context->zesDdiTable.load()->Frequency.pfnGetState;
+        if( nullptr == pfnGetState ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetState;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetState( hFrequency, pState );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3085,6 +4329,7 @@ zesFrequencyGetState(
     }
 
     return pfnGetState( hFrequency, pState );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3111,6 +4356,23 @@ zesFrequencyGetThrottleTime(
                                                     ///< specified domain.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnFrequencyGetThrottleTime_t pfnGetThrottleTime = [&result] {
+        auto pfnGetThrottleTime = ze_lib::context->zesDdiTable.load()->Frequency.pfnGetThrottleTime;
+        if( nullptr == pfnGetThrottleTime ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetThrottleTime;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetThrottleTime( hFrequency, pThrottleTime );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3124,6 +4386,7 @@ zesFrequencyGetThrottleTime(
     }
 
     return pfnGetThrottleTime( hFrequency, pThrottleTime );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3150,6 +4413,23 @@ zesFrequencyOcGetCapabilities(
     zes_oc_capabilities_t* pOcCapabilities          ///< [in,out] Pointer to the capabilities structure.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnFrequencyOcGetCapabilities_t pfnOcGetCapabilities = [&result] {
+        auto pfnOcGetCapabilities = ze_lib::context->zesDdiTable.load()->Frequency.pfnOcGetCapabilities;
+        if( nullptr == pfnOcGetCapabilities ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnOcGetCapabilities;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnOcGetCapabilities( hFrequency, pOcCapabilities );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3163,6 +4443,7 @@ zesFrequencyOcGetCapabilities(
     }
 
     return pfnOcGetCapabilities( hFrequency, pOcCapabilities );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3201,6 +4482,23 @@ zesFrequencyOcGetFrequencyTarget(
                                                     ///< ::zes_oc_capabilities_t.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnFrequencyOcGetFrequencyTarget_t pfnOcGetFrequencyTarget = [&result] {
+        auto pfnOcGetFrequencyTarget = ze_lib::context->zesDdiTable.load()->Frequency.pfnOcGetFrequencyTarget;
+        if( nullptr == pfnOcGetFrequencyTarget ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnOcGetFrequencyTarget;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnOcGetFrequencyTarget( hFrequency, pCurrentOcFrequency );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3214,6 +4512,7 @@ zesFrequencyOcGetFrequencyTarget(
     }
 
     return pfnOcGetFrequencyTarget( hFrequency, pCurrentOcFrequency );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3250,6 +4549,23 @@ zesFrequencyOcSetFrequencyTarget(
                                                     ///< ::zes_oc_capabilities_t.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnFrequencyOcSetFrequencyTarget_t pfnOcSetFrequencyTarget = [&result] {
+        auto pfnOcSetFrequencyTarget = ze_lib::context->zesDdiTable.load()->Frequency.pfnOcSetFrequencyTarget;
+        if( nullptr == pfnOcSetFrequencyTarget ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnOcSetFrequencyTarget;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnOcSetFrequencyTarget( hFrequency, CurrentOcFrequency );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3263,6 +4579,7 @@ zesFrequencyOcSetFrequencyTarget(
     }
 
     return pfnOcSetFrequencyTarget( hFrequency, CurrentOcFrequency );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3303,6 +4620,23 @@ zesFrequencyOcGetVoltageTarget(
                                                     ///< `maxOcVoltageOffset` members of ::zes_oc_capabilities_t.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnFrequencyOcGetVoltageTarget_t pfnOcGetVoltageTarget = [&result] {
+        auto pfnOcGetVoltageTarget = ze_lib::context->zesDdiTable.load()->Frequency.pfnOcGetVoltageTarget;
+        if( nullptr == pfnOcGetVoltageTarget ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnOcGetVoltageTarget;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnOcGetVoltageTarget( hFrequency, pCurrentVoltageTarget, pCurrentVoltageOffset );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3316,6 +4650,7 @@ zesFrequencyOcGetVoltageTarget(
     }
 
     return pfnOcGetVoltageTarget( hFrequency, pCurrentVoltageTarget, pCurrentVoltageOffset );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3353,6 +4688,23 @@ zesFrequencyOcSetVoltageTarget(
                                                     ///< `maxOcVoltageOffset` members of ::zes_oc_capabilities_t.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnFrequencyOcSetVoltageTarget_t pfnOcSetVoltageTarget = [&result] {
+        auto pfnOcSetVoltageTarget = ze_lib::context->zesDdiTable.load()->Frequency.pfnOcSetVoltageTarget;
+        if( nullptr == pfnOcSetVoltageTarget ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnOcSetVoltageTarget;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnOcSetVoltageTarget( hFrequency, CurrentVoltageTarget, CurrentVoltageOffset );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3366,6 +4718,7 @@ zesFrequencyOcSetVoltageTarget(
     }
 
     return pfnOcSetVoltageTarget( hFrequency, CurrentVoltageTarget, CurrentVoltageOffset );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3400,6 +4753,23 @@ zesFrequencyOcSetMode(
     zes_oc_mode_t CurrentOcMode                     ///< [in] Current Overclocking Mode ::zes_oc_mode_t.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnFrequencyOcSetMode_t pfnOcSetMode = [&result] {
+        auto pfnOcSetMode = ze_lib::context->zesDdiTable.load()->Frequency.pfnOcSetMode;
+        if( nullptr == pfnOcSetMode ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnOcSetMode;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnOcSetMode( hFrequency, CurrentOcMode );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3413,6 +4783,7 @@ zesFrequencyOcSetMode(
     }
 
     return pfnOcSetMode( hFrequency, CurrentOcMode );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3447,6 +4818,23 @@ zesFrequencyOcGetMode(
     zes_oc_mode_t* pCurrentOcMode                   ///< [out] Current Overclocking Mode ::zes_oc_mode_t.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnFrequencyOcGetMode_t pfnOcGetMode = [&result] {
+        auto pfnOcGetMode = ze_lib::context->zesDdiTable.load()->Frequency.pfnOcGetMode;
+        if( nullptr == pfnOcGetMode ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnOcGetMode;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnOcGetMode( hFrequency, pCurrentOcMode );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3460,6 +4848,7 @@ zesFrequencyOcGetMode(
     }
 
     return pfnOcGetMode( hFrequency, pCurrentOcMode );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3490,6 +4879,23 @@ zesFrequencyOcGetIccMax(
                                                     ///< successful return.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnFrequencyOcGetIccMax_t pfnOcGetIccMax = [&result] {
+        auto pfnOcGetIccMax = ze_lib::context->zesDdiTable.load()->Frequency.pfnOcGetIccMax;
+        if( nullptr == pfnOcGetIccMax ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnOcGetIccMax;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnOcGetIccMax( hFrequency, pOcIccMax );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3503,6 +4909,7 @@ zesFrequencyOcGetIccMax(
     }
 
     return pfnOcGetIccMax( hFrequency, pOcIccMax );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3537,6 +4944,23 @@ zesFrequencyOcSetIccMax(
     double ocIccMax                                 ///< [in] The new maximum current limit in Amperes.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnFrequencyOcSetIccMax_t pfnOcSetIccMax = [&result] {
+        auto pfnOcSetIccMax = ze_lib::context->zesDdiTable.load()->Frequency.pfnOcSetIccMax;
+        if( nullptr == pfnOcSetIccMax ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnOcSetIccMax;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnOcSetIccMax( hFrequency, ocIccMax );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3550,6 +4974,7 @@ zesFrequencyOcSetIccMax(
     }
 
     return pfnOcSetIccMax( hFrequency, ocIccMax );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3579,6 +5004,23 @@ zesFrequencyOcGetTjMax(
                                                     ///< on successful return.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnFrequencyOcGetTjMax_t pfnOcGetTjMax = [&result] {
+        auto pfnOcGetTjMax = ze_lib::context->zesDdiTable.load()->Frequency.pfnOcGetTjMax;
+        if( nullptr == pfnOcGetTjMax ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnOcGetTjMax;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnOcGetTjMax( hFrequency, pOcTjMax );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3592,6 +5034,7 @@ zesFrequencyOcGetTjMax(
     }
 
     return pfnOcGetTjMax( hFrequency, pOcTjMax );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3626,6 +5069,23 @@ zesFrequencyOcSetTjMax(
     double ocTjMax                                  ///< [in] The new maximum temperature limit in degrees Celsius.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnFrequencyOcSetTjMax_t pfnOcSetTjMax = [&result] {
+        auto pfnOcSetTjMax = ze_lib::context->zesDdiTable.load()->Frequency.pfnOcSetTjMax;
+        if( nullptr == pfnOcSetTjMax ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnOcSetTjMax;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnOcSetTjMax( hFrequency, ocTjMax );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3639,6 +5099,7 @@ zesFrequencyOcSetTjMax(
     }
 
     return pfnOcSetTjMax( hFrequency, ocTjMax );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3674,6 +5135,23 @@ zesDeviceEnumLeds(
                                                     ///< component handles.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDeviceEnumLeds_t pfnEnumLeds = [&result] {
+        auto pfnEnumLeds = ze_lib::context->zesDdiTable.load()->Device.pfnEnumLeds;
+        if( nullptr == pfnEnumLeds ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnEnumLeds;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnEnumLeds( hDevice, pCount, phLed );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3687,6 +5165,7 @@ zesDeviceEnumLeds(
     }
 
     return pfnEnumLeds( hDevice, pCount, phLed );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3712,6 +5191,23 @@ zesLedGetProperties(
     zes_led_properties_t* pProperties               ///< [in,out] Will contain the properties of the LED.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnLedGetProperties_t pfnGetProperties = [&result] {
+        auto pfnGetProperties = ze_lib::context->zesDdiTable.load()->Led.pfnGetProperties;
+        if( nullptr == pfnGetProperties ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetProperties;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetProperties( hLed, pProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3725,6 +5221,7 @@ zesLedGetProperties(
     }
 
     return pfnGetProperties( hLed, pProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3750,6 +5247,23 @@ zesLedGetState(
     zes_led_state_t* pState                         ///< [in,out] Will contain the current state of the LED.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnLedGetState_t pfnGetState = [&result] {
+        auto pfnGetState = ze_lib::context->zesDdiTable.load()->Led.pfnGetState;
+        if( nullptr == pfnGetState ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetState;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetState( hLed, pState );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3763,6 +5277,7 @@ zesLedGetState(
     }
 
     return pfnGetState( hLed, pState );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3788,6 +5303,23 @@ zesLedSetState(
     ze_bool_t enable                                ///< [in] Set to TRUE to turn the LED on, FALSE to turn off.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnLedSetState_t pfnSetState = [&result] {
+        auto pfnSetState = ze_lib::context->zesDdiTable.load()->Led.pfnSetState;
+        if( nullptr == pfnSetState ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnSetState;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnSetState( hLed, enable );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3801,6 +5333,7 @@ zesLedSetState(
     }
 
     return pfnSetState( hLed, enable );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3830,6 +5363,23 @@ zesLedSetColor(
     const zes_led_color_t* pColor                   ///< [in] New color of the LED.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnLedSetColor_t pfnSetColor = [&result] {
+        auto pfnSetColor = ze_lib::context->zesDdiTable.load()->Led.pfnSetColor;
+        if( nullptr == pfnSetColor ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnSetColor;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnSetColor( hLed, pColor );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3843,6 +5393,7 @@ zesLedSetColor(
     }
 
     return pfnSetColor( hLed, pColor );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3878,6 +5429,23 @@ zesDeviceEnumMemoryModules(
                                                     ///< component handles.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDeviceEnumMemoryModules_t pfnEnumMemoryModules = [&result] {
+        auto pfnEnumMemoryModules = ze_lib::context->zesDdiTable.load()->Device.pfnEnumMemoryModules;
+        if( nullptr == pfnEnumMemoryModules ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnEnumMemoryModules;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnEnumMemoryModules( hDevice, pCount, phMemory );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3891,6 +5459,7 @@ zesDeviceEnumMemoryModules(
     }
 
     return pfnEnumMemoryModules( hDevice, pCount, phMemory );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3916,6 +5485,23 @@ zesMemoryGetProperties(
     zes_mem_properties_t* pProperties               ///< [in,out] Will contain memory properties.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnMemoryGetProperties_t pfnGetProperties = [&result] {
+        auto pfnGetProperties = ze_lib::context->zesDdiTable.load()->Memory.pfnGetProperties;
+        if( nullptr == pfnGetProperties ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetProperties;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetProperties( hMemory, pProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3929,6 +5515,7 @@ zesMemoryGetProperties(
     }
 
     return pfnGetProperties( hMemory, pProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3954,6 +5541,23 @@ zesMemoryGetState(
     zes_mem_state_t* pState                         ///< [in,out] Will contain the current health and allocated memory.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnMemoryGetState_t pfnGetState = [&result] {
+        auto pfnGetState = ze_lib::context->zesDdiTable.load()->Memory.pfnGetState;
+        if( nullptr == pfnGetState ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetState;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetState( hMemory, pState );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3967,6 +5571,7 @@ zesMemoryGetState(
     }
 
     return pfnGetState( hMemory, pState );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3995,6 +5600,23 @@ zesMemoryGetBandwidth(
                                                     ///< to memory, as well as the current maximum bandwidth.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnMemoryGetBandwidth_t pfnGetBandwidth = [&result] {
+        auto pfnGetBandwidth = ze_lib::context->zesDdiTable.load()->Memory.pfnGetBandwidth;
+        if( nullptr == pfnGetBandwidth ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetBandwidth;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetBandwidth( hMemory, pBandwidth );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4008,6 +5630,7 @@ zesMemoryGetBandwidth(
     }
 
     return pfnGetBandwidth( hMemory, pBandwidth );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4045,6 +5668,23 @@ zesDeviceEnumPerformanceFactorDomains(
                                                     ///< component handles.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDeviceEnumPerformanceFactorDomains_t pfnEnumPerformanceFactorDomains = [&result] {
+        auto pfnEnumPerformanceFactorDomains = ze_lib::context->zesDdiTable.load()->Device.pfnEnumPerformanceFactorDomains;
+        if( nullptr == pfnEnumPerformanceFactorDomains ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnEnumPerformanceFactorDomains;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnEnumPerformanceFactorDomains( hDevice, pCount, phPerf );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4058,6 +5698,7 @@ zesDeviceEnumPerformanceFactorDomains(
     }
 
     return pfnEnumPerformanceFactorDomains( hDevice, pCount, phPerf );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4084,6 +5725,23 @@ zesPerformanceFactorGetProperties(
                                                     ///< Factor domain.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnPerformanceFactorGetProperties_t pfnGetProperties = [&result] {
+        auto pfnGetProperties = ze_lib::context->zesDdiTable.load()->PerformanceFactor.pfnGetProperties;
+        if( nullptr == pfnGetProperties ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetProperties;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetProperties( hPerf, pProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4097,6 +5755,7 @@ zesPerformanceFactorGetProperties(
     }
 
     return pfnGetProperties( hPerf, pProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4123,6 +5782,23 @@ zesPerformanceFactorGetConfig(
                                                     ///< hardware (may not be the same as the requested Performance Factor).
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnPerformanceFactorGetConfig_t pfnGetConfig = [&result] {
+        auto pfnGetConfig = ze_lib::context->zesDdiTable.load()->PerformanceFactor.pfnGetConfig;
+        if( nullptr == pfnGetConfig ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetConfig;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetConfig( hPerf, pFactor );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4136,6 +5812,7 @@ zesPerformanceFactorGetConfig(
     }
 
     return pfnGetConfig( hPerf, pFactor );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4164,6 +5841,23 @@ zesPerformanceFactorSetConfig(
     double factor                                   ///< [in] The new Performance Factor.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnPerformanceFactorSetConfig_t pfnSetConfig = [&result] {
+        auto pfnSetConfig = ze_lib::context->zesDdiTable.load()->PerformanceFactor.pfnSetConfig;
+        if( nullptr == pfnSetConfig ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnSetConfig;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnSetConfig( hPerf, factor );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4177,6 +5871,7 @@ zesPerformanceFactorSetConfig(
     }
 
     return pfnSetConfig( hPerf, factor );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4212,6 +5907,23 @@ zesDeviceEnumPowerDomains(
                                                     ///< component handles.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDeviceEnumPowerDomains_t pfnEnumPowerDomains = [&result] {
+        auto pfnEnumPowerDomains = ze_lib::context->zesDdiTable.load()->Device.pfnEnumPowerDomains;
+        if( nullptr == pfnEnumPowerDomains ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnEnumPowerDomains;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnEnumPowerDomains( hDevice, pCount, phPower );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4225,6 +5937,7 @@ zesDeviceEnumPowerDomains(
     }
 
     return pfnEnumPowerDomains( hDevice, pCount, phPower );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4253,6 +5966,23 @@ zesDeviceGetCardPowerDomain(
     zes_pwr_handle_t* phPower                       ///< [in,out] power domain handle for the entire PCIe card.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDeviceGetCardPowerDomain_t pfnGetCardPowerDomain = [&result] {
+        auto pfnGetCardPowerDomain = ze_lib::context->zesDdiTable.load()->Device.pfnGetCardPowerDomain;
+        if( nullptr == pfnGetCardPowerDomain ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetCardPowerDomain;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetCardPowerDomain( hDevice, phPower );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4266,6 +5996,7 @@ zesDeviceGetCardPowerDomain(
     }
 
     return pfnGetCardPowerDomain( hDevice, phPower );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4291,6 +6022,23 @@ zesPowerGetProperties(
     zes_power_properties_t* pProperties             ///< [in,out] Structure that will contain property data.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnPowerGetProperties_t pfnGetProperties = [&result] {
+        auto pfnGetProperties = ze_lib::context->zesDdiTable.load()->Power.pfnGetProperties;
+        if( nullptr == pfnGetProperties ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetProperties;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetProperties( hPower, pProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4304,6 +6052,7 @@ zesPowerGetProperties(
     }
 
     return pfnGetProperties( hPower, pProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4330,6 +6079,23 @@ zesPowerGetEnergyCounter(
                                                     ///< timestamp when the last counter value was measured.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnPowerGetEnergyCounter_t pfnGetEnergyCounter = [&result] {
+        auto pfnGetEnergyCounter = ze_lib::context->zesDdiTable.load()->Power.pfnGetEnergyCounter;
+        if( nullptr == pfnGetEnergyCounter ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetEnergyCounter;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetEnergyCounter( hPower, pEnergy );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4343,6 +6109,7 @@ zesPowerGetEnergyCounter(
     }
 
     return pfnGetEnergyCounter( hPower, pEnergy );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4372,6 +6139,23 @@ zesPowerGetLimits(
                                                     ///< power limits will not be returned.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnPowerGetLimits_t pfnGetLimits = [&result] {
+        auto pfnGetLimits = ze_lib::context->zesDdiTable.load()->Power.pfnGetLimits;
+        if( nullptr == pfnGetLimits ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetLimits;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetLimits( hPower, pSustained, pBurst, pPeak );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4385,6 +6169,7 @@ zesPowerGetLimits(
     }
 
     return pfnGetLimits( hPower, pSustained, pBurst, pPeak );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4418,6 +6203,23 @@ zesPowerSetLimits(
                                                     ///< be made to the peak power limits.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnPowerSetLimits_t pfnSetLimits = [&result] {
+        auto pfnSetLimits = ze_lib::context->zesDdiTable.load()->Power.pfnSetLimits;
+        if( nullptr == pfnSetLimits ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnSetLimits;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnSetLimits( hPower, pSustained, pBurst, pPeak );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4431,6 +6233,7 @@ zesPowerSetLimits(
     }
 
     return pfnSetLimits( hPower, pSustained, pBurst, pPeak );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4461,6 +6264,23 @@ zesPowerGetEnergyThreshold(
                                                     ///< enabled/energy threshold/process ID.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnPowerGetEnergyThreshold_t pfnGetEnergyThreshold = [&result] {
+        auto pfnGetEnergyThreshold = ze_lib::context->zesDdiTable.load()->Power.pfnGetEnergyThreshold;
+        if( nullptr == pfnGetEnergyThreshold ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetEnergyThreshold;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetEnergyThreshold( hPower, pThreshold );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4474,6 +6294,7 @@ zesPowerGetEnergyThreshold(
     }
 
     return pfnGetEnergyThreshold( hPower, pThreshold );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4517,6 +6338,23 @@ zesPowerSetEnergyThreshold(
     double threshold                                ///< [in] The energy threshold to be set in joules.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnPowerSetEnergyThreshold_t pfnSetEnergyThreshold = [&result] {
+        auto pfnSetEnergyThreshold = ze_lib::context->zesDdiTable.load()->Power.pfnSetEnergyThreshold;
+        if( nullptr == pfnSetEnergyThreshold ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnSetEnergyThreshold;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnSetEnergyThreshold( hPower, threshold );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4530,6 +6368,7 @@ zesPowerSetEnergyThreshold(
     }
 
     return pfnSetEnergyThreshold( hPower, threshold );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4565,6 +6404,23 @@ zesDeviceEnumPsus(
                                                     ///< component handles.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDeviceEnumPsus_t pfnEnumPsus = [&result] {
+        auto pfnEnumPsus = ze_lib::context->zesDdiTable.load()->Device.pfnEnumPsus;
+        if( nullptr == pfnEnumPsus ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnEnumPsus;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnEnumPsus( hDevice, pCount, phPsu );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4578,6 +6434,7 @@ zesDeviceEnumPsus(
     }
 
     return pfnEnumPsus( hDevice, pCount, phPsu );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4603,6 +6460,23 @@ zesPsuGetProperties(
     zes_psu_properties_t* pProperties               ///< [in,out] Will contain the properties of the power supply.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnPsuGetProperties_t pfnGetProperties = [&result] {
+        auto pfnGetProperties = ze_lib::context->zesDdiTable.load()->Psu.pfnGetProperties;
+        if( nullptr == pfnGetProperties ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetProperties;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetProperties( hPsu, pProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4616,6 +6490,7 @@ zesPsuGetProperties(
     }
 
     return pfnGetProperties( hPsu, pProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4641,6 +6516,23 @@ zesPsuGetState(
     zes_psu_state_t* pState                         ///< [in,out] Will contain the current state of the power supply.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnPsuGetState_t pfnGetState = [&result] {
+        auto pfnGetState = ze_lib::context->zesDdiTable.load()->Psu.pfnGetState;
+        if( nullptr == pfnGetState ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetState;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetState( hPsu, pState );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4654,6 +6546,7 @@ zesPsuGetState(
     }
 
     return pfnGetState( hPsu, pState );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4699,6 +6592,23 @@ zesDeviceEnumRasErrorSets(
                                                     ///< component handles.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDeviceEnumRasErrorSets_t pfnEnumRasErrorSets = [&result] {
+        auto pfnEnumRasErrorSets = ze_lib::context->zesDdiTable.load()->Device.pfnEnumRasErrorSets;
+        if( nullptr == pfnEnumRasErrorSets ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnEnumRasErrorSets;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnEnumRasErrorSets( hDevice, pCount, phRas );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4712,6 +6622,7 @@ zesDeviceEnumRasErrorSets(
     }
 
     return pfnEnumRasErrorSets( hDevice, pCount, phRas );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4739,6 +6650,23 @@ zesRasGetProperties(
     zes_ras_properties_t* pProperties               ///< [in,out] Structure describing RAS properties
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnRasGetProperties_t pfnGetProperties = [&result] {
+        auto pfnGetProperties = ze_lib::context->zesDdiTable.load()->Ras.pfnGetProperties;
+        if( nullptr == pfnGetProperties ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetProperties;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetProperties( hRas, pProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4752,6 +6680,7 @@ zesRasGetProperties(
     }
 
     return pfnGetProperties( hRas, pProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4787,6 +6716,23 @@ zesRasGetConfig(
                                                     ///< thresholds used to trigger events
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnRasGetConfig_t pfnGetConfig = [&result] {
+        auto pfnGetConfig = ze_lib::context->zesDdiTable.load()->Ras.pfnGetConfig;
+        if( nullptr == pfnGetConfig ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetConfig;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetConfig( hRas, pConfig );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4800,6 +6746,7 @@ zesRasGetConfig(
     }
 
     return pfnGetConfig( hRas, pConfig );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4840,6 +6787,23 @@ zesRasSetConfig(
     const zes_ras_config_t* pConfig                 ///< [in] Change the RAS configuration - thresholds used to trigger events
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnRasSetConfig_t pfnSetConfig = [&result] {
+        auto pfnSetConfig = ze_lib::context->zesDdiTable.load()->Ras.pfnSetConfig;
+        if( nullptr == pfnSetConfig ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnSetConfig;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnSetConfig( hRas, pConfig );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4853,6 +6817,7 @@ zesRasSetConfig(
     }
 
     return pfnSetConfig( hRas, pConfig );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4884,6 +6849,23 @@ zesRasGetState(
     zes_ras_state_t* pState                         ///< [in,out] Breakdown of where errors have occurred
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnRasGetState_t pfnGetState = [&result] {
+        auto pfnGetState = ze_lib::context->zesDdiTable.load()->Ras.pfnGetState;
+        if( nullptr == pfnGetState ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetState;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetState( hRas, clear, pState );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4897,6 +6879,7 @@ zesRasGetState(
     }
 
     return pfnGetState( hRas, clear, pState );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4938,6 +6921,23 @@ zesDeviceEnumSchedulers(
                                                     ///< component handles.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDeviceEnumSchedulers_t pfnEnumSchedulers = [&result] {
+        auto pfnEnumSchedulers = ze_lib::context->zesDdiTable.load()->Device.pfnEnumSchedulers;
+        if( nullptr == pfnEnumSchedulers ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnEnumSchedulers;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnEnumSchedulers( hDevice, pCount, phScheduler );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4951,6 +6951,7 @@ zesDeviceEnumSchedulers(
     }
 
     return pfnEnumSchedulers( hDevice, pCount, phScheduler );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4976,6 +6977,23 @@ zesSchedulerGetProperties(
     zes_sched_properties_t* pProperties             ///< [in,out] Structure that will contain property data.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnSchedulerGetProperties_t pfnGetProperties = [&result] {
+        auto pfnGetProperties = ze_lib::context->zesDdiTable.load()->Scheduler.pfnGetProperties;
+        if( nullptr == pfnGetProperties ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetProperties;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetProperties( hScheduler, pProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4989,6 +7007,7 @@ zesSchedulerGetProperties(
     }
 
     return pfnGetProperties( hScheduler, pProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5016,6 +7035,23 @@ zesSchedulerGetCurrentMode(
     zes_sched_mode_t* pMode                         ///< [in,out] Will contain the current scheduler mode.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnSchedulerGetCurrentMode_t pfnGetCurrentMode = [&result] {
+        auto pfnGetCurrentMode = ze_lib::context->zesDdiTable.load()->Scheduler.pfnGetCurrentMode;
+        if( nullptr == pfnGetCurrentMode ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetCurrentMode;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetCurrentMode( hScheduler, pMode );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -5029,6 +7065,7 @@ zesSchedulerGetCurrentMode(
     }
 
     return pfnGetCurrentMode( hScheduler, pMode );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5058,6 +7095,23 @@ zesSchedulerGetTimeoutModeProperties(
     zes_sched_timeout_properties_t* pConfig         ///< [in,out] Will contain the current parameters for this mode.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnSchedulerGetTimeoutModeProperties_t pfnGetTimeoutModeProperties = [&result] {
+        auto pfnGetTimeoutModeProperties = ze_lib::context->zesDdiTable.load()->Scheduler.pfnGetTimeoutModeProperties;
+        if( nullptr == pfnGetTimeoutModeProperties ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetTimeoutModeProperties;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetTimeoutModeProperties( hScheduler, getDefaults, pConfig );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -5071,6 +7125,7 @@ zesSchedulerGetTimeoutModeProperties(
     }
 
     return pfnGetTimeoutModeProperties( hScheduler, getDefaults, pConfig );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5100,6 +7155,23 @@ zesSchedulerGetTimesliceModeProperties(
     zes_sched_timeslice_properties_t* pConfig       ///< [in,out] Will contain the current parameters for this mode.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnSchedulerGetTimesliceModeProperties_t pfnGetTimesliceModeProperties = [&result] {
+        auto pfnGetTimesliceModeProperties = ze_lib::context->zesDdiTable.load()->Scheduler.pfnGetTimesliceModeProperties;
+        if( nullptr == pfnGetTimesliceModeProperties ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetTimesliceModeProperties;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetTimesliceModeProperties( hScheduler, getDefaults, pConfig );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -5113,6 +7185,7 @@ zesSchedulerGetTimesliceModeProperties(
     }
 
     return pfnGetTimesliceModeProperties( hScheduler, getDefaults, pConfig );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5150,6 +7223,23 @@ zesSchedulerSetTimeoutMode(
                                                     ///< apply the new scheduler mode.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnSchedulerSetTimeoutMode_t pfnSetTimeoutMode = [&result] {
+        auto pfnSetTimeoutMode = ze_lib::context->zesDdiTable.load()->Scheduler.pfnSetTimeoutMode;
+        if( nullptr == pfnSetTimeoutMode ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnSetTimeoutMode;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnSetTimeoutMode( hScheduler, pProperties, pNeedReload );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -5163,6 +7253,7 @@ zesSchedulerSetTimeoutMode(
     }
 
     return pfnSetTimeoutMode( hScheduler, pProperties, pNeedReload );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5199,6 +7290,23 @@ zesSchedulerSetTimesliceMode(
                                                     ///< apply the new scheduler mode.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnSchedulerSetTimesliceMode_t pfnSetTimesliceMode = [&result] {
+        auto pfnSetTimesliceMode = ze_lib::context->zesDdiTable.load()->Scheduler.pfnSetTimesliceMode;
+        if( nullptr == pfnSetTimesliceMode ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnSetTimesliceMode;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnSetTimesliceMode( hScheduler, pProperties, pNeedReload );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -5212,6 +7320,7 @@ zesSchedulerSetTimesliceMode(
     }
 
     return pfnSetTimesliceMode( hScheduler, pProperties, pNeedReload );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5246,6 +7355,23 @@ zesSchedulerSetExclusiveMode(
                                                     ///< apply the new scheduler mode.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnSchedulerSetExclusiveMode_t pfnSetExclusiveMode = [&result] {
+        auto pfnSetExclusiveMode = ze_lib::context->zesDdiTable.load()->Scheduler.pfnSetExclusiveMode;
+        if( nullptr == pfnSetExclusiveMode ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnSetExclusiveMode;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnSetExclusiveMode( hScheduler, pNeedReload );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -5259,6 +7385,7 @@ zesSchedulerSetExclusiveMode(
     }
 
     return pfnSetExclusiveMode( hScheduler, pNeedReload );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5295,6 +7422,23 @@ zesSchedulerSetComputeUnitDebugMode(
                                                     ///< apply the new scheduler mode.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnSchedulerSetComputeUnitDebugMode_t pfnSetComputeUnitDebugMode = [&result] {
+        auto pfnSetComputeUnitDebugMode = ze_lib::context->zesDdiTable.load()->Scheduler.pfnSetComputeUnitDebugMode;
+        if( nullptr == pfnSetComputeUnitDebugMode ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnSetComputeUnitDebugMode;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnSetComputeUnitDebugMode( hScheduler, pNeedReload );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -5308,6 +7452,7 @@ zesSchedulerSetComputeUnitDebugMode(
     }
 
     return pfnSetComputeUnitDebugMode( hScheduler, pNeedReload );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5343,6 +7488,23 @@ zesDeviceEnumStandbyDomains(
                                                     ///< component handles.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDeviceEnumStandbyDomains_t pfnEnumStandbyDomains = [&result] {
+        auto pfnEnumStandbyDomains = ze_lib::context->zesDdiTable.load()->Device.pfnEnumStandbyDomains;
+        if( nullptr == pfnEnumStandbyDomains ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnEnumStandbyDomains;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnEnumStandbyDomains( hDevice, pCount, phStandby );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -5356,6 +7518,7 @@ zesDeviceEnumStandbyDomains(
     }
 
     return pfnEnumStandbyDomains( hDevice, pCount, phStandby );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5381,6 +7544,23 @@ zesStandbyGetProperties(
     zes_standby_properties_t* pProperties           ///< [in,out] Will contain the standby hardware properties.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnStandbyGetProperties_t pfnGetProperties = [&result] {
+        auto pfnGetProperties = ze_lib::context->zesDdiTable.load()->Standby.pfnGetProperties;
+        if( nullptr == pfnGetProperties ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetProperties;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetProperties( hStandby, pProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -5394,6 +7574,7 @@ zesStandbyGetProperties(
     }
 
     return pfnGetProperties( hStandby, pProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5419,6 +7600,23 @@ zesStandbyGetMode(
     zes_standby_promo_mode_t* pMode                 ///< [in,out] Will contain the current standby mode.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnStandbyGetMode_t pfnGetMode = [&result] {
+        auto pfnGetMode = ze_lib::context->zesDdiTable.load()->Standby.pfnGetMode;
+        if( nullptr == pfnGetMode ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetMode;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetMode( hStandby, pMode );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -5432,6 +7630,7 @@ zesStandbyGetMode(
     }
 
     return pfnGetMode( hStandby, pMode );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5459,6 +7658,23 @@ zesStandbySetMode(
     zes_standby_promo_mode_t mode                   ///< [in] New standby mode.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnStandbySetMode_t pfnSetMode = [&result] {
+        auto pfnSetMode = ze_lib::context->zesDdiTable.load()->Standby.pfnSetMode;
+        if( nullptr == pfnSetMode ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnSetMode;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnSetMode( hStandby, mode );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -5472,6 +7688,7 @@ zesStandbySetMode(
     }
 
     return pfnSetMode( hStandby, mode );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5507,6 +7724,23 @@ zesDeviceEnumTemperatureSensors(
                                                     ///< component handles.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDeviceEnumTemperatureSensors_t pfnEnumTemperatureSensors = [&result] {
+        auto pfnEnumTemperatureSensors = ze_lib::context->zesDdiTable.load()->Device.pfnEnumTemperatureSensors;
+        if( nullptr == pfnEnumTemperatureSensors ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnEnumTemperatureSensors;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnEnumTemperatureSensors( hDevice, pCount, phTemperature );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -5520,6 +7754,7 @@ zesDeviceEnumTemperatureSensors(
     }
 
     return pfnEnumTemperatureSensors( hDevice, pCount, phTemperature );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5545,6 +7780,23 @@ zesTemperatureGetProperties(
     zes_temp_properties_t* pProperties              ///< [in,out] Will contain the temperature sensor properties.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnTemperatureGetProperties_t pfnGetProperties = [&result] {
+        auto pfnGetProperties = ze_lib::context->zesDdiTable.load()->Temperature.pfnGetProperties;
+        if( nullptr == pfnGetProperties ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetProperties;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetProperties( hTemperature, pProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -5558,6 +7810,7 @@ zesTemperatureGetProperties(
     }
 
     return pfnGetProperties( hTemperature, pProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5589,6 +7842,23 @@ zesTemperatureGetConfig(
     zes_temp_config_t* pConfig                      ///< [in,out] Returns current configuration.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnTemperatureGetConfig_t pfnGetConfig = [&result] {
+        auto pfnGetConfig = ze_lib::context->zesDdiTable.load()->Temperature.pfnGetConfig;
+        if( nullptr == pfnGetConfig ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetConfig;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetConfig( hTemperature, pConfig );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -5602,6 +7872,7 @@ zesTemperatureGetConfig(
     }
 
     return pfnGetConfig( hTemperature, pConfig );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5650,6 +7921,23 @@ zesTemperatureSetConfig(
     const zes_temp_config_t* pConfig                ///< [in] New configuration.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnTemperatureSetConfig_t pfnSetConfig = [&result] {
+        auto pfnSetConfig = ze_lib::context->zesDdiTable.load()->Temperature.pfnSetConfig;
+        if( nullptr == pfnSetConfig ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnSetConfig;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnSetConfig( hTemperature, pConfig );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -5663,6 +7951,7 @@ zesTemperatureSetConfig(
     }
 
     return pfnSetConfig( hTemperature, pConfig );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5689,6 +7978,23 @@ zesTemperatureGetState(
                                                     ///< in degrees Celsius.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnTemperatureGetState_t pfnGetState = [&result] {
+        auto pfnGetState = ze_lib::context->zesDdiTable.load()->Temperature.pfnGetState;
+        if( nullptr == pfnGetState ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetState;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetState( hTemperature, pTemperature );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -5702,6 +8008,7 @@ zesTemperatureGetState(
     }
 
     return pfnGetState( hTemperature, pTemperature );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5737,6 +8044,23 @@ zesPowerGetLimitsExt(
                                                     ///< number of components.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnPowerGetLimitsExt_t pfnGetLimitsExt = [&result] {
+        auto pfnGetLimitsExt = ze_lib::context->zesDdiTable.load()->Power.pfnGetLimitsExt;
+        if( nullptr == pfnGetLimitsExt ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetLimitsExt;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetLimitsExt( hPower, pCount, pSustained );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -5750,6 +8074,7 @@ zesPowerGetLimitsExt(
     }
 
     return pfnGetLimitsExt( hPower, pCount, pSustained );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5788,6 +8113,23 @@ zesPowerSetLimitsExt(
     zes_power_limit_ext_desc_t* pSustained          ///< [in][optional][range(0, *pCount)] Array of power limit descriptors.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnPowerSetLimitsExt_t pfnSetLimitsExt = [&result] {
+        auto pfnSetLimitsExt = ze_lib::context->zesDdiTable.load()->Power.pfnSetLimitsExt;
+        if( nullptr == pfnSetLimitsExt ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnSetLimitsExt;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnSetLimitsExt( hPower, pCount, pSustained );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -5801,6 +8143,7 @@ zesPowerSetLimitsExt(
     }
 
     return pfnSetLimitsExt( hPower, pCount, pSustained );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5841,6 +8184,23 @@ zesEngineGetActivityExt(
                                                     ///< of VF engine stats.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnEngineGetActivityExt_t pfnGetActivityExt = [&result] {
+        auto pfnGetActivityExt = ze_lib::context->zesDdiTable.load()->Engine.pfnGetActivityExt;
+        if( nullptr == pfnGetActivityExt ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetActivityExt;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetActivityExt( hEngine, pCount, pStats );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -5854,6 +8214,7 @@ zesEngineGetActivityExt(
     }
 
     return pfnGetActivityExt( hEngine, pCount, pStats );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5889,6 +8250,23 @@ zesRasGetStateExp(
                                                     ///< shall only retrieve that number of RAS states.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnRasGetStateExp_t pfnGetStateExp = [&result] {
+        auto pfnGetStateExp = ze_lib::context->zesDdiTable.load()->RasExp.pfnGetStateExp;
+        if( nullptr == pfnGetStateExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetStateExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetStateExp( hRas, pCount, pState );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -5902,6 +8280,7 @@ zesRasGetStateExp(
     }
 
     return pfnGetStateExp( hRas, pCount, pState );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5934,6 +8313,23 @@ zesRasClearStateExp(
     zes_ras_error_category_exp_t category           ///< [in] category for which error counter is to be cleared.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnRasClearStateExp_t pfnClearStateExp = [&result] {
+        auto pfnClearStateExp = ze_lib::context->zesDdiTable.load()->RasExp.pfnClearStateExp;
+        if( nullptr == pfnClearStateExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnClearStateExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnClearStateExp( hRas, category );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -5947,6 +8343,7 @@ zesRasClearStateExp(
     }
 
     return pfnClearStateExp( hRas, category );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5977,6 +8374,23 @@ zesFirmwareGetSecurityVersionExp(
                                                     ///< returned if this property cannot be determined.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnFirmwareGetSecurityVersionExp_t pfnGetSecurityVersionExp = [&result] {
+        auto pfnGetSecurityVersionExp = ze_lib::context->zesDdiTable.load()->FirmwareExp.pfnGetSecurityVersionExp;
+        if( nullptr == pfnGetSecurityVersionExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetSecurityVersionExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetSecurityVersionExp( hFirmware, pVersion );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -5990,6 +8404,7 @@ zesFirmwareGetSecurityVersionExp(
     }
 
     return pfnGetSecurityVersionExp( hFirmware, pVersion );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6012,6 +8427,23 @@ zesFirmwareSetSecurityVersionExp(
     zes_firmware_handle_t hFirmware                 ///< [in] Handle for the component.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnFirmwareSetSecurityVersionExp_t pfnSetSecurityVersionExp = [&result] {
+        auto pfnSetSecurityVersionExp = ze_lib::context->zesDdiTable.load()->FirmwareExp.pfnSetSecurityVersionExp;
+        if( nullptr == pfnSetSecurityVersionExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnSetSecurityVersionExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnSetSecurityVersionExp( hFirmware );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -6025,6 +8457,7 @@ zesFirmwareSetSecurityVersionExp(
     }
 
     return pfnSetSecurityVersionExp( hFirmware );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6058,6 +8491,23 @@ zesDeviceGetSubDevicePropertiesExp(
                                                     ///< the driver shall only retrieve that number of sub device property structures.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDeviceGetSubDevicePropertiesExp_t pfnGetSubDevicePropertiesExp = [&result] {
+        auto pfnGetSubDevicePropertiesExp = ze_lib::context->zesDdiTable.load()->DeviceExp.pfnGetSubDevicePropertiesExp;
+        if( nullptr == pfnGetSubDevicePropertiesExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetSubDevicePropertiesExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetSubDevicePropertiesExp( hDevice, pCount, pSubdeviceProps );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -6071,6 +8521,7 @@ zesDeviceGetSubDevicePropertiesExp(
     }
 
     return pfnGetSubDevicePropertiesExp( hDevice, pCount, pSubdeviceProps );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6103,6 +8554,23 @@ zesDriverGetDeviceByUuidExp(
     uint32_t* subdeviceId                           ///< [out] If onSubdevice is true, this gives the ID of the sub-device
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDriverGetDeviceByUuidExp_t pfnGetDeviceByUuidExp = [&result] {
+        auto pfnGetDeviceByUuidExp = ze_lib::context->zesDdiTable.load()->DriverExp.pfnGetDeviceByUuidExp;
+        if( nullptr == pfnGetDeviceByUuidExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetDeviceByUuidExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetDeviceByUuidExp( hDriver, uuid, phDevice, onSubdevice, subdeviceId );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -6116,6 +8584,7 @@ zesDriverGetDeviceByUuidExp(
     }
 
     return pfnGetDeviceByUuidExp( hDriver, uuid, phDevice, onSubdevice, subdeviceId );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6152,6 +8621,23 @@ zesDeviceEnumActiveVFExp(
                                                     ///< component handles.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDeviceEnumActiveVFExp_t pfnEnumActiveVFExp = [&result] {
+        auto pfnEnumActiveVFExp = ze_lib::context->zesDdiTable.load()->DeviceExp.pfnEnumActiveVFExp;
+        if( nullptr == pfnEnumActiveVFExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnEnumActiveVFExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnEnumActiveVFExp( hDevice, pCount, phVFhandle );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -6165,6 +8651,7 @@ zesDeviceEnumActiveVFExp(
     }
 
     return pfnEnumActiveVFExp( hDevice, pCount, phVFhandle );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6192,6 +8679,23 @@ zesVFManagementGetVFPropertiesExp(
     zes_vf_exp_properties_t* pProperties            ///< [in,out] Will contain VF properties.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnVFManagementGetVFPropertiesExp_t pfnGetVFPropertiesExp = [&result] {
+        auto pfnGetVFPropertiesExp = ze_lib::context->zesDdiTable.load()->VFManagementExp.pfnGetVFPropertiesExp;
+        if( nullptr == pfnGetVFPropertiesExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetVFPropertiesExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetVFPropertiesExp( hVFhandle, pProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -6205,6 +8709,7 @@ zesVFManagementGetVFPropertiesExp(
     }
 
     return pfnGetVFPropertiesExp( hVFhandle, pProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6245,6 +8750,23 @@ zesVFManagementGetVFMemoryUtilizationExp(
                                                     ///< memory stats.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnVFManagementGetVFMemoryUtilizationExp_t pfnGetVFMemoryUtilizationExp = [&result] {
+        auto pfnGetVFMemoryUtilizationExp = ze_lib::context->zesDdiTable.load()->VFManagementExp.pfnGetVFMemoryUtilizationExp;
+        if( nullptr == pfnGetVFMemoryUtilizationExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetVFMemoryUtilizationExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetVFMemoryUtilizationExp( hVFhandle, pCount, pMemUtil );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -6258,6 +8780,7 @@ zesVFManagementGetVFMemoryUtilizationExp(
     }
 
     return pfnGetVFMemoryUtilizationExp( hVFhandle, pCount, pMemUtil );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6298,6 +8821,23 @@ zesVFManagementGetVFEngineUtilizationExp(
                                                     ///< engine stats.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnVFManagementGetVFEngineUtilizationExp_t pfnGetVFEngineUtilizationExp = [&result] {
+        auto pfnGetVFEngineUtilizationExp = ze_lib::context->zesDdiTable.load()->VFManagementExp.pfnGetVFEngineUtilizationExp;
+        if( nullptr == pfnGetVFEngineUtilizationExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetVFEngineUtilizationExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetVFEngineUtilizationExp( hVFhandle, pCount, pEngineUtil );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -6311,6 +8851,7 @@ zesVFManagementGetVFEngineUtilizationExp(
     }
 
     return pfnGetVFEngineUtilizationExp( hVFhandle, pCount, pEngineUtil );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6340,6 +8881,23 @@ zesVFManagementSetVFTelemetryModeExp(
     ze_bool_t enable                                ///< [in] Enable utilization telemetry.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnVFManagementSetVFTelemetryModeExp_t pfnSetVFTelemetryModeExp = [&result] {
+        auto pfnSetVFTelemetryModeExp = ze_lib::context->zesDdiTable.load()->VFManagementExp.pfnSetVFTelemetryModeExp;
+        if( nullptr == pfnSetVFTelemetryModeExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnSetVFTelemetryModeExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnSetVFTelemetryModeExp( hVFhandle, flags, enable );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -6353,6 +8911,7 @@ zesVFManagementSetVFTelemetryModeExp(
     }
 
     return pfnSetVFTelemetryModeExp( hVFhandle, flags, enable );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6382,6 +8941,23 @@ zesVFManagementSetVFTelemetrySamplingIntervalExp(
     uint64_t samplingInterval                       ///< [in] Sampling interval value.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnVFManagementSetVFTelemetrySamplingIntervalExp_t pfnSetVFTelemetrySamplingIntervalExp = [&result] {
+        auto pfnSetVFTelemetrySamplingIntervalExp = ze_lib::context->zesDdiTable.load()->VFManagementExp.pfnSetVFTelemetrySamplingIntervalExp;
+        if( nullptr == pfnSetVFTelemetrySamplingIntervalExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnSetVFTelemetrySamplingIntervalExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnSetVFTelemetrySamplingIntervalExp( hVFhandle, flag, samplingInterval );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -6395,6 +8971,7 @@ zesVFManagementSetVFTelemetrySamplingIntervalExp(
     }
 
     return pfnSetVFTelemetrySamplingIntervalExp( hVFhandle, flag, samplingInterval );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6430,6 +9007,23 @@ zesDeviceEnumEnabledVFExp(
                                                     ///< component handles.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnDeviceEnumEnabledVFExp_t pfnEnumEnabledVFExp = [&result] {
+        auto pfnEnumEnabledVFExp = ze_lib::context->zesDdiTable.load()->DeviceExp.pfnEnumEnabledVFExp;
+        if( nullptr == pfnEnumEnabledVFExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnEnumEnabledVFExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnEnumEnabledVFExp( hDevice, pCount, phVFhandle );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -6443,6 +9037,7 @@ zesDeviceEnumEnabledVFExp(
     }
 
     return pfnEnumEnabledVFExp( hDevice, pCount, phVFhandle );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6470,6 +9065,23 @@ zesVFManagementGetVFCapabilitiesExp(
     zes_vf_exp_capabilities_t* pCapability          ///< [in,out] Will contain VF capability.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnVFManagementGetVFCapabilitiesExp_t pfnGetVFCapabilitiesExp = [&result] {
+        auto pfnGetVFCapabilitiesExp = ze_lib::context->zesDdiTable.load()->VFManagementExp.pfnGetVFCapabilitiesExp;
+        if( nullptr == pfnGetVFCapabilitiesExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetVFCapabilitiesExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetVFCapabilitiesExp( hVFhandle, pCapability );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -6483,6 +9095,7 @@ zesVFManagementGetVFCapabilitiesExp(
     }
 
     return pfnGetVFCapabilitiesExp( hVFhandle, pCapability );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6520,6 +9133,23 @@ zesVFManagementGetVFMemoryUtilizationExp2(
                                                     ///< memory stats.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnVFManagementGetVFMemoryUtilizationExp2_t pfnGetVFMemoryUtilizationExp2 = [&result] {
+        auto pfnGetVFMemoryUtilizationExp2 = ze_lib::context->zesDdiTable.load()->VFManagementExp.pfnGetVFMemoryUtilizationExp2;
+        if( nullptr == pfnGetVFMemoryUtilizationExp2 ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetVFMemoryUtilizationExp2;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetVFMemoryUtilizationExp2( hVFhandle, pCount, pMemUtil );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -6533,6 +9163,7 @@ zesVFManagementGetVFMemoryUtilizationExp2(
     }
 
     return pfnGetVFMemoryUtilizationExp2( hVFhandle, pCount, pMemUtil );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6570,6 +9201,23 @@ zesVFManagementGetVFEngineUtilizationExp2(
                                                     ///< engine stats.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnVFManagementGetVFEngineUtilizationExp2_t pfnGetVFEngineUtilizationExp2 = [&result] {
+        auto pfnGetVFEngineUtilizationExp2 = ze_lib::context->zesDdiTable.load()->VFManagementExp.pfnGetVFEngineUtilizationExp2;
+        if( nullptr == pfnGetVFEngineUtilizationExp2 ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetVFEngineUtilizationExp2;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetVFEngineUtilizationExp2( hVFhandle, pCount, pEngineUtil );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -6583,6 +9231,7 @@ zesVFManagementGetVFEngineUtilizationExp2(
     }
 
     return pfnGetVFEngineUtilizationExp2( hVFhandle, pCount, pEngineUtil );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6608,6 +9257,23 @@ zesVFManagementGetVFCapabilitiesExp2(
     zes_vf_exp2_capabilities_t* pCapability         ///< [in,out] Will contain VF capability.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zes_pfnVFManagementGetVFCapabilitiesExp2_t pfnGetVFCapabilitiesExp2 = [&result] {
+        auto pfnGetVFCapabilitiesExp2 = ze_lib::context->zesDdiTable.load()->VFManagementExp.pfnGetVFCapabilitiesExp2;
+        if( nullptr == pfnGetVFCapabilitiesExp2 ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetVFCapabilitiesExp2;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetVFCapabilitiesExp2( hVFhandle, pCapability );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -6621,6 +9287,7 @@ zesVFManagementGetVFCapabilitiesExp2(
     }
 
     return pfnGetVFCapabilitiesExp2( hVFhandle, pCapability );
+    #endif
 }
 
 } // extern "C"

--- a/source/lib/zes_libddi.cpp
+++ b/source/lib/zes_libddi.cpp
@@ -27,6 +27,8 @@ namespace ze_lib
             auto getTable = reinterpret_cast<zes_pfnGetGlobalProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetGlobalProcAddrTable") );
             getTableWithCheck(getTable, version, &initialzesDdiTable.Global );
+            initialzesDdiTable.Global.pfnInit = reinterpret_cast<zes_pfnInit_t>(
+                GET_FUNCTION_PTR(loader, "zesInit") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -34,6 +36,80 @@ namespace ze_lib
             auto getTable = reinterpret_cast<zes_pfnGetDeviceProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetDeviceProcAddrTable") );
             result = getTableWithCheck(getTable, version, &initialzesDdiTable.Device );
+            initialzesDdiTable.Device.pfnGetProperties = reinterpret_cast<zes_pfnDeviceGetProperties_t>(
+                GET_FUNCTION_PTR(loader, "zesDeviceGetProperties") );
+            initialzesDdiTable.Device.pfnGetState = reinterpret_cast<zes_pfnDeviceGetState_t>(
+                GET_FUNCTION_PTR(loader, "zesDeviceGetState") );
+            initialzesDdiTable.Device.pfnReset = reinterpret_cast<zes_pfnDeviceReset_t>(
+                GET_FUNCTION_PTR(loader, "zesDeviceReset") );
+            initialzesDdiTable.Device.pfnProcessesGetState = reinterpret_cast<zes_pfnDeviceProcessesGetState_t>(
+                GET_FUNCTION_PTR(loader, "zesDeviceProcessesGetState") );
+            initialzesDdiTable.Device.pfnPciGetProperties = reinterpret_cast<zes_pfnDevicePciGetProperties_t>(
+                GET_FUNCTION_PTR(loader, "zesDevicePciGetProperties") );
+            initialzesDdiTable.Device.pfnPciGetState = reinterpret_cast<zes_pfnDevicePciGetState_t>(
+                GET_FUNCTION_PTR(loader, "zesDevicePciGetState") );
+            initialzesDdiTable.Device.pfnPciGetBars = reinterpret_cast<zes_pfnDevicePciGetBars_t>(
+                GET_FUNCTION_PTR(loader, "zesDevicePciGetBars") );
+            initialzesDdiTable.Device.pfnPciGetStats = reinterpret_cast<zes_pfnDevicePciGetStats_t>(
+                GET_FUNCTION_PTR(loader, "zesDevicePciGetStats") );
+            initialzesDdiTable.Device.pfnEnumDiagnosticTestSuites = reinterpret_cast<zes_pfnDeviceEnumDiagnosticTestSuites_t>(
+                GET_FUNCTION_PTR(loader, "zesDeviceEnumDiagnosticTestSuites") );
+            initialzesDdiTable.Device.pfnEnumEngineGroups = reinterpret_cast<zes_pfnDeviceEnumEngineGroups_t>(
+                GET_FUNCTION_PTR(loader, "zesDeviceEnumEngineGroups") );
+            initialzesDdiTable.Device.pfnEventRegister = reinterpret_cast<zes_pfnDeviceEventRegister_t>(
+                GET_FUNCTION_PTR(loader, "zesDeviceEventRegister") );
+            initialzesDdiTable.Device.pfnEnumFabricPorts = reinterpret_cast<zes_pfnDeviceEnumFabricPorts_t>(
+                GET_FUNCTION_PTR(loader, "zesDeviceEnumFabricPorts") );
+            initialzesDdiTable.Device.pfnEnumFans = reinterpret_cast<zes_pfnDeviceEnumFans_t>(
+                GET_FUNCTION_PTR(loader, "zesDeviceEnumFans") );
+            initialzesDdiTable.Device.pfnEnumFirmwares = reinterpret_cast<zes_pfnDeviceEnumFirmwares_t>(
+                GET_FUNCTION_PTR(loader, "zesDeviceEnumFirmwares") );
+            initialzesDdiTable.Device.pfnEnumFrequencyDomains = reinterpret_cast<zes_pfnDeviceEnumFrequencyDomains_t>(
+                GET_FUNCTION_PTR(loader, "zesDeviceEnumFrequencyDomains") );
+            initialzesDdiTable.Device.pfnEnumLeds = reinterpret_cast<zes_pfnDeviceEnumLeds_t>(
+                GET_FUNCTION_PTR(loader, "zesDeviceEnumLeds") );
+            initialzesDdiTable.Device.pfnEnumMemoryModules = reinterpret_cast<zes_pfnDeviceEnumMemoryModules_t>(
+                GET_FUNCTION_PTR(loader, "zesDeviceEnumMemoryModules") );
+            initialzesDdiTable.Device.pfnEnumPerformanceFactorDomains = reinterpret_cast<zes_pfnDeviceEnumPerformanceFactorDomains_t>(
+                GET_FUNCTION_PTR(loader, "zesDeviceEnumPerformanceFactorDomains") );
+            initialzesDdiTable.Device.pfnEnumPowerDomains = reinterpret_cast<zes_pfnDeviceEnumPowerDomains_t>(
+                GET_FUNCTION_PTR(loader, "zesDeviceEnumPowerDomains") );
+            initialzesDdiTable.Device.pfnGetCardPowerDomain = reinterpret_cast<zes_pfnDeviceGetCardPowerDomain_t>(
+                GET_FUNCTION_PTR(loader, "zesDeviceGetCardPowerDomain") );
+            initialzesDdiTable.Device.pfnEnumPsus = reinterpret_cast<zes_pfnDeviceEnumPsus_t>(
+                GET_FUNCTION_PTR(loader, "zesDeviceEnumPsus") );
+            initialzesDdiTable.Device.pfnEnumRasErrorSets = reinterpret_cast<zes_pfnDeviceEnumRasErrorSets_t>(
+                GET_FUNCTION_PTR(loader, "zesDeviceEnumRasErrorSets") );
+            initialzesDdiTable.Device.pfnEnumSchedulers = reinterpret_cast<zes_pfnDeviceEnumSchedulers_t>(
+                GET_FUNCTION_PTR(loader, "zesDeviceEnumSchedulers") );
+            initialzesDdiTable.Device.pfnEnumStandbyDomains = reinterpret_cast<zes_pfnDeviceEnumStandbyDomains_t>(
+                GET_FUNCTION_PTR(loader, "zesDeviceEnumStandbyDomains") );
+            initialzesDdiTable.Device.pfnEnumTemperatureSensors = reinterpret_cast<zes_pfnDeviceEnumTemperatureSensors_t>(
+                GET_FUNCTION_PTR(loader, "zesDeviceEnumTemperatureSensors") );
+            initialzesDdiTable.Device.pfnEccAvailable = reinterpret_cast<zes_pfnDeviceEccAvailable_t>(
+                GET_FUNCTION_PTR(loader, "zesDeviceEccAvailable") );
+            initialzesDdiTable.Device.pfnEccConfigurable = reinterpret_cast<zes_pfnDeviceEccConfigurable_t>(
+                GET_FUNCTION_PTR(loader, "zesDeviceEccConfigurable") );
+            initialzesDdiTable.Device.pfnGetEccState = reinterpret_cast<zes_pfnDeviceGetEccState_t>(
+                GET_FUNCTION_PTR(loader, "zesDeviceGetEccState") );
+            initialzesDdiTable.Device.pfnSetEccState = reinterpret_cast<zes_pfnDeviceSetEccState_t>(
+                GET_FUNCTION_PTR(loader, "zesDeviceSetEccState") );
+            initialzesDdiTable.Device.pfnGet = reinterpret_cast<zes_pfnDeviceGet_t>(
+                GET_FUNCTION_PTR(loader, "zesDeviceGet") );
+            initialzesDdiTable.Device.pfnSetOverclockWaiver = reinterpret_cast<zes_pfnDeviceSetOverclockWaiver_t>(
+                GET_FUNCTION_PTR(loader, "zesDeviceSetOverclockWaiver") );
+            initialzesDdiTable.Device.pfnGetOverclockDomains = reinterpret_cast<zes_pfnDeviceGetOverclockDomains_t>(
+                GET_FUNCTION_PTR(loader, "zesDeviceGetOverclockDomains") );
+            initialzesDdiTable.Device.pfnGetOverclockControls = reinterpret_cast<zes_pfnDeviceGetOverclockControls_t>(
+                GET_FUNCTION_PTR(loader, "zesDeviceGetOverclockControls") );
+            initialzesDdiTable.Device.pfnResetOverclockSettings = reinterpret_cast<zes_pfnDeviceResetOverclockSettings_t>(
+                GET_FUNCTION_PTR(loader, "zesDeviceResetOverclockSettings") );
+            initialzesDdiTable.Device.pfnReadOverclockState = reinterpret_cast<zes_pfnDeviceReadOverclockState_t>(
+                GET_FUNCTION_PTR(loader, "zesDeviceReadOverclockState") );
+            initialzesDdiTable.Device.pfnEnumOverclockDomains = reinterpret_cast<zes_pfnDeviceEnumOverclockDomains_t>(
+                GET_FUNCTION_PTR(loader, "zesDeviceEnumOverclockDomains") );
+            initialzesDdiTable.Device.pfnResetExt = reinterpret_cast<zes_pfnDeviceResetExt_t>(
+                GET_FUNCTION_PTR(loader, "zesDeviceResetExt") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -42,6 +118,12 @@ namespace ze_lib
             auto getTable = reinterpret_cast<zes_pfnGetDeviceExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetDeviceExpProcAddrTable") );
             getTableWithCheck(getTable, version, &initialzesDdiTable.DeviceExp );
+            initialzesDdiTable.DeviceExp.pfnEnumEnabledVFExp = reinterpret_cast<zes_pfnDeviceEnumEnabledVFExp_t>(
+                GET_FUNCTION_PTR(loader, "zesDeviceEnumEnabledVFExp") );
+            initialzesDdiTable.DeviceExp.pfnGetSubDevicePropertiesExp = reinterpret_cast<zes_pfnDeviceGetSubDevicePropertiesExp_t>(
+                GET_FUNCTION_PTR(loader, "zesDeviceGetSubDevicePropertiesExp") );
+            initialzesDdiTable.DeviceExp.pfnEnumActiveVFExp = reinterpret_cast<zes_pfnDeviceEnumActiveVFExp_t>(
+                GET_FUNCTION_PTR(loader, "zesDeviceEnumActiveVFExp") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -49,6 +131,16 @@ namespace ze_lib
             auto getTable = reinterpret_cast<zes_pfnGetDriverProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetDriverProcAddrTable") );
             result = getTableWithCheck(getTable, version, &initialzesDdiTable.Driver );
+            initialzesDdiTable.Driver.pfnEventListen = reinterpret_cast<zes_pfnDriverEventListen_t>(
+                GET_FUNCTION_PTR(loader, "zesDriverEventListen") );
+            initialzesDdiTable.Driver.pfnEventListenEx = reinterpret_cast<zes_pfnDriverEventListenEx_t>(
+                GET_FUNCTION_PTR(loader, "zesDriverEventListenEx") );
+            initialzesDdiTable.Driver.pfnGet = reinterpret_cast<zes_pfnDriverGet_t>(
+                GET_FUNCTION_PTR(loader, "zesDriverGet") );
+            initialzesDdiTable.Driver.pfnGetExtensionProperties = reinterpret_cast<zes_pfnDriverGetExtensionProperties_t>(
+                GET_FUNCTION_PTR(loader, "zesDriverGetExtensionProperties") );
+            initialzesDdiTable.Driver.pfnGetExtensionFunctionAddress = reinterpret_cast<zes_pfnDriverGetExtensionFunctionAddress_t>(
+                GET_FUNCTION_PTR(loader, "zesDriverGetExtensionFunctionAddress") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -57,6 +149,8 @@ namespace ze_lib
             auto getTable = reinterpret_cast<zes_pfnGetDriverExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetDriverExpProcAddrTable") );
             getTableWithCheck(getTable, version, &initialzesDdiTable.DriverExp );
+            initialzesDdiTable.DriverExp.pfnGetDeviceByUuidExp = reinterpret_cast<zes_pfnDriverGetDeviceByUuidExp_t>(
+                GET_FUNCTION_PTR(loader, "zesDriverGetDeviceByUuidExp") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -64,6 +158,12 @@ namespace ze_lib
             auto getTable = reinterpret_cast<zes_pfnGetDiagnosticsProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetDiagnosticsProcAddrTable") );
             result = getTableWithCheck(getTable, version, &initialzesDdiTable.Diagnostics );
+            initialzesDdiTable.Diagnostics.pfnGetProperties = reinterpret_cast<zes_pfnDiagnosticsGetProperties_t>(
+                GET_FUNCTION_PTR(loader, "zesDiagnosticsGetProperties") );
+            initialzesDdiTable.Diagnostics.pfnGetTests = reinterpret_cast<zes_pfnDiagnosticsGetTests_t>(
+                GET_FUNCTION_PTR(loader, "zesDiagnosticsGetTests") );
+            initialzesDdiTable.Diagnostics.pfnRunTests = reinterpret_cast<zes_pfnDiagnosticsRunTests_t>(
+                GET_FUNCTION_PTR(loader, "zesDiagnosticsRunTests") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -71,6 +171,12 @@ namespace ze_lib
             auto getTable = reinterpret_cast<zes_pfnGetEngineProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetEngineProcAddrTable") );
             result = getTableWithCheck(getTable, version, &initialzesDdiTable.Engine );
+            initialzesDdiTable.Engine.pfnGetProperties = reinterpret_cast<zes_pfnEngineGetProperties_t>(
+                GET_FUNCTION_PTR(loader, "zesEngineGetProperties") );
+            initialzesDdiTable.Engine.pfnGetActivity = reinterpret_cast<zes_pfnEngineGetActivity_t>(
+                GET_FUNCTION_PTR(loader, "zesEngineGetActivity") );
+            initialzesDdiTable.Engine.pfnGetActivityExt = reinterpret_cast<zes_pfnEngineGetActivityExt_t>(
+                GET_FUNCTION_PTR(loader, "zesEngineGetActivityExt") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -78,6 +184,22 @@ namespace ze_lib
             auto getTable = reinterpret_cast<zes_pfnGetFabricPortProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetFabricPortProcAddrTable") );
             result = getTableWithCheck(getTable, version, &initialzesDdiTable.FabricPort );
+            initialzesDdiTable.FabricPort.pfnGetProperties = reinterpret_cast<zes_pfnFabricPortGetProperties_t>(
+                GET_FUNCTION_PTR(loader, "zesFabricPortGetProperties") );
+            initialzesDdiTable.FabricPort.pfnGetLinkType = reinterpret_cast<zes_pfnFabricPortGetLinkType_t>(
+                GET_FUNCTION_PTR(loader, "zesFabricPortGetLinkType") );
+            initialzesDdiTable.FabricPort.pfnGetConfig = reinterpret_cast<zes_pfnFabricPortGetConfig_t>(
+                GET_FUNCTION_PTR(loader, "zesFabricPortGetConfig") );
+            initialzesDdiTable.FabricPort.pfnSetConfig = reinterpret_cast<zes_pfnFabricPortSetConfig_t>(
+                GET_FUNCTION_PTR(loader, "zesFabricPortSetConfig") );
+            initialzesDdiTable.FabricPort.pfnGetState = reinterpret_cast<zes_pfnFabricPortGetState_t>(
+                GET_FUNCTION_PTR(loader, "zesFabricPortGetState") );
+            initialzesDdiTable.FabricPort.pfnGetThroughput = reinterpret_cast<zes_pfnFabricPortGetThroughput_t>(
+                GET_FUNCTION_PTR(loader, "zesFabricPortGetThroughput") );
+            initialzesDdiTable.FabricPort.pfnGetFabricErrorCounters = reinterpret_cast<zes_pfnFabricPortGetFabricErrorCounters_t>(
+                GET_FUNCTION_PTR(loader, "zesFabricPortGetFabricErrorCounters") );
+            initialzesDdiTable.FabricPort.pfnGetMultiPortThroughput = reinterpret_cast<zes_pfnFabricPortGetMultiPortThroughput_t>(
+                GET_FUNCTION_PTR(loader, "zesFabricPortGetMultiPortThroughput") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -85,6 +207,18 @@ namespace ze_lib
             auto getTable = reinterpret_cast<zes_pfnGetFanProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetFanProcAddrTable") );
             result = getTableWithCheck(getTable, version, &initialzesDdiTable.Fan );
+            initialzesDdiTable.Fan.pfnGetProperties = reinterpret_cast<zes_pfnFanGetProperties_t>(
+                GET_FUNCTION_PTR(loader, "zesFanGetProperties") );
+            initialzesDdiTable.Fan.pfnGetConfig = reinterpret_cast<zes_pfnFanGetConfig_t>(
+                GET_FUNCTION_PTR(loader, "zesFanGetConfig") );
+            initialzesDdiTable.Fan.pfnSetDefaultMode = reinterpret_cast<zes_pfnFanSetDefaultMode_t>(
+                GET_FUNCTION_PTR(loader, "zesFanSetDefaultMode") );
+            initialzesDdiTable.Fan.pfnSetFixedSpeedMode = reinterpret_cast<zes_pfnFanSetFixedSpeedMode_t>(
+                GET_FUNCTION_PTR(loader, "zesFanSetFixedSpeedMode") );
+            initialzesDdiTable.Fan.pfnSetSpeedTableMode = reinterpret_cast<zes_pfnFanSetSpeedTableMode_t>(
+                GET_FUNCTION_PTR(loader, "zesFanSetSpeedTableMode") );
+            initialzesDdiTable.Fan.pfnGetState = reinterpret_cast<zes_pfnFanGetState_t>(
+                GET_FUNCTION_PTR(loader, "zesFanGetState") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -92,6 +226,14 @@ namespace ze_lib
             auto getTable = reinterpret_cast<zes_pfnGetFirmwareProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetFirmwareProcAddrTable") );
             result = getTableWithCheck(getTable, version, &initialzesDdiTable.Firmware );
+            initialzesDdiTable.Firmware.pfnGetProperties = reinterpret_cast<zes_pfnFirmwareGetProperties_t>(
+                GET_FUNCTION_PTR(loader, "zesFirmwareGetProperties") );
+            initialzesDdiTable.Firmware.pfnFlash = reinterpret_cast<zes_pfnFirmwareFlash_t>(
+                GET_FUNCTION_PTR(loader, "zesFirmwareFlash") );
+            initialzesDdiTable.Firmware.pfnGetFlashProgress = reinterpret_cast<zes_pfnFirmwareGetFlashProgress_t>(
+                GET_FUNCTION_PTR(loader, "zesFirmwareGetFlashProgress") );
+            initialzesDdiTable.Firmware.pfnGetConsoleLogs = reinterpret_cast<zes_pfnFirmwareGetConsoleLogs_t>(
+                GET_FUNCTION_PTR(loader, "zesFirmwareGetConsoleLogs") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -100,6 +242,10 @@ namespace ze_lib
             auto getTable = reinterpret_cast<zes_pfnGetFirmwareExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetFirmwareExpProcAddrTable") );
             getTableWithCheck(getTable, version, &initialzesDdiTable.FirmwareExp );
+            initialzesDdiTable.FirmwareExp.pfnGetSecurityVersionExp = reinterpret_cast<zes_pfnFirmwareGetSecurityVersionExp_t>(
+                GET_FUNCTION_PTR(loader, "zesFirmwareGetSecurityVersionExp") );
+            initialzesDdiTable.FirmwareExp.pfnSetSecurityVersionExp = reinterpret_cast<zes_pfnFirmwareSetSecurityVersionExp_t>(
+                GET_FUNCTION_PTR(loader, "zesFirmwareSetSecurityVersionExp") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -107,6 +253,40 @@ namespace ze_lib
             auto getTable = reinterpret_cast<zes_pfnGetFrequencyProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetFrequencyProcAddrTable") );
             result = getTableWithCheck(getTable, version, &initialzesDdiTable.Frequency );
+            initialzesDdiTable.Frequency.pfnGetProperties = reinterpret_cast<zes_pfnFrequencyGetProperties_t>(
+                GET_FUNCTION_PTR(loader, "zesFrequencyGetProperties") );
+            initialzesDdiTable.Frequency.pfnGetAvailableClocks = reinterpret_cast<zes_pfnFrequencyGetAvailableClocks_t>(
+                GET_FUNCTION_PTR(loader, "zesFrequencyGetAvailableClocks") );
+            initialzesDdiTable.Frequency.pfnGetRange = reinterpret_cast<zes_pfnFrequencyGetRange_t>(
+                GET_FUNCTION_PTR(loader, "zesFrequencyGetRange") );
+            initialzesDdiTable.Frequency.pfnSetRange = reinterpret_cast<zes_pfnFrequencySetRange_t>(
+                GET_FUNCTION_PTR(loader, "zesFrequencySetRange") );
+            initialzesDdiTable.Frequency.pfnGetState = reinterpret_cast<zes_pfnFrequencyGetState_t>(
+                GET_FUNCTION_PTR(loader, "zesFrequencyGetState") );
+            initialzesDdiTable.Frequency.pfnGetThrottleTime = reinterpret_cast<zes_pfnFrequencyGetThrottleTime_t>(
+                GET_FUNCTION_PTR(loader, "zesFrequencyGetThrottleTime") );
+            initialzesDdiTable.Frequency.pfnOcGetCapabilities = reinterpret_cast<zes_pfnFrequencyOcGetCapabilities_t>(
+                GET_FUNCTION_PTR(loader, "zesFrequencyOcGetCapabilities") );
+            initialzesDdiTable.Frequency.pfnOcGetFrequencyTarget = reinterpret_cast<zes_pfnFrequencyOcGetFrequencyTarget_t>(
+                GET_FUNCTION_PTR(loader, "zesFrequencyOcGetFrequencyTarget") );
+            initialzesDdiTable.Frequency.pfnOcSetFrequencyTarget = reinterpret_cast<zes_pfnFrequencyOcSetFrequencyTarget_t>(
+                GET_FUNCTION_PTR(loader, "zesFrequencyOcSetFrequencyTarget") );
+            initialzesDdiTable.Frequency.pfnOcGetVoltageTarget = reinterpret_cast<zes_pfnFrequencyOcGetVoltageTarget_t>(
+                GET_FUNCTION_PTR(loader, "zesFrequencyOcGetVoltageTarget") );
+            initialzesDdiTable.Frequency.pfnOcSetVoltageTarget = reinterpret_cast<zes_pfnFrequencyOcSetVoltageTarget_t>(
+                GET_FUNCTION_PTR(loader, "zesFrequencyOcSetVoltageTarget") );
+            initialzesDdiTable.Frequency.pfnOcSetMode = reinterpret_cast<zes_pfnFrequencyOcSetMode_t>(
+                GET_FUNCTION_PTR(loader, "zesFrequencyOcSetMode") );
+            initialzesDdiTable.Frequency.pfnOcGetMode = reinterpret_cast<zes_pfnFrequencyOcGetMode_t>(
+                GET_FUNCTION_PTR(loader, "zesFrequencyOcGetMode") );
+            initialzesDdiTable.Frequency.pfnOcGetIccMax = reinterpret_cast<zes_pfnFrequencyOcGetIccMax_t>(
+                GET_FUNCTION_PTR(loader, "zesFrequencyOcGetIccMax") );
+            initialzesDdiTable.Frequency.pfnOcSetIccMax = reinterpret_cast<zes_pfnFrequencyOcSetIccMax_t>(
+                GET_FUNCTION_PTR(loader, "zesFrequencyOcSetIccMax") );
+            initialzesDdiTable.Frequency.pfnOcGetTjMax = reinterpret_cast<zes_pfnFrequencyOcGetTjMax_t>(
+                GET_FUNCTION_PTR(loader, "zesFrequencyOcGetTjMax") );
+            initialzesDdiTable.Frequency.pfnOcSetTjMax = reinterpret_cast<zes_pfnFrequencyOcSetTjMax_t>(
+                GET_FUNCTION_PTR(loader, "zesFrequencyOcSetTjMax") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -114,6 +294,14 @@ namespace ze_lib
             auto getTable = reinterpret_cast<zes_pfnGetLedProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetLedProcAddrTable") );
             result = getTableWithCheck(getTable, version, &initialzesDdiTable.Led );
+            initialzesDdiTable.Led.pfnGetProperties = reinterpret_cast<zes_pfnLedGetProperties_t>(
+                GET_FUNCTION_PTR(loader, "zesLedGetProperties") );
+            initialzesDdiTable.Led.pfnGetState = reinterpret_cast<zes_pfnLedGetState_t>(
+                GET_FUNCTION_PTR(loader, "zesLedGetState") );
+            initialzesDdiTable.Led.pfnSetState = reinterpret_cast<zes_pfnLedSetState_t>(
+                GET_FUNCTION_PTR(loader, "zesLedSetState") );
+            initialzesDdiTable.Led.pfnSetColor = reinterpret_cast<zes_pfnLedSetColor_t>(
+                GET_FUNCTION_PTR(loader, "zesLedSetColor") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -121,6 +309,12 @@ namespace ze_lib
             auto getTable = reinterpret_cast<zes_pfnGetMemoryProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetMemoryProcAddrTable") );
             result = getTableWithCheck(getTable, version, &initialzesDdiTable.Memory );
+            initialzesDdiTable.Memory.pfnGetProperties = reinterpret_cast<zes_pfnMemoryGetProperties_t>(
+                GET_FUNCTION_PTR(loader, "zesMemoryGetProperties") );
+            initialzesDdiTable.Memory.pfnGetState = reinterpret_cast<zes_pfnMemoryGetState_t>(
+                GET_FUNCTION_PTR(loader, "zesMemoryGetState") );
+            initialzesDdiTable.Memory.pfnGetBandwidth = reinterpret_cast<zes_pfnMemoryGetBandwidth_t>(
+                GET_FUNCTION_PTR(loader, "zesMemoryGetBandwidth") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -129,6 +323,24 @@ namespace ze_lib
             auto getTable = reinterpret_cast<zes_pfnGetOverclockProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetOverclockProcAddrTable") );
             getTableWithCheck(getTable, version, &initialzesDdiTable.Overclock );
+            initialzesDdiTable.Overclock.pfnGetDomainProperties = reinterpret_cast<zes_pfnOverclockGetDomainProperties_t>(
+                GET_FUNCTION_PTR(loader, "zesOverclockGetDomainProperties") );
+            initialzesDdiTable.Overclock.pfnGetDomainVFProperties = reinterpret_cast<zes_pfnOverclockGetDomainVFProperties_t>(
+                GET_FUNCTION_PTR(loader, "zesOverclockGetDomainVFProperties") );
+            initialzesDdiTable.Overclock.pfnGetDomainControlProperties = reinterpret_cast<zes_pfnOverclockGetDomainControlProperties_t>(
+                GET_FUNCTION_PTR(loader, "zesOverclockGetDomainControlProperties") );
+            initialzesDdiTable.Overclock.pfnGetControlCurrentValue = reinterpret_cast<zes_pfnOverclockGetControlCurrentValue_t>(
+                GET_FUNCTION_PTR(loader, "zesOverclockGetControlCurrentValue") );
+            initialzesDdiTable.Overclock.pfnGetControlPendingValue = reinterpret_cast<zes_pfnOverclockGetControlPendingValue_t>(
+                GET_FUNCTION_PTR(loader, "zesOverclockGetControlPendingValue") );
+            initialzesDdiTable.Overclock.pfnSetControlUserValue = reinterpret_cast<zes_pfnOverclockSetControlUserValue_t>(
+                GET_FUNCTION_PTR(loader, "zesOverclockSetControlUserValue") );
+            initialzesDdiTable.Overclock.pfnGetControlState = reinterpret_cast<zes_pfnOverclockGetControlState_t>(
+                GET_FUNCTION_PTR(loader, "zesOverclockGetControlState") );
+            initialzesDdiTable.Overclock.pfnGetVFPointValues = reinterpret_cast<zes_pfnOverclockGetVFPointValues_t>(
+                GET_FUNCTION_PTR(loader, "zesOverclockGetVFPointValues") );
+            initialzesDdiTable.Overclock.pfnSetVFPointValues = reinterpret_cast<zes_pfnOverclockSetVFPointValues_t>(
+                GET_FUNCTION_PTR(loader, "zesOverclockSetVFPointValues") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -136,6 +348,12 @@ namespace ze_lib
             auto getTable = reinterpret_cast<zes_pfnGetPerformanceFactorProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetPerformanceFactorProcAddrTable") );
             result = getTableWithCheck(getTable, version, &initialzesDdiTable.PerformanceFactor );
+            initialzesDdiTable.PerformanceFactor.pfnGetProperties = reinterpret_cast<zes_pfnPerformanceFactorGetProperties_t>(
+                GET_FUNCTION_PTR(loader, "zesPerformanceFactorGetProperties") );
+            initialzesDdiTable.PerformanceFactor.pfnGetConfig = reinterpret_cast<zes_pfnPerformanceFactorGetConfig_t>(
+                GET_FUNCTION_PTR(loader, "zesPerformanceFactorGetConfig") );
+            initialzesDdiTable.PerformanceFactor.pfnSetConfig = reinterpret_cast<zes_pfnPerformanceFactorSetConfig_t>(
+                GET_FUNCTION_PTR(loader, "zesPerformanceFactorSetConfig") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -143,6 +361,22 @@ namespace ze_lib
             auto getTable = reinterpret_cast<zes_pfnGetPowerProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetPowerProcAddrTable") );
             result = getTableWithCheck(getTable, version, &initialzesDdiTable.Power );
+            initialzesDdiTable.Power.pfnGetProperties = reinterpret_cast<zes_pfnPowerGetProperties_t>(
+                GET_FUNCTION_PTR(loader, "zesPowerGetProperties") );
+            initialzesDdiTable.Power.pfnGetEnergyCounter = reinterpret_cast<zes_pfnPowerGetEnergyCounter_t>(
+                GET_FUNCTION_PTR(loader, "zesPowerGetEnergyCounter") );
+            initialzesDdiTable.Power.pfnGetLimits = reinterpret_cast<zes_pfnPowerGetLimits_t>(
+                GET_FUNCTION_PTR(loader, "zesPowerGetLimits") );
+            initialzesDdiTable.Power.pfnSetLimits = reinterpret_cast<zes_pfnPowerSetLimits_t>(
+                GET_FUNCTION_PTR(loader, "zesPowerSetLimits") );
+            initialzesDdiTable.Power.pfnGetEnergyThreshold = reinterpret_cast<zes_pfnPowerGetEnergyThreshold_t>(
+                GET_FUNCTION_PTR(loader, "zesPowerGetEnergyThreshold") );
+            initialzesDdiTable.Power.pfnSetEnergyThreshold = reinterpret_cast<zes_pfnPowerSetEnergyThreshold_t>(
+                GET_FUNCTION_PTR(loader, "zesPowerSetEnergyThreshold") );
+            initialzesDdiTable.Power.pfnGetLimitsExt = reinterpret_cast<zes_pfnPowerGetLimitsExt_t>(
+                GET_FUNCTION_PTR(loader, "zesPowerGetLimitsExt") );
+            initialzesDdiTable.Power.pfnSetLimitsExt = reinterpret_cast<zes_pfnPowerSetLimitsExt_t>(
+                GET_FUNCTION_PTR(loader, "zesPowerSetLimitsExt") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -150,6 +384,10 @@ namespace ze_lib
             auto getTable = reinterpret_cast<zes_pfnGetPsuProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetPsuProcAddrTable") );
             result = getTableWithCheck(getTable, version, &initialzesDdiTable.Psu );
+            initialzesDdiTable.Psu.pfnGetProperties = reinterpret_cast<zes_pfnPsuGetProperties_t>(
+                GET_FUNCTION_PTR(loader, "zesPsuGetProperties") );
+            initialzesDdiTable.Psu.pfnGetState = reinterpret_cast<zes_pfnPsuGetState_t>(
+                GET_FUNCTION_PTR(loader, "zesPsuGetState") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -157,6 +395,14 @@ namespace ze_lib
             auto getTable = reinterpret_cast<zes_pfnGetRasProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetRasProcAddrTable") );
             result = getTableWithCheck(getTable, version, &initialzesDdiTable.Ras );
+            initialzesDdiTable.Ras.pfnGetProperties = reinterpret_cast<zes_pfnRasGetProperties_t>(
+                GET_FUNCTION_PTR(loader, "zesRasGetProperties") );
+            initialzesDdiTable.Ras.pfnGetConfig = reinterpret_cast<zes_pfnRasGetConfig_t>(
+                GET_FUNCTION_PTR(loader, "zesRasGetConfig") );
+            initialzesDdiTable.Ras.pfnSetConfig = reinterpret_cast<zes_pfnRasSetConfig_t>(
+                GET_FUNCTION_PTR(loader, "zesRasSetConfig") );
+            initialzesDdiTable.Ras.pfnGetState = reinterpret_cast<zes_pfnRasGetState_t>(
+                GET_FUNCTION_PTR(loader, "zesRasGetState") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -165,6 +411,10 @@ namespace ze_lib
             auto getTable = reinterpret_cast<zes_pfnGetRasExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetRasExpProcAddrTable") );
             getTableWithCheck(getTable, version, &initialzesDdiTable.RasExp );
+            initialzesDdiTable.RasExp.pfnGetStateExp = reinterpret_cast<zes_pfnRasGetStateExp_t>(
+                GET_FUNCTION_PTR(loader, "zesRasGetStateExp") );
+            initialzesDdiTable.RasExp.pfnClearStateExp = reinterpret_cast<zes_pfnRasClearStateExp_t>(
+                GET_FUNCTION_PTR(loader, "zesRasClearStateExp") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -172,6 +422,22 @@ namespace ze_lib
             auto getTable = reinterpret_cast<zes_pfnGetSchedulerProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetSchedulerProcAddrTable") );
             result = getTableWithCheck(getTable, version, &initialzesDdiTable.Scheduler );
+            initialzesDdiTable.Scheduler.pfnGetProperties = reinterpret_cast<zes_pfnSchedulerGetProperties_t>(
+                GET_FUNCTION_PTR(loader, "zesSchedulerGetProperties") );
+            initialzesDdiTable.Scheduler.pfnGetCurrentMode = reinterpret_cast<zes_pfnSchedulerGetCurrentMode_t>(
+                GET_FUNCTION_PTR(loader, "zesSchedulerGetCurrentMode") );
+            initialzesDdiTable.Scheduler.pfnGetTimeoutModeProperties = reinterpret_cast<zes_pfnSchedulerGetTimeoutModeProperties_t>(
+                GET_FUNCTION_PTR(loader, "zesSchedulerGetTimeoutModeProperties") );
+            initialzesDdiTable.Scheduler.pfnGetTimesliceModeProperties = reinterpret_cast<zes_pfnSchedulerGetTimesliceModeProperties_t>(
+                GET_FUNCTION_PTR(loader, "zesSchedulerGetTimesliceModeProperties") );
+            initialzesDdiTable.Scheduler.pfnSetTimeoutMode = reinterpret_cast<zes_pfnSchedulerSetTimeoutMode_t>(
+                GET_FUNCTION_PTR(loader, "zesSchedulerSetTimeoutMode") );
+            initialzesDdiTable.Scheduler.pfnSetTimesliceMode = reinterpret_cast<zes_pfnSchedulerSetTimesliceMode_t>(
+                GET_FUNCTION_PTR(loader, "zesSchedulerSetTimesliceMode") );
+            initialzesDdiTable.Scheduler.pfnSetExclusiveMode = reinterpret_cast<zes_pfnSchedulerSetExclusiveMode_t>(
+                GET_FUNCTION_PTR(loader, "zesSchedulerSetExclusiveMode") );
+            initialzesDdiTable.Scheduler.pfnSetComputeUnitDebugMode = reinterpret_cast<zes_pfnSchedulerSetComputeUnitDebugMode_t>(
+                GET_FUNCTION_PTR(loader, "zesSchedulerSetComputeUnitDebugMode") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -179,6 +445,12 @@ namespace ze_lib
             auto getTable = reinterpret_cast<zes_pfnGetStandbyProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetStandbyProcAddrTable") );
             result = getTableWithCheck(getTable, version, &initialzesDdiTable.Standby );
+            initialzesDdiTable.Standby.pfnGetProperties = reinterpret_cast<zes_pfnStandbyGetProperties_t>(
+                GET_FUNCTION_PTR(loader, "zesStandbyGetProperties") );
+            initialzesDdiTable.Standby.pfnGetMode = reinterpret_cast<zes_pfnStandbyGetMode_t>(
+                GET_FUNCTION_PTR(loader, "zesStandbyGetMode") );
+            initialzesDdiTable.Standby.pfnSetMode = reinterpret_cast<zes_pfnStandbySetMode_t>(
+                GET_FUNCTION_PTR(loader, "zesStandbySetMode") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -186,6 +458,14 @@ namespace ze_lib
             auto getTable = reinterpret_cast<zes_pfnGetTemperatureProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetTemperatureProcAddrTable") );
             result = getTableWithCheck(getTable, version, &initialzesDdiTable.Temperature );
+            initialzesDdiTable.Temperature.pfnGetProperties = reinterpret_cast<zes_pfnTemperatureGetProperties_t>(
+                GET_FUNCTION_PTR(loader, "zesTemperatureGetProperties") );
+            initialzesDdiTable.Temperature.pfnGetConfig = reinterpret_cast<zes_pfnTemperatureGetConfig_t>(
+                GET_FUNCTION_PTR(loader, "zesTemperatureGetConfig") );
+            initialzesDdiTable.Temperature.pfnSetConfig = reinterpret_cast<zes_pfnTemperatureSetConfig_t>(
+                GET_FUNCTION_PTR(loader, "zesTemperatureSetConfig") );
+            initialzesDdiTable.Temperature.pfnGetState = reinterpret_cast<zes_pfnTemperatureGetState_t>(
+                GET_FUNCTION_PTR(loader, "zesTemperatureGetState") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -194,6 +474,24 @@ namespace ze_lib
             auto getTable = reinterpret_cast<zes_pfnGetVFManagementExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zesGetVFManagementExpProcAddrTable") );
             getTableWithCheck(getTable, version, &initialzesDdiTable.VFManagementExp );
+            initialzesDdiTable.VFManagementExp.pfnGetVFCapabilitiesExp = reinterpret_cast<zes_pfnVFManagementGetVFCapabilitiesExp_t>(
+                GET_FUNCTION_PTR(loader, "zesVFManagementGetVFCapabilitiesExp") );
+            initialzesDdiTable.VFManagementExp.pfnGetVFMemoryUtilizationExp2 = reinterpret_cast<zes_pfnVFManagementGetVFMemoryUtilizationExp2_t>(
+                GET_FUNCTION_PTR(loader, "zesVFManagementGetVFMemoryUtilizationExp2") );
+            initialzesDdiTable.VFManagementExp.pfnGetVFEngineUtilizationExp2 = reinterpret_cast<zes_pfnVFManagementGetVFEngineUtilizationExp2_t>(
+                GET_FUNCTION_PTR(loader, "zesVFManagementGetVFEngineUtilizationExp2") );
+            initialzesDdiTable.VFManagementExp.pfnGetVFCapabilitiesExp2 = reinterpret_cast<zes_pfnVFManagementGetVFCapabilitiesExp2_t>(
+                GET_FUNCTION_PTR(loader, "zesVFManagementGetVFCapabilitiesExp2") );
+            initialzesDdiTable.VFManagementExp.pfnGetVFPropertiesExp = reinterpret_cast<zes_pfnVFManagementGetVFPropertiesExp_t>(
+                GET_FUNCTION_PTR(loader, "zesVFManagementGetVFPropertiesExp") );
+            initialzesDdiTable.VFManagementExp.pfnGetVFMemoryUtilizationExp = reinterpret_cast<zes_pfnVFManagementGetVFMemoryUtilizationExp_t>(
+                GET_FUNCTION_PTR(loader, "zesVFManagementGetVFMemoryUtilizationExp") );
+            initialzesDdiTable.VFManagementExp.pfnGetVFEngineUtilizationExp = reinterpret_cast<zes_pfnVFManagementGetVFEngineUtilizationExp_t>(
+                GET_FUNCTION_PTR(loader, "zesVFManagementGetVFEngineUtilizationExp") );
+            initialzesDdiTable.VFManagementExp.pfnSetVFTelemetryModeExp = reinterpret_cast<zes_pfnVFManagementSetVFTelemetryModeExp_t>(
+                GET_FUNCTION_PTR(loader, "zesVFManagementSetVFTelemetryModeExp") );
+            initialzesDdiTable.VFManagementExp.pfnSetVFTelemetrySamplingIntervalExp = reinterpret_cast<zes_pfnVFManagementSetVFTelemetrySamplingIntervalExp_t>(
+                GET_FUNCTION_PTR(loader, "zesVFManagementSetVFTelemetrySamplingIntervalExp") );
         }
 
         return result;

--- a/source/lib/zet_libapi.cpp
+++ b/source/lib/zet_libapi.cpp
@@ -2937,6 +2937,8 @@ zetMetricGroupCloseExp(
 ///     - It is necessary to call ::zetMetricDestroyExp for each of the metric
 ///       handles (created from ::zetMetricCreateFromProgrammableExp2) to
 ///       destroy them.
+///     - It is not necessary to remove the metrics in the metricGroup before
+///       destroying it.
 /// 
 /// @returns
 ///     - ::ZE_RESULT_SUCCESS

--- a/source/lib/zet_libapi.cpp
+++ b/source/lib/zet_libapi.cpp
@@ -44,6 +44,23 @@ zetModuleGetDebugInfo(
     uint8_t* pDebugInfo                             ///< [in,out][optional] byte pointer to debug info
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnModuleGetDebugInfo_t pfnGetDebugInfo = [&result] {
+        auto pfnGetDebugInfo = ze_lib::context->zetDdiTable.load()->Module.pfnGetDebugInfo;
+        if( nullptr == pfnGetDebugInfo ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetDebugInfo;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetDebugInfo( hModule, format, pSize, pDebugInfo );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -57,6 +74,7 @@ zetModuleGetDebugInfo(
     }
 
     return pfnGetDebugInfo( hModule, format, pSize, pDebugInfo );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -78,6 +96,23 @@ zetDeviceGetDebugProperties(
     zet_device_debug_properties_t* pDebugProperties ///< [in,out] query result for debug properties
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnDeviceGetDebugProperties_t pfnGetDebugProperties = [&result] {
+        auto pfnGetDebugProperties = ze_lib::context->zetDdiTable.load()->Device.pfnGetDebugProperties;
+        if( nullptr == pfnGetDebugProperties ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetDebugProperties;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetDebugProperties( hDevice, pDebugProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -91,6 +126,7 @@ zetDeviceGetDebugProperties(
     }
 
     return pfnGetDebugProperties( hDevice, pDebugProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -124,6 +160,23 @@ zetDebugAttach(
     zet_debug_session_handle_t* phDebug             ///< [out] debug session handle
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnDebugAttach_t pfnAttach = [&result] {
+        auto pfnAttach = ze_lib::context->zetDdiTable.load()->Debug.pfnAttach;
+        if( nullptr == pfnAttach ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnAttach;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnAttach( hDevice, config, phDebug );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -137,6 +190,7 @@ zetDebugAttach(
     }
 
     return pfnAttach( hDevice, config, phDebug );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -155,6 +209,23 @@ zetDebugDetach(
     zet_debug_session_handle_t hDebug               ///< [in][release] debug session handle
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnDebugDetach_t pfnDetach = [&result] {
+        auto pfnDetach = ze_lib::context->zetDdiTable.load()->Debug.pfnDetach;
+        if( nullptr == pfnDetach ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnDetach;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnDetach( hDebug );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -168,6 +239,7 @@ zetDebugDetach(
     }
 
     return pfnDetach( hDebug );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -198,6 +270,23 @@ zetDebugReadEvent(
     zet_debug_event_t* event                        ///< [in,out] a pointer to a ::zet_debug_event_t.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnDebugReadEvent_t pfnReadEvent = [&result] {
+        auto pfnReadEvent = ze_lib::context->zetDdiTable.load()->Debug.pfnReadEvent;
+        if( nullptr == pfnReadEvent ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnReadEvent;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnReadEvent( hDebug, timeout, event );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -211,6 +300,7 @@ zetDebugReadEvent(
     }
 
     return pfnReadEvent( hDebug, timeout, event );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -232,6 +322,23 @@ zetDebugAcknowledgeEvent(
     const zet_debug_event_t* event                  ///< [in] a pointer to a ::zet_debug_event_t.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnDebugAcknowledgeEvent_t pfnAcknowledgeEvent = [&result] {
+        auto pfnAcknowledgeEvent = ze_lib::context->zetDdiTable.load()->Debug.pfnAcknowledgeEvent;
+        if( nullptr == pfnAcknowledgeEvent ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnAcknowledgeEvent;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnAcknowledgeEvent( hDebug, event );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -245,6 +352,7 @@ zetDebugAcknowledgeEvent(
     }
 
     return pfnAcknowledgeEvent( hDebug, event );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -266,6 +374,23 @@ zetDebugInterrupt(
     ze_device_thread_t thread                       ///< [in] the thread to interrupt
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnDebugInterrupt_t pfnInterrupt = [&result] {
+        auto pfnInterrupt = ze_lib::context->zetDdiTable.load()->Debug.pfnInterrupt;
+        if( nullptr == pfnInterrupt ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnInterrupt;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnInterrupt( hDebug, thread );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -279,6 +404,7 @@ zetDebugInterrupt(
     }
 
     return pfnInterrupt( hDebug, thread );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -300,6 +426,23 @@ zetDebugResume(
     ze_device_thread_t thread                       ///< [in] the thread to resume
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnDebugResume_t pfnResume = [&result] {
+        auto pfnResume = ze_lib::context->zetDdiTable.load()->Debug.pfnResume;
+        if( nullptr == pfnResume ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnResume;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnResume( hDebug, thread );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -313,6 +456,7 @@ zetDebugResume(
     }
 
     return pfnResume( hDebug, thread );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -347,6 +491,23 @@ zetDebugReadMemory(
     void* buffer                                    ///< [in,out] a buffer to hold a copy of the memory
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnDebugReadMemory_t pfnReadMemory = [&result] {
+        auto pfnReadMemory = ze_lib::context->zetDdiTable.load()->Debug.pfnReadMemory;
+        if( nullptr == pfnReadMemory ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnReadMemory;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnReadMemory( hDebug, thread, desc, size, buffer );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -360,6 +521,7 @@ zetDebugReadMemory(
     }
 
     return pfnReadMemory( hDebug, thread, desc, size, buffer );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -394,6 +556,23 @@ zetDebugWriteMemory(
     const void* buffer                              ///< [in] a buffer holding the pattern to write
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnDebugWriteMemory_t pfnWriteMemory = [&result] {
+        auto pfnWriteMemory = ze_lib::context->zetDdiTable.load()->Debug.pfnWriteMemory;
+        if( nullptr == pfnWriteMemory ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnWriteMemory;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnWriteMemory( hDebug, thread, desc, size, buffer );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -407,6 +586,7 @@ zetDebugWriteMemory(
     }
 
     return pfnWriteMemory( hDebug, thread, desc, size, buffer );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -437,6 +617,23 @@ zetDebugGetRegisterSetProperties(
                                                     ///< then driver shall only retrieve that number of register set properties.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnDebugGetRegisterSetProperties_t pfnGetRegisterSetProperties = [&result] {
+        auto pfnGetRegisterSetProperties = ze_lib::context->zetDdiTable.load()->Debug.pfnGetRegisterSetProperties;
+        if( nullptr == pfnGetRegisterSetProperties ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetRegisterSetProperties;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetRegisterSetProperties( hDevice, pCount, pRegisterSetProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -450,6 +647,7 @@ zetDebugGetRegisterSetProperties(
     }
 
     return pfnGetRegisterSetProperties( hDevice, pCount, pRegisterSetProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -485,6 +683,23 @@ zetDebugGetThreadRegisterSetProperties(
                                                     ///< then driver shall only retrieve that number of register set properties.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnDebugGetThreadRegisterSetProperties_t pfnGetThreadRegisterSetProperties = [&result] {
+        auto pfnGetThreadRegisterSetProperties = ze_lib::context->zetDdiTable.load()->Debug.pfnGetThreadRegisterSetProperties;
+        if( nullptr == pfnGetThreadRegisterSetProperties ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetThreadRegisterSetProperties;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetThreadRegisterSetProperties( hDebug, thread, pCount, pRegisterSetProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -498,6 +713,7 @@ zetDebugGetThreadRegisterSetProperties(
     }
 
     return pfnGetThreadRegisterSetProperties( hDebug, thread, pCount, pRegisterSetProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -527,6 +743,23 @@ zetDebugReadRegisters(
     void* pRegisterValues                           ///< [in,out][optional][range(0, count)] buffer of register values
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnDebugReadRegisters_t pfnReadRegisters = [&result] {
+        auto pfnReadRegisters = ze_lib::context->zetDdiTable.load()->Debug.pfnReadRegisters;
+        if( nullptr == pfnReadRegisters ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnReadRegisters;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnReadRegisters( hDebug, thread, type, start, count, pRegisterValues );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -540,6 +773,7 @@ zetDebugReadRegisters(
     }
 
     return pfnReadRegisters( hDebug, thread, type, start, count, pRegisterValues );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -569,6 +803,23 @@ zetDebugWriteRegisters(
     void* pRegisterValues                           ///< [in,out][optional][range(0, count)] buffer of register values
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnDebugWriteRegisters_t pfnWriteRegisters = [&result] {
+        auto pfnWriteRegisters = ze_lib::context->zetDdiTable.load()->Debug.pfnWriteRegisters;
+        if( nullptr == pfnWriteRegisters ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnWriteRegisters;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnWriteRegisters( hDebug, thread, type, start, count, pRegisterValues );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -582,6 +833,7 @@ zetDebugWriteRegisters(
     }
 
     return pfnWriteRegisters( hDebug, thread, type, start, count, pRegisterValues );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -614,6 +866,23 @@ zetMetricGroupGet(
                                                     ///< driver shall only retrieve that number of metric groups.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnMetricGroupGet_t pfnGet = [&result] {
+        auto pfnGet = ze_lib::context->zetDdiTable.load()->MetricGroup.pfnGet;
+        if( nullptr == pfnGet ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGet;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGet( hDevice, pCount, phMetricGroups );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -627,6 +896,7 @@ zetMetricGroupGet(
     }
 
     return pfnGet( hDevice, pCount, phMetricGroups );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -651,6 +921,23 @@ zetMetricGroupGetProperties(
     zet_metric_group_properties_t* pProperties      ///< [in,out] metric group properties
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnMetricGroupGetProperties_t pfnGetProperties = [&result] {
+        auto pfnGetProperties = ze_lib::context->zetDdiTable.load()->MetricGroup.pfnGetProperties;
+        if( nullptr == pfnGetProperties ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetProperties;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetProperties( hMetricGroup, pProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -664,6 +951,7 @@ zetMetricGroupGetProperties(
     }
 
     return pfnGetProperties( hMetricGroup, pProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -702,6 +990,23 @@ zetMetricGroupCalculateMetricValues(
                                                     ///< then driver shall only calculate that number of metric values.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnMetricGroupCalculateMetricValues_t pfnCalculateMetricValues = [&result] {
+        auto pfnCalculateMetricValues = ze_lib::context->zetDdiTable.load()->MetricGroup.pfnCalculateMetricValues;
+        if( nullptr == pfnCalculateMetricValues ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnCalculateMetricValues;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnCalculateMetricValues( hMetricGroup, type, rawDataSize, pRawData, pMetricValueCount, pMetricValues );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -715,6 +1020,7 @@ zetMetricGroupCalculateMetricValues(
     }
 
     return pfnCalculateMetricValues( hMetricGroup, type, rawDataSize, pRawData, pMetricValueCount, pMetricValues );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -746,6 +1052,23 @@ zetMetricGet(
                                                     ///< shall only retrieve that number of metrics.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnMetricGet_t pfnGet = [&result] {
+        auto pfnGet = ze_lib::context->zetDdiTable.load()->Metric.pfnGet;
+        if( nullptr == pfnGet ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGet;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGet( hMetricGroup, pCount, phMetrics );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -759,6 +1082,7 @@ zetMetricGet(
     }
 
     return pfnGet( hMetricGroup, pCount, phMetrics );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -783,6 +1107,23 @@ zetMetricGetProperties(
     zet_metric_properties_t* pProperties            ///< [in,out] metric properties
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnMetricGetProperties_t pfnGetProperties = [&result] {
+        auto pfnGetProperties = ze_lib::context->zetDdiTable.load()->Metric.pfnGetProperties;
+        if( nullptr == pfnGetProperties ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetProperties;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetProperties( hMetric, pProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -796,6 +1137,7 @@ zetMetricGetProperties(
     }
 
     return pfnGetProperties( hMetric, pProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -838,6 +1180,23 @@ zetContextActivateMetricGroups(
                                                     ///< metric query and metric stream must use activated metric groups.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnContextActivateMetricGroups_t pfnActivateMetricGroups = [&result] {
+        auto pfnActivateMetricGroups = ze_lib::context->zetDdiTable.load()->Context.pfnActivateMetricGroups;
+        if( nullptr == pfnActivateMetricGroups ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnActivateMetricGroups;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnActivateMetricGroups( hContext, hDevice, count, phMetricGroups );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -851,6 +1210,7 @@ zetContextActivateMetricGroups(
     }
 
     return pfnActivateMetricGroups( hContext, hDevice, count, phMetricGroups );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -890,6 +1250,23 @@ zetMetricStreamerOpen(
     zet_metric_streamer_handle_t* phMetricStreamer  ///< [out] handle of metric streamer
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnMetricStreamerOpen_t pfnOpen = [&result] {
+        auto pfnOpen = ze_lib::context->zetDdiTable.load()->MetricStreamer.pfnOpen;
+        if( nullptr == pfnOpen ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnOpen;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnOpen( hContext, hDevice, hMetricGroup, desc, hNotificationEvent, phMetricStreamer );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -903,6 +1280,7 @@ zetMetricStreamerOpen(
     }
 
     return pfnOpen( hContext, hDevice, hMetricGroup, desc, hNotificationEvent, phMetricStreamer );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -934,6 +1312,23 @@ zetCommandListAppendMetricStreamerMarker(
     uint32_t value                                  ///< [in] streamer marker value
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnCommandListAppendMetricStreamerMarker_t pfnAppendMetricStreamerMarker = [&result] {
+        auto pfnAppendMetricStreamerMarker = ze_lib::context->zetDdiTable.load()->CommandList.pfnAppendMetricStreamerMarker;
+        if( nullptr == pfnAppendMetricStreamerMarker ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnAppendMetricStreamerMarker;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnAppendMetricStreamerMarker( hCommandList, hMetricStreamer, value );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -947,6 +1342,7 @@ zetCommandListAppendMetricStreamerMarker(
     }
 
     return pfnAppendMetricStreamerMarker( hCommandList, hMetricStreamer, value );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -969,6 +1365,23 @@ zetMetricStreamerClose(
     zet_metric_streamer_handle_t hMetricStreamer    ///< [in][release] handle of the metric streamer
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnMetricStreamerClose_t pfnClose = [&result] {
+        auto pfnClose = ze_lib::context->zetDdiTable.load()->MetricStreamer.pfnClose;
+        if( nullptr == pfnClose ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnClose;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnClose( hMetricStreamer );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -982,6 +1395,7 @@ zetMetricStreamerClose(
     }
 
     return pfnClose( hMetricStreamer );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1018,6 +1432,23 @@ zetMetricStreamerReadData(
                                                     ///< reports in raw format
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnMetricStreamerReadData_t pfnReadData = [&result] {
+        auto pfnReadData = ze_lib::context->zetDdiTable.load()->MetricStreamer.pfnReadData;
+        if( nullptr == pfnReadData ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnReadData;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnReadData( hMetricStreamer, maxReportCount, pRawDataSize, pRawData );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1031,6 +1462,7 @@ zetMetricStreamerReadData(
     }
 
     return pfnReadData( hMetricStreamer, maxReportCount, pRawDataSize, pRawData );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1064,6 +1496,23 @@ zetMetricQueryPoolCreate(
     zet_metric_query_pool_handle_t* phMetricQueryPool   ///< [out] handle of metric query pool
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnMetricQueryPoolCreate_t pfnCreate = [&result] {
+        auto pfnCreate = ze_lib::context->zetDdiTable.load()->MetricQueryPool.pfnCreate;
+        if( nullptr == pfnCreate ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnCreate;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnCreate( hContext, hDevice, hMetricGroup, desc, phMetricQueryPool );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1077,6 +1526,7 @@ zetMetricQueryPoolCreate(
     }
 
     return pfnCreate( hContext, hDevice, hMetricGroup, desc, phMetricQueryPool );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1105,6 +1555,23 @@ zetMetricQueryPoolDestroy(
     zet_metric_query_pool_handle_t hMetricQueryPool ///< [in][release] handle of the metric query pool
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnMetricQueryPoolDestroy_t pfnDestroy = [&result] {
+        auto pfnDestroy = ze_lib::context->zetDdiTable.load()->MetricQueryPool.pfnDestroy;
+        if( nullptr == pfnDestroy ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnDestroy;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnDestroy( hMetricQueryPool );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1118,6 +1585,7 @@ zetMetricQueryPoolDestroy(
     }
 
     return pfnDestroy( hMetricQueryPool );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1144,6 +1612,23 @@ zetMetricQueryCreate(
     zet_metric_query_handle_t* phMetricQuery        ///< [out] handle of metric query
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnMetricQueryCreate_t pfnCreate = [&result] {
+        auto pfnCreate = ze_lib::context->zetDdiTable.load()->MetricQuery.pfnCreate;
+        if( nullptr == pfnCreate ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnCreate;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnCreate( hMetricQueryPool, index, phMetricQuery );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1157,6 +1642,7 @@ zetMetricQueryCreate(
     }
 
     return pfnCreate( hMetricQueryPool, index, phMetricQuery );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1183,6 +1669,23 @@ zetMetricQueryDestroy(
     zet_metric_query_handle_t hMetricQuery          ///< [in][release] handle of metric query
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnMetricQueryDestroy_t pfnDestroy = [&result] {
+        auto pfnDestroy = ze_lib::context->zetDdiTable.load()->MetricQuery.pfnDestroy;
+        if( nullptr == pfnDestroy ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnDestroy;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnDestroy( hMetricQuery );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1196,6 +1699,7 @@ zetMetricQueryDestroy(
     }
 
     return pfnDestroy( hMetricQuery );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1220,6 +1724,23 @@ zetMetricQueryReset(
     zet_metric_query_handle_t hMetricQuery          ///< [in] handle of metric query
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnMetricQueryReset_t pfnReset = [&result] {
+        auto pfnReset = ze_lib::context->zetDdiTable.load()->MetricQuery.pfnReset;
+        if( nullptr == pfnReset ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnReset;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnReset( hMetricQuery );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1233,6 +1754,7 @@ zetMetricQueryReset(
     }
 
     return pfnReset( hMetricQuery );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1263,6 +1785,23 @@ zetCommandListAppendMetricQueryBegin(
     zet_metric_query_handle_t hMetricQuery          ///< [in] handle of the metric query
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnCommandListAppendMetricQueryBegin_t pfnAppendMetricQueryBegin = [&result] {
+        auto pfnAppendMetricQueryBegin = ze_lib::context->zetDdiTable.load()->CommandList.pfnAppendMetricQueryBegin;
+        if( nullptr == pfnAppendMetricQueryBegin ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnAppendMetricQueryBegin;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnAppendMetricQueryBegin( hCommandList, hMetricQuery );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1276,6 +1815,7 @@ zetCommandListAppendMetricQueryBegin(
     }
 
     return pfnAppendMetricQueryBegin( hCommandList, hMetricQuery );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1320,6 +1860,23 @@ zetCommandListAppendMetricQueryEnd(
     ze_event_handle_t* phWaitEvents                 ///< [in][mbz] must be nullptr
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnCommandListAppendMetricQueryEnd_t pfnAppendMetricQueryEnd = [&result] {
+        auto pfnAppendMetricQueryEnd = ze_lib::context->zetDdiTable.load()->CommandList.pfnAppendMetricQueryEnd;
+        if( nullptr == pfnAppendMetricQueryEnd ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnAppendMetricQueryEnd;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnAppendMetricQueryEnd( hCommandList, hMetricQuery, hSignalEvent, numWaitEvents, phWaitEvents );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1333,6 +1890,7 @@ zetCommandListAppendMetricQueryEnd(
     }
 
     return pfnAppendMetricQueryEnd( hCommandList, hMetricQuery, hSignalEvent, numWaitEvents, phWaitEvents );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1355,6 +1913,23 @@ zetCommandListAppendMetricMemoryBarrier(
     zet_command_list_handle_t hCommandList          ///< [in] handle of the command list
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnCommandListAppendMetricMemoryBarrier_t pfnAppendMetricMemoryBarrier = [&result] {
+        auto pfnAppendMetricMemoryBarrier = ze_lib::context->zetDdiTable.load()->CommandList.pfnAppendMetricMemoryBarrier;
+        if( nullptr == pfnAppendMetricMemoryBarrier ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnAppendMetricMemoryBarrier;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnAppendMetricMemoryBarrier( hCommandList );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1368,6 +1943,7 @@ zetCommandListAppendMetricMemoryBarrier(
     }
 
     return pfnAppendMetricMemoryBarrier( hCommandList );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1400,6 +1976,23 @@ zetMetricQueryGetData(
                                                     ///< reports in raw format
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnMetricQueryGetData_t pfnGetData = [&result] {
+        auto pfnGetData = ze_lib::context->zetDdiTable.load()->MetricQuery.pfnGetData;
+        if( nullptr == pfnGetData ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetData;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetData( hMetricQuery, pRawDataSize, pRawData );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1413,6 +2006,7 @@ zetMetricQueryGetData(
     }
 
     return pfnGetData( hMetricQuery, pRawDataSize, pRawData );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1442,6 +2036,23 @@ zetKernelGetProfileInfo(
     zet_profile_properties_t* pProfileProperties    ///< [out] pointer to profile properties
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnKernelGetProfileInfo_t pfnGetProfileInfo = [&result] {
+        auto pfnGetProfileInfo = ze_lib::context->zetDdiTable.load()->Kernel.pfnGetProfileInfo;
+        if( nullptr == pfnGetProfileInfo ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetProfileInfo;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetProfileInfo( hKernel, pProfileProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1455,6 +2066,7 @@ zetKernelGetProfileInfo(
     }
 
     return pfnGetProfileInfo( hKernel, pProfileProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1486,6 +2098,23 @@ zetTracerExpCreate(
     zet_tracer_exp_handle_t* phTracer               ///< [out] pointer to handle of tracer object created
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnTracerExpCreate_t pfnCreate = [&result] {
+        auto pfnCreate = ze_lib::context->zetDdiTable.load()->TracerExp.pfnCreate;
+        if( nullptr == pfnCreate ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnCreate;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnCreate( hContext, desc, phTracer );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1499,6 +2128,7 @@ zetTracerExpCreate(
     }
 
     return pfnCreate( hContext, desc, phTracer );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1526,6 +2156,23 @@ zetTracerExpDestroy(
     zet_tracer_exp_handle_t hTracer                 ///< [in][release] handle of tracer object to destroy
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnTracerExpDestroy_t pfnDestroy = [&result] {
+        auto pfnDestroy = ze_lib::context->zetDdiTable.load()->TracerExp.pfnDestroy;
+        if( nullptr == pfnDestroy ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnDestroy;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnDestroy( hTracer );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1539,6 +2186,7 @@ zetTracerExpDestroy(
     }
 
     return pfnDestroy( hTracer );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1569,6 +2217,23 @@ zetTracerExpSetPrologues(
     zet_core_callbacks_t* pCoreCbs                  ///< [in] pointer to table of 'core' callback function pointers
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnTracerExpSetPrologues_t pfnSetPrologues = [&result] {
+        auto pfnSetPrologues = ze_lib::context->zetDdiTable.load()->TracerExp.pfnSetPrologues;
+        if( nullptr == pfnSetPrologues ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnSetPrologues;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnSetPrologues( hTracer, pCoreCbs );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1582,6 +2247,7 @@ zetTracerExpSetPrologues(
     }
 
     return pfnSetPrologues( hTracer, pCoreCbs );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1612,6 +2278,23 @@ zetTracerExpSetEpilogues(
     zet_core_callbacks_t* pCoreCbs                  ///< [in] pointer to table of 'core' callback function pointers
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnTracerExpSetEpilogues_t pfnSetEpilogues = [&result] {
+        auto pfnSetEpilogues = ze_lib::context->zetDdiTable.load()->TracerExp.pfnSetEpilogues;
+        if( nullptr == pfnSetEpilogues ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnSetEpilogues;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnSetEpilogues( hTracer, pCoreCbs );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1625,6 +2308,7 @@ zetTracerExpSetEpilogues(
     }
 
     return pfnSetEpilogues( hTracer, pCoreCbs );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1648,6 +2332,23 @@ zetTracerExpSetEnabled(
     ze_bool_t enable                                ///< [in] enable the tracer if true; disable if false
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnTracerExpSetEnabled_t pfnSetEnabled = [&result] {
+        auto pfnSetEnabled = ze_lib::context->zetDdiTable.load()->TracerExp.pfnSetEnabled;
+        if( nullptr == pfnSetEnabled ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnSetEnabled;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnSetEnabled( hTracer, enable );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1661,6 +2362,7 @@ zetTracerExpSetEnabled(
     }
 
     return pfnSetEnabled( hTracer, enable );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1692,6 +2394,23 @@ zetDeviceGetConcurrentMetricGroupsExp(
                                                     ///< replays necessary.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnDeviceGetConcurrentMetricGroupsExp_t pfnGetConcurrentMetricGroupsExp = [&result] {
+        auto pfnGetConcurrentMetricGroupsExp = ze_lib::context->zetDdiTable.load()->DeviceExp.pfnGetConcurrentMetricGroupsExp;
+        if( nullptr == pfnGetConcurrentMetricGroupsExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetConcurrentMetricGroupsExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetConcurrentMetricGroupsExp( hDevice, metricGroupCount, phMetricGroups, pMetricGroupsCountPerConcurrentGroup, pConcurrentGroupCount );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1705,6 +2424,7 @@ zetDeviceGetConcurrentMetricGroupsExp(
     }
 
     return pfnGetConcurrentMetricGroupsExp( hDevice, metricGroupCount, phMetricGroups, pMetricGroupsCountPerConcurrentGroup, pConcurrentGroupCount );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1752,6 +2472,23 @@ zetMetricTracerCreateExp(
     zet_metric_tracer_exp_handle_t* phMetricTracer  ///< [out] handle of the metric tracer
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnMetricTracerCreateExp_t pfnCreateExp = [&result] {
+        auto pfnCreateExp = ze_lib::context->zetDdiTable.load()->MetricTracerExp.pfnCreateExp;
+        if( nullptr == pfnCreateExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnCreateExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnCreateExp( hContext, hDevice, metricGroupCount, phMetricGroups, desc, hNotificationEvent, phMetricTracer );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1765,6 +2502,7 @@ zetMetricTracerCreateExp(
     }
 
     return pfnCreateExp( hContext, hDevice, metricGroupCount, phMetricGroups, desc, hNotificationEvent, phMetricTracer );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1787,6 +2525,23 @@ zetMetricTracerDestroyExp(
     zet_metric_tracer_exp_handle_t hMetricTracer    ///< [in] handle of the metric tracer
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnMetricTracerDestroyExp_t pfnDestroyExp = [&result] {
+        auto pfnDestroyExp = ze_lib::context->zetDdiTable.load()->MetricTracerExp.pfnDestroyExp;
+        if( nullptr == pfnDestroyExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnDestroyExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnDestroyExp( hMetricTracer );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1800,6 +2555,7 @@ zetMetricTracerDestroyExp(
     }
 
     return pfnDestroyExp( hMetricTracer );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1830,6 +2586,23 @@ zetMetricTracerEnableExp(
                                                     ///< when the tracer is active.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnMetricTracerEnableExp_t pfnEnableExp = [&result] {
+        auto pfnEnableExp = ze_lib::context->zetDdiTable.load()->MetricTracerExp.pfnEnableExp;
+        if( nullptr == pfnEnableExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnEnableExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnEnableExp( hMetricTracer, synchronous );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1843,6 +2616,7 @@ zetMetricTracerEnableExp(
     }
 
     return pfnEnableExp( hMetricTracer, synchronous );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1874,6 +2648,23 @@ zetMetricTracerDisableExp(
                                                     ///< has no more data to be retrieved.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnMetricTracerDisableExp_t pfnDisableExp = [&result] {
+        auto pfnDisableExp = ze_lib::context->zetDdiTable.load()->MetricTracerExp.pfnDisableExp;
+        if( nullptr == pfnDisableExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnDisableExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnDisableExp( hMetricTracer, synchronous );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1887,6 +2678,7 @@ zetMetricTracerDisableExp(
     }
 
     return pfnDisableExp( hMetricTracer, synchronous );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1926,6 +2718,23 @@ zetMetricTracerReadDataExp(
                                                     ///< data in raw format
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnMetricTracerReadDataExp_t pfnReadDataExp = [&result] {
+        auto pfnReadDataExp = ze_lib::context->zetDdiTable.load()->MetricTracerExp.pfnReadDataExp;
+        if( nullptr == pfnReadDataExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnReadDataExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnReadDataExp( hMetricTracer, pRawDataSize, pRawData );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1939,6 +2748,7 @@ zetMetricTracerReadDataExp(
     }
 
     return pfnReadDataExp( hMetricTracer, pRawDataSize, pRawData );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1960,6 +2770,23 @@ zetMetricDecoderCreateExp(
     zet_metric_decoder_exp_handle_t* phMetricDecoder///< [out] handle of the metric decoder object
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnMetricDecoderCreateExp_t pfnCreateExp = [&result] {
+        auto pfnCreateExp = ze_lib::context->zetDdiTable.load()->MetricDecoderExp.pfnCreateExp;
+        if( nullptr == pfnCreateExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnCreateExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnCreateExp( hMetricTracer, phMetricDecoder );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1973,6 +2800,7 @@ zetMetricDecoderCreateExp(
     }
 
     return pfnCreateExp( hMetricTracer, phMetricDecoder );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1991,6 +2819,23 @@ zetMetricDecoderDestroyExp(
     zet_metric_decoder_exp_handle_t phMetricDecoder ///< [in] handle of the metric decoder object
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnMetricDecoderDestroyExp_t pfnDestroyExp = [&result] {
+        auto pfnDestroyExp = ze_lib::context->zetDdiTable.load()->MetricDecoderExp.pfnDestroyExp;
+        if( nullptr == pfnDestroyExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnDestroyExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnDestroyExp( phMetricDecoder );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2004,6 +2849,7 @@ zetMetricDecoderDestroyExp(
     }
 
     return pfnDestroyExp( phMetricDecoder );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2044,6 +2890,23 @@ zetMetricDecoderGetDecodableMetricsExp(
                                                     ///< the hMetricDecoder handle provided.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnMetricDecoderGetDecodableMetricsExp_t pfnGetDecodableMetricsExp = [&result] {
+        auto pfnGetDecodableMetricsExp = ze_lib::context->zetDdiTable.load()->MetricDecoderExp.pfnGetDecodableMetricsExp;
+        if( nullptr == pfnGetDecodableMetricsExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetDecodableMetricsExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetDecodableMetricsExp( hMetricDecoder, pCount, phMetrics );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2057,6 +2920,7 @@ zetMetricDecoderGetDecodableMetricsExp(
     }
 
     return pfnGetDecodableMetricsExp( hMetricDecoder, pCount, phMetrics );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2119,6 +2983,23 @@ zetMetricTracerDecodeExp(
                                                     ///< decoded metric entries
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnMetricTracerDecodeExp_t pfnDecodeExp = [&result] {
+        auto pfnDecodeExp = ze_lib::context->zetDdiTable.load()->MetricTracerExp.pfnDecodeExp;
+        if( nullptr == pfnDecodeExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnDecodeExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnDecodeExp( phMetricDecoder, pRawDataSize, pRawData, metricsCount, phMetrics, pSetCount, pMetricEntriesCountPerSet, pMetricEntriesCount, pMetricEntries );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2132,6 +3013,7 @@ zetMetricTracerDecodeExp(
     }
 
     return pfnDecodeExp( phMetricDecoder, pRawDataSize, pRawData, metricsCount, phMetrics, pSetCount, pMetricEntriesCountPerSet, pMetricEntriesCount, pMetricEntries );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2189,6 +3071,23 @@ zetMetricGroupCalculateMultipleMetricValuesExp(
                                                     ///< then driver shall only calculate that number of metric values.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnMetricGroupCalculateMultipleMetricValuesExp_t pfnCalculateMultipleMetricValuesExp = [&result] {
+        auto pfnCalculateMultipleMetricValuesExp = ze_lib::context->zetDdiTable.load()->MetricGroupExp.pfnCalculateMultipleMetricValuesExp;
+        if( nullptr == pfnCalculateMultipleMetricValuesExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnCalculateMultipleMetricValuesExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnCalculateMultipleMetricValuesExp( hMetricGroup, type, rawDataSize, pRawData, pSetCount, pTotalMetricValueCount, pMetricCounts, pMetricValues );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2202,6 +3101,7 @@ zetMetricGroupCalculateMultipleMetricValuesExp(
     }
 
     return pfnCalculateMultipleMetricValuesExp( hMetricGroup, type, rawDataSize, pRawData, pSetCount, pTotalMetricValueCount, pMetricCounts, pMetricValues );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2232,6 +3132,23 @@ zetMetricGroupGetGlobalTimestampsExp(
     uint64_t* metricTimestamp                       ///< [out] Metric timestamp.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnMetricGroupGetGlobalTimestampsExp_t pfnGetGlobalTimestampsExp = [&result] {
+        auto pfnGetGlobalTimestampsExp = ze_lib::context->zetDdiTable.load()->MetricGroupExp.pfnGetGlobalTimestampsExp;
+        if( nullptr == pfnGetGlobalTimestampsExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetGlobalTimestampsExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetGlobalTimestampsExp( hMetricGroup, synchronizedWithHost, globalTimestamp, metricTimestamp );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2245,6 +3162,7 @@ zetMetricGroupGetGlobalTimestampsExp(
     }
 
     return pfnGetGlobalTimestampsExp( hMetricGroup, synchronizedWithHost, globalTimestamp, metricTimestamp );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2283,6 +3201,23 @@ zetMetricGroupGetExportDataExp(
     uint8_t * pExportData                           ///< [in,out][optional][range(0, *pExportDataSize)] buffer of exported data.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnMetricGroupGetExportDataExp_t pfnGetExportDataExp = [&result] {
+        auto pfnGetExportDataExp = ze_lib::context->zetDdiTable.load()->MetricGroupExp.pfnGetExportDataExp;
+        if( nullptr == pfnGetExportDataExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetExportDataExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetExportDataExp( hMetricGroup, pRawData, rawDataSize, pExportDataSize, pExportData );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2296,6 +3231,7 @@ zetMetricGroupGetExportDataExp(
     }
 
     return pfnGetExportDataExp( hMetricGroup, pRawData, rawDataSize, pExportDataSize, pExportData );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2354,6 +3290,23 @@ zetMetricGroupCalculateMetricExportDataExp(
                                                     ///< then driver shall only calculate that number of metric values.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnMetricGroupCalculateMetricExportDataExp_t pfnCalculateMetricExportDataExp = [&result] {
+        auto pfnCalculateMetricExportDataExp = ze_lib::context->zetDdiTable.load()->MetricGroupExp.pfnCalculateMetricExportDataExp;
+        if( nullptr == pfnCalculateMetricExportDataExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnCalculateMetricExportDataExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnCalculateMetricExportDataExp( hDriver, type, exportDataSize, pExportData, pCalculateDescriptor, pSetCount, pTotalMetricValueCount, pMetricCounts, pMetricValues );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2367,6 +3320,7 @@ zetMetricGroupCalculateMetricExportDataExp(
     }
 
     return pfnCalculateMetricExportDataExp( hDriver, type, exportDataSize, pExportData, pCalculateDescriptor, pSetCount, pTotalMetricValueCount, pMetricCounts, pMetricValues );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2401,6 +3355,23 @@ zetMetricProgrammableGetExp(
                                                     ///< then driver shall only retrieve that number of metric programmables.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnMetricProgrammableGetExp_t pfnGetExp = [&result] {
+        auto pfnGetExp = ze_lib::context->zetDdiTable.load()->MetricProgrammableExp.pfnGetExp;
+        if( nullptr == pfnGetExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetExp( hDevice, pCount, phMetricProgrammables );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2414,6 +3385,7 @@ zetMetricProgrammableGetExp(
     }
 
     return pfnGetExp( hDevice, pCount, phMetricProgrammables );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2438,6 +3410,23 @@ zetMetricProgrammableGetPropertiesExp(
     zet_metric_programmable_exp_properties_t* pProperties   ///< [in,out] properties of the metric programmable
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnMetricProgrammableGetPropertiesExp_t pfnGetPropertiesExp = [&result] {
+        auto pfnGetPropertiesExp = ze_lib::context->zetDdiTable.load()->MetricProgrammableExp.pfnGetPropertiesExp;
+        if( nullptr == pfnGetPropertiesExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetPropertiesExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetPropertiesExp( hMetricProgrammable, pProperties );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2451,6 +3440,7 @@ zetMetricProgrammableGetPropertiesExp(
     }
 
     return pfnGetPropertiesExp( hMetricProgrammable, pProperties );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2484,6 +3474,23 @@ zetMetricProgrammableGetParamInfoExp(
                                                     ///< then driver shall only retrieve that number of parameter info.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnMetricProgrammableGetParamInfoExp_t pfnGetParamInfoExp = [&result] {
+        auto pfnGetParamInfoExp = ze_lib::context->zetDdiTable.load()->MetricProgrammableExp.pfnGetParamInfoExp;
+        if( nullptr == pfnGetParamInfoExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetParamInfoExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetParamInfoExp( hMetricProgrammable, pParameterCount, pParameterInfo );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2497,6 +3504,7 @@ zetMetricProgrammableGetParamInfoExp(
     }
 
     return pfnGetParamInfoExp( hMetricProgrammable, pParameterCount, pParameterInfo );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2532,6 +3540,23 @@ zetMetricProgrammableGetParamValueInfoExp(
                                                     ///< then driver shall only retrieve that number of value info.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnMetricProgrammableGetParamValueInfoExp_t pfnGetParamValueInfoExp = [&result] {
+        auto pfnGetParamValueInfoExp = ze_lib::context->zetDdiTable.load()->MetricProgrammableExp.pfnGetParamValueInfoExp;
+        if( nullptr == pfnGetParamValueInfoExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnGetParamValueInfoExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnGetParamValueInfoExp( hMetricProgrammable, parameterOrdinal, pValueInfoCount, pValueInfo );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2545,6 +3570,7 @@ zetMetricProgrammableGetParamValueInfoExp(
     }
 
     return pfnGetParamValueInfoExp( hMetricProgrammable, parameterOrdinal, pValueInfoCount, pValueInfo );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2596,6 +3622,23 @@ zetMetricCreateFromProgrammableExp2(
                                                     ///< shall only retrieve that number of metric handles.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnMetricCreateFromProgrammableExp2_t pfnCreateFromProgrammableExp2 = [&result] {
+        auto pfnCreateFromProgrammableExp2 = ze_lib::context->zetDdiTable.load()->MetricExp.pfnCreateFromProgrammableExp2;
+        if( nullptr == pfnCreateFromProgrammableExp2 ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnCreateFromProgrammableExp2;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnCreateFromProgrammableExp2( hMetricProgrammable, parameterCount, pParameterValues, pName, pDescription, pMetricHandleCount, phMetricHandles );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2609,6 +3652,7 @@ zetMetricCreateFromProgrammableExp2(
     }
 
     return pfnCreateFromProgrammableExp2( hMetricProgrammable, parameterCount, pParameterValues, pName, pDescription, pMetricHandleCount, phMetricHandles );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2653,6 +3697,23 @@ zetMetricCreateFromProgrammableExp(
                                                     ///< shall only retrieve that number of metric handles.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnMetricCreateFromProgrammableExp_t pfnCreateFromProgrammableExp = [&result] {
+        auto pfnCreateFromProgrammableExp = ze_lib::context->zetDdiTable.load()->MetricExp.pfnCreateFromProgrammableExp;
+        if( nullptr == pfnCreateFromProgrammableExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnCreateFromProgrammableExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnCreateFromProgrammableExp( hMetricProgrammable, pParameterValues, parameterCount, pName, pDescription, pMetricHandleCount, phMetricHandles );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2666,6 +3727,7 @@ zetMetricCreateFromProgrammableExp(
     }
 
     return pfnCreateFromProgrammableExp( hMetricProgrammable, pParameterValues, parameterCount, pName, pDescription, pMetricHandleCount, phMetricHandles );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2715,6 +3777,23 @@ zetDeviceCreateMetricGroupsFromMetricsExp(
                                                     ///< Created Metric group handles.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnDeviceCreateMetricGroupsFromMetricsExp_t pfnCreateMetricGroupsFromMetricsExp = [&result] {
+        auto pfnCreateMetricGroupsFromMetricsExp = ze_lib::context->zetDdiTable.load()->DeviceExp.pfnCreateMetricGroupsFromMetricsExp;
+        if( nullptr == pfnCreateMetricGroupsFromMetricsExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnCreateMetricGroupsFromMetricsExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnCreateMetricGroupsFromMetricsExp( hDevice, metricCount, phMetrics, pMetricGroupNamePrefix, pDescription, pMetricGroupCount, phMetricGroup );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2728,6 +3807,7 @@ zetDeviceCreateMetricGroupsFromMetricsExp(
     }
 
     return pfnCreateMetricGroupsFromMetricsExp( hDevice, metricCount, phMetrics, pMetricGroupNamePrefix, pDescription, pMetricGroupCount, phMetricGroup );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2763,6 +3843,23 @@ zetMetricGroupCreateExp(
     zet_metric_group_handle_t* phMetricGroup        ///< [in,out] Created Metric group handle
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnMetricGroupCreateExp_t pfnCreateExp = [&result] {
+        auto pfnCreateExp = ze_lib::context->zetDdiTable.load()->MetricGroupExp.pfnCreateExp;
+        if( nullptr == pfnCreateExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnCreateExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnCreateExp( hDevice, pName, pDescription, samplingType, phMetricGroup );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2776,6 +3873,7 @@ zetMetricGroupCreateExp(
     }
 
     return pfnCreateExp( hDevice, pName, pDescription, samplingType, phMetricGroup );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2819,6 +3917,23 @@ zetMetricGroupAddMetricExp(
                                                     ///< available, then driver shall only retrieve that length of error string.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnMetricGroupAddMetricExp_t pfnAddMetricExp = [&result] {
+        auto pfnAddMetricExp = ze_lib::context->zetDdiTable.load()->MetricGroupExp.pfnAddMetricExp;
+        if( nullptr == pfnAddMetricExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnAddMetricExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnAddMetricExp( hMetricGroup, hMetric, pErrorStringSize, pErrorString );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2832,6 +3947,7 @@ zetMetricGroupAddMetricExp(
     }
 
     return pfnAddMetricExp( hMetricGroup, hMetric, pErrorStringSize, pErrorString );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2861,6 +3977,23 @@ zetMetricGroupRemoveMetricExp(
     zet_metric_handle_t hMetric                     ///< [in] Metric handle to be removed from the metric group.
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnMetricGroupRemoveMetricExp_t pfnRemoveMetricExp = [&result] {
+        auto pfnRemoveMetricExp = ze_lib::context->zetDdiTable.load()->MetricGroupExp.pfnRemoveMetricExp;
+        if( nullptr == pfnRemoveMetricExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnRemoveMetricExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnRemoveMetricExp( hMetricGroup, hMetric );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2874,6 +4007,7 @@ zetMetricGroupRemoveMetricExp(
     }
 
     return pfnRemoveMetricExp( hMetricGroup, hMetric );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2912,6 +4046,23 @@ zetMetricGroupCloseExp(
     zet_metric_group_handle_t hMetricGroup          ///< [in] Handle of the metric group
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnMetricGroupCloseExp_t pfnCloseExp = [&result] {
+        auto pfnCloseExp = ze_lib::context->zetDdiTable.load()->MetricGroupExp.pfnCloseExp;
+        if( nullptr == pfnCloseExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnCloseExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnCloseExp( hMetricGroup );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2925,6 +4076,7 @@ zetMetricGroupCloseExp(
     }
 
     return pfnCloseExp( hMetricGroup );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2957,6 +4109,23 @@ zetMetricGroupDestroyExp(
     zet_metric_group_handle_t hMetricGroup          ///< [in] Handle of the metric group to destroy
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnMetricGroupDestroyExp_t pfnDestroyExp = [&result] {
+        auto pfnDestroyExp = ze_lib::context->zetDdiTable.load()->MetricGroupExp.pfnDestroyExp;
+        if( nullptr == pfnDestroyExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnDestroyExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnDestroyExp( hMetricGroup );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2970,6 +4139,7 @@ zetMetricGroupDestroyExp(
     }
 
     return pfnDestroyExp( hMetricGroup );
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2996,6 +4166,23 @@ zetMetricDestroyExp(
     zet_metric_handle_t hMetric                     ///< [in] Handle of the metric to destroy
     )
 {
+    #ifdef DYNAMIC_LOAD_LOADER
+    ze_result_t result = ZE_RESULT_SUCCESS;
+    if(ze_lib::destruction) {
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+    static const zet_pfnMetricDestroyExp_t pfnDestroyExp = [&result] {
+        auto pfnDestroyExp = ze_lib::context->zetDdiTable.load()->MetricExp.pfnDestroyExp;
+        if( nullptr == pfnDestroyExp ) {
+            result = ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+        }
+        return pfnDestroyExp;
+    }();
+    if (result != ZE_RESULT_SUCCESS) {
+        return result;
+    }
+    return pfnDestroyExp( hMetric );
+    #else
     if(ze_lib::destruction) {
         return ZE_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3009,6 +4196,7 @@ zetMetricDestroyExp(
     }
 
     return pfnDestroyExp( hMetric );
+    #endif
 }
 
 } // extern "C"

--- a/source/lib/zet_libddi.cpp
+++ b/source/lib/zet_libddi.cpp
@@ -27,6 +27,12 @@ namespace ze_lib
             auto getTable = reinterpret_cast<zet_pfnGetMetricDecoderExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zetGetMetricDecoderExpProcAddrTable") );
             getTableWithCheck(getTable, version, &initialzetDdiTable.MetricDecoderExp );
+            initialzetDdiTable.MetricDecoderExp.pfnCreateExp = reinterpret_cast<zet_pfnMetricDecoderCreateExp_t>(
+                GET_FUNCTION_PTR(loader, "zetMetricDecoderCreateExp") );
+            initialzetDdiTable.MetricDecoderExp.pfnDestroyExp = reinterpret_cast<zet_pfnMetricDecoderDestroyExp_t>(
+                GET_FUNCTION_PTR(loader, "zetMetricDecoderDestroyExp") );
+            initialzetDdiTable.MetricDecoderExp.pfnGetDecodableMetricsExp = reinterpret_cast<zet_pfnMetricDecoderGetDecodableMetricsExp_t>(
+                GET_FUNCTION_PTR(loader, "zetMetricDecoderGetDecodableMetricsExp") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -35,6 +41,14 @@ namespace ze_lib
             auto getTable = reinterpret_cast<zet_pfnGetMetricProgrammableExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zetGetMetricProgrammableExpProcAddrTable") );
             getTableWithCheck(getTable, version, &initialzetDdiTable.MetricProgrammableExp );
+            initialzetDdiTable.MetricProgrammableExp.pfnGetExp = reinterpret_cast<zet_pfnMetricProgrammableGetExp_t>(
+                GET_FUNCTION_PTR(loader, "zetMetricProgrammableGetExp") );
+            initialzetDdiTable.MetricProgrammableExp.pfnGetPropertiesExp = reinterpret_cast<zet_pfnMetricProgrammableGetPropertiesExp_t>(
+                GET_FUNCTION_PTR(loader, "zetMetricProgrammableGetPropertiesExp") );
+            initialzetDdiTable.MetricProgrammableExp.pfnGetParamInfoExp = reinterpret_cast<zet_pfnMetricProgrammableGetParamInfoExp_t>(
+                GET_FUNCTION_PTR(loader, "zetMetricProgrammableGetParamInfoExp") );
+            initialzetDdiTable.MetricProgrammableExp.pfnGetParamValueInfoExp = reinterpret_cast<zet_pfnMetricProgrammableGetParamValueInfoExp_t>(
+                GET_FUNCTION_PTR(loader, "zetMetricProgrammableGetParamValueInfoExp") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -43,6 +57,18 @@ namespace ze_lib
             auto getTable = reinterpret_cast<zet_pfnGetMetricTracerExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zetGetMetricTracerExpProcAddrTable") );
             getTableWithCheck(getTable, version, &initialzetDdiTable.MetricTracerExp );
+            initialzetDdiTable.MetricTracerExp.pfnCreateExp = reinterpret_cast<zet_pfnMetricTracerCreateExp_t>(
+                GET_FUNCTION_PTR(loader, "zetMetricTracerCreateExp") );
+            initialzetDdiTable.MetricTracerExp.pfnDestroyExp = reinterpret_cast<zet_pfnMetricTracerDestroyExp_t>(
+                GET_FUNCTION_PTR(loader, "zetMetricTracerDestroyExp") );
+            initialzetDdiTable.MetricTracerExp.pfnEnableExp = reinterpret_cast<zet_pfnMetricTracerEnableExp_t>(
+                GET_FUNCTION_PTR(loader, "zetMetricTracerEnableExp") );
+            initialzetDdiTable.MetricTracerExp.pfnDisableExp = reinterpret_cast<zet_pfnMetricTracerDisableExp_t>(
+                GET_FUNCTION_PTR(loader, "zetMetricTracerDisableExp") );
+            initialzetDdiTable.MetricTracerExp.pfnReadDataExp = reinterpret_cast<zet_pfnMetricTracerReadDataExp_t>(
+                GET_FUNCTION_PTR(loader, "zetMetricTracerReadDataExp") );
+            initialzetDdiTable.MetricTracerExp.pfnDecodeExp = reinterpret_cast<zet_pfnMetricTracerDecodeExp_t>(
+                GET_FUNCTION_PTR(loader, "zetMetricTracerDecodeExp") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -50,6 +76,8 @@ namespace ze_lib
             auto getTable = reinterpret_cast<zet_pfnGetDeviceProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zetGetDeviceProcAddrTable") );
             result = getTableWithCheck(getTable, version, &initialzetDdiTable.Device );
+            initialzetDdiTable.Device.pfnGetDebugProperties = reinterpret_cast<zet_pfnDeviceGetDebugProperties_t>(
+                GET_FUNCTION_PTR(loader, "zetDeviceGetDebugProperties") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -58,6 +86,10 @@ namespace ze_lib
             auto getTable = reinterpret_cast<zet_pfnGetDeviceExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zetGetDeviceExpProcAddrTable") );
             getTableWithCheck(getTable, version, &initialzetDdiTable.DeviceExp );
+            initialzetDdiTable.DeviceExp.pfnGetConcurrentMetricGroupsExp = reinterpret_cast<zet_pfnDeviceGetConcurrentMetricGroupsExp_t>(
+                GET_FUNCTION_PTR(loader, "zetDeviceGetConcurrentMetricGroupsExp") );
+            initialzetDdiTable.DeviceExp.pfnCreateMetricGroupsFromMetricsExp = reinterpret_cast<zet_pfnDeviceCreateMetricGroupsFromMetricsExp_t>(
+                GET_FUNCTION_PTR(loader, "zetDeviceCreateMetricGroupsFromMetricsExp") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -65,6 +97,8 @@ namespace ze_lib
             auto getTable = reinterpret_cast<zet_pfnGetContextProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zetGetContextProcAddrTable") );
             result = getTableWithCheck(getTable, version, &initialzetDdiTable.Context );
+            initialzetDdiTable.Context.pfnActivateMetricGroups = reinterpret_cast<zet_pfnContextActivateMetricGroups_t>(
+                GET_FUNCTION_PTR(loader, "zetContextActivateMetricGroups") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -72,6 +106,14 @@ namespace ze_lib
             auto getTable = reinterpret_cast<zet_pfnGetCommandListProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zetGetCommandListProcAddrTable") );
             result = getTableWithCheck(getTable, version, &initialzetDdiTable.CommandList );
+            initialzetDdiTable.CommandList.pfnAppendMetricStreamerMarker = reinterpret_cast<zet_pfnCommandListAppendMetricStreamerMarker_t>(
+                GET_FUNCTION_PTR(loader, "zetCommandListAppendMetricStreamerMarker") );
+            initialzetDdiTable.CommandList.pfnAppendMetricQueryBegin = reinterpret_cast<zet_pfnCommandListAppendMetricQueryBegin_t>(
+                GET_FUNCTION_PTR(loader, "zetCommandListAppendMetricQueryBegin") );
+            initialzetDdiTable.CommandList.pfnAppendMetricQueryEnd = reinterpret_cast<zet_pfnCommandListAppendMetricQueryEnd_t>(
+                GET_FUNCTION_PTR(loader, "zetCommandListAppendMetricQueryEnd") );
+            initialzetDdiTable.CommandList.pfnAppendMetricMemoryBarrier = reinterpret_cast<zet_pfnCommandListAppendMetricMemoryBarrier_t>(
+                GET_FUNCTION_PTR(loader, "zetCommandListAppendMetricMemoryBarrier") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -79,6 +121,8 @@ namespace ze_lib
             auto getTable = reinterpret_cast<zet_pfnGetKernelProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zetGetKernelProcAddrTable") );
             result = getTableWithCheck(getTable, version, &initialzetDdiTable.Kernel );
+            initialzetDdiTable.Kernel.pfnGetProfileInfo = reinterpret_cast<zet_pfnKernelGetProfileInfo_t>(
+                GET_FUNCTION_PTR(loader, "zetKernelGetProfileInfo") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -86,6 +130,8 @@ namespace ze_lib
             auto getTable = reinterpret_cast<zet_pfnGetModuleProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zetGetModuleProcAddrTable") );
             result = getTableWithCheck(getTable, version, &initialzetDdiTable.Module );
+            initialzetDdiTable.Module.pfnGetDebugInfo = reinterpret_cast<zet_pfnModuleGetDebugInfo_t>(
+                GET_FUNCTION_PTR(loader, "zetModuleGetDebugInfo") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -93,6 +139,30 @@ namespace ze_lib
             auto getTable = reinterpret_cast<zet_pfnGetDebugProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zetGetDebugProcAddrTable") );
             result = getTableWithCheck(getTable, version, &initialzetDdiTable.Debug );
+            initialzetDdiTable.Debug.pfnAttach = reinterpret_cast<zet_pfnDebugAttach_t>(
+                GET_FUNCTION_PTR(loader, "zetDebugAttach") );
+            initialzetDdiTable.Debug.pfnDetach = reinterpret_cast<zet_pfnDebugDetach_t>(
+                GET_FUNCTION_PTR(loader, "zetDebugDetach") );
+            initialzetDdiTable.Debug.pfnReadEvent = reinterpret_cast<zet_pfnDebugReadEvent_t>(
+                GET_FUNCTION_PTR(loader, "zetDebugReadEvent") );
+            initialzetDdiTable.Debug.pfnAcknowledgeEvent = reinterpret_cast<zet_pfnDebugAcknowledgeEvent_t>(
+                GET_FUNCTION_PTR(loader, "zetDebugAcknowledgeEvent") );
+            initialzetDdiTable.Debug.pfnInterrupt = reinterpret_cast<zet_pfnDebugInterrupt_t>(
+                GET_FUNCTION_PTR(loader, "zetDebugInterrupt") );
+            initialzetDdiTable.Debug.pfnResume = reinterpret_cast<zet_pfnDebugResume_t>(
+                GET_FUNCTION_PTR(loader, "zetDebugResume") );
+            initialzetDdiTable.Debug.pfnReadMemory = reinterpret_cast<zet_pfnDebugReadMemory_t>(
+                GET_FUNCTION_PTR(loader, "zetDebugReadMemory") );
+            initialzetDdiTable.Debug.pfnWriteMemory = reinterpret_cast<zet_pfnDebugWriteMemory_t>(
+                GET_FUNCTION_PTR(loader, "zetDebugWriteMemory") );
+            initialzetDdiTable.Debug.pfnGetRegisterSetProperties = reinterpret_cast<zet_pfnDebugGetRegisterSetProperties_t>(
+                GET_FUNCTION_PTR(loader, "zetDebugGetRegisterSetProperties") );
+            initialzetDdiTable.Debug.pfnReadRegisters = reinterpret_cast<zet_pfnDebugReadRegisters_t>(
+                GET_FUNCTION_PTR(loader, "zetDebugReadRegisters") );
+            initialzetDdiTable.Debug.pfnWriteRegisters = reinterpret_cast<zet_pfnDebugWriteRegisters_t>(
+                GET_FUNCTION_PTR(loader, "zetDebugWriteRegisters") );
+            initialzetDdiTable.Debug.pfnGetThreadRegisterSetProperties = reinterpret_cast<zet_pfnDebugGetThreadRegisterSetProperties_t>(
+                GET_FUNCTION_PTR(loader, "zetDebugGetThreadRegisterSetProperties") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -100,6 +170,10 @@ namespace ze_lib
             auto getTable = reinterpret_cast<zet_pfnGetMetricProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zetGetMetricProcAddrTable") );
             result = getTableWithCheck(getTable, version, &initialzetDdiTable.Metric );
+            initialzetDdiTable.Metric.pfnGet = reinterpret_cast<zet_pfnMetricGet_t>(
+                GET_FUNCTION_PTR(loader, "zetMetricGet") );
+            initialzetDdiTable.Metric.pfnGetProperties = reinterpret_cast<zet_pfnMetricGetProperties_t>(
+                GET_FUNCTION_PTR(loader, "zetMetricGetProperties") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -108,6 +182,12 @@ namespace ze_lib
             auto getTable = reinterpret_cast<zet_pfnGetMetricExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zetGetMetricExpProcAddrTable") );
             getTableWithCheck(getTable, version, &initialzetDdiTable.MetricExp );
+            initialzetDdiTable.MetricExp.pfnCreateFromProgrammableExp2 = reinterpret_cast<zet_pfnMetricCreateFromProgrammableExp2_t>(
+                GET_FUNCTION_PTR(loader, "zetMetricCreateFromProgrammableExp2") );
+            initialzetDdiTable.MetricExp.pfnCreateFromProgrammableExp = reinterpret_cast<zet_pfnMetricCreateFromProgrammableExp_t>(
+                GET_FUNCTION_PTR(loader, "zetMetricCreateFromProgrammableExp") );
+            initialzetDdiTable.MetricExp.pfnDestroyExp = reinterpret_cast<zet_pfnMetricDestroyExp_t>(
+                GET_FUNCTION_PTR(loader, "zetMetricDestroyExp") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -115,6 +195,12 @@ namespace ze_lib
             auto getTable = reinterpret_cast<zet_pfnGetMetricGroupProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zetGetMetricGroupProcAddrTable") );
             result = getTableWithCheck(getTable, version, &initialzetDdiTable.MetricGroup );
+            initialzetDdiTable.MetricGroup.pfnGet = reinterpret_cast<zet_pfnMetricGroupGet_t>(
+                GET_FUNCTION_PTR(loader, "zetMetricGroupGet") );
+            initialzetDdiTable.MetricGroup.pfnGetProperties = reinterpret_cast<zet_pfnMetricGroupGetProperties_t>(
+                GET_FUNCTION_PTR(loader, "zetMetricGroupGetProperties") );
+            initialzetDdiTable.MetricGroup.pfnCalculateMetricValues = reinterpret_cast<zet_pfnMetricGroupCalculateMetricValues_t>(
+                GET_FUNCTION_PTR(loader, "zetMetricGroupCalculateMetricValues") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -123,6 +209,24 @@ namespace ze_lib
             auto getTable = reinterpret_cast<zet_pfnGetMetricGroupExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zetGetMetricGroupExpProcAddrTable") );
             getTableWithCheck(getTable, version, &initialzetDdiTable.MetricGroupExp );
+            initialzetDdiTable.MetricGroupExp.pfnCalculateMultipleMetricValuesExp = reinterpret_cast<zet_pfnMetricGroupCalculateMultipleMetricValuesExp_t>(
+                GET_FUNCTION_PTR(loader, "zetMetricGroupCalculateMultipleMetricValuesExp") );
+            initialzetDdiTable.MetricGroupExp.pfnGetGlobalTimestampsExp = reinterpret_cast<zet_pfnMetricGroupGetGlobalTimestampsExp_t>(
+                GET_FUNCTION_PTR(loader, "zetMetricGroupGetGlobalTimestampsExp") );
+            initialzetDdiTable.MetricGroupExp.pfnGetExportDataExp = reinterpret_cast<zet_pfnMetricGroupGetExportDataExp_t>(
+                GET_FUNCTION_PTR(loader, "zetMetricGroupGetExportDataExp") );
+            initialzetDdiTable.MetricGroupExp.pfnCalculateMetricExportDataExp = reinterpret_cast<zet_pfnMetricGroupCalculateMetricExportDataExp_t>(
+                GET_FUNCTION_PTR(loader, "zetMetricGroupCalculateMetricExportDataExp") );
+            initialzetDdiTable.MetricGroupExp.pfnCreateExp = reinterpret_cast<zet_pfnMetricGroupCreateExp_t>(
+                GET_FUNCTION_PTR(loader, "zetMetricGroupCreateExp") );
+            initialzetDdiTable.MetricGroupExp.pfnAddMetricExp = reinterpret_cast<zet_pfnMetricGroupAddMetricExp_t>(
+                GET_FUNCTION_PTR(loader, "zetMetricGroupAddMetricExp") );
+            initialzetDdiTable.MetricGroupExp.pfnRemoveMetricExp = reinterpret_cast<zet_pfnMetricGroupRemoveMetricExp_t>(
+                GET_FUNCTION_PTR(loader, "zetMetricGroupRemoveMetricExp") );
+            initialzetDdiTable.MetricGroupExp.pfnCloseExp = reinterpret_cast<zet_pfnMetricGroupCloseExp_t>(
+                GET_FUNCTION_PTR(loader, "zetMetricGroupCloseExp") );
+            initialzetDdiTable.MetricGroupExp.pfnDestroyExp = reinterpret_cast<zet_pfnMetricGroupDestroyExp_t>(
+                GET_FUNCTION_PTR(loader, "zetMetricGroupDestroyExp") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -130,6 +234,14 @@ namespace ze_lib
             auto getTable = reinterpret_cast<zet_pfnGetMetricQueryProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zetGetMetricQueryProcAddrTable") );
             result = getTableWithCheck(getTable, version, &initialzetDdiTable.MetricQuery );
+            initialzetDdiTable.MetricQuery.pfnCreate = reinterpret_cast<zet_pfnMetricQueryCreate_t>(
+                GET_FUNCTION_PTR(loader, "zetMetricQueryCreate") );
+            initialzetDdiTable.MetricQuery.pfnDestroy = reinterpret_cast<zet_pfnMetricQueryDestroy_t>(
+                GET_FUNCTION_PTR(loader, "zetMetricQueryDestroy") );
+            initialzetDdiTable.MetricQuery.pfnReset = reinterpret_cast<zet_pfnMetricQueryReset_t>(
+                GET_FUNCTION_PTR(loader, "zetMetricQueryReset") );
+            initialzetDdiTable.MetricQuery.pfnGetData = reinterpret_cast<zet_pfnMetricQueryGetData_t>(
+                GET_FUNCTION_PTR(loader, "zetMetricQueryGetData") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -137,6 +249,10 @@ namespace ze_lib
             auto getTable = reinterpret_cast<zet_pfnGetMetricQueryPoolProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zetGetMetricQueryPoolProcAddrTable") );
             result = getTableWithCheck(getTable, version, &initialzetDdiTable.MetricQueryPool );
+            initialzetDdiTable.MetricQueryPool.pfnCreate = reinterpret_cast<zet_pfnMetricQueryPoolCreate_t>(
+                GET_FUNCTION_PTR(loader, "zetMetricQueryPoolCreate") );
+            initialzetDdiTable.MetricQueryPool.pfnDestroy = reinterpret_cast<zet_pfnMetricQueryPoolDestroy_t>(
+                GET_FUNCTION_PTR(loader, "zetMetricQueryPoolDestroy") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -144,6 +260,12 @@ namespace ze_lib
             auto getTable = reinterpret_cast<zet_pfnGetMetricStreamerProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zetGetMetricStreamerProcAddrTable") );
             result = getTableWithCheck(getTable, version, &initialzetDdiTable.MetricStreamer );
+            initialzetDdiTable.MetricStreamer.pfnOpen = reinterpret_cast<zet_pfnMetricStreamerOpen_t>(
+                GET_FUNCTION_PTR(loader, "zetMetricStreamerOpen") );
+            initialzetDdiTable.MetricStreamer.pfnClose = reinterpret_cast<zet_pfnMetricStreamerClose_t>(
+                GET_FUNCTION_PTR(loader, "zetMetricStreamerClose") );
+            initialzetDdiTable.MetricStreamer.pfnReadData = reinterpret_cast<zet_pfnMetricStreamerReadData_t>(
+                GET_FUNCTION_PTR(loader, "zetMetricStreamerReadData") );
         }
 
         if( ZE_RESULT_SUCCESS == result )
@@ -151,6 +273,16 @@ namespace ze_lib
             auto getTable = reinterpret_cast<zet_pfnGetTracerExpProcAddrTable_t>(
                 GET_FUNCTION_PTR(loader, "zetGetTracerExpProcAddrTable") );
             result = getTableWithCheck(getTable, version, &initialzetDdiTable.TracerExp );
+            initialzetDdiTable.TracerExp.pfnCreate = reinterpret_cast<zet_pfnTracerExpCreate_t>(
+                GET_FUNCTION_PTR(loader, "zetTracerExpCreate") );
+            initialzetDdiTable.TracerExp.pfnDestroy = reinterpret_cast<zet_pfnTracerExpDestroy_t>(
+                GET_FUNCTION_PTR(loader, "zetTracerExpDestroy") );
+            initialzetDdiTable.TracerExp.pfnSetPrologues = reinterpret_cast<zet_pfnTracerExpSetPrologues_t>(
+                GET_FUNCTION_PTR(loader, "zetTracerExpSetPrologues") );
+            initialzetDdiTable.TracerExp.pfnSetEpilogues = reinterpret_cast<zet_pfnTracerExpSetEpilogues_t>(
+                GET_FUNCTION_PTR(loader, "zetTracerExpSetEpilogues") );
+            initialzetDdiTable.TracerExp.pfnSetEnabled = reinterpret_cast<zet_pfnTracerExpSetEnabled_t>(
+                GET_FUNCTION_PTR(loader, "zetTracerExpSetEnabled") );
         }
 
         return result;


### PR DESCRIPTION
- To allow for dynamic init of tracing, the static loader cannot optimize out the call to the ze_loader's ze_lib.
- Therefore, during init, the function pointer is instead assigned to the dynamic loaded loader's apis to enable tracing.