### PR TITLE
Add ability to Register a TeardownCallback to notify release of L0 resources

### DIFF
--- a/include/loader/ze_loader.h
+++ b/include/loader/ze_loader.h
@@ -95,6 +95,17 @@ ZE_DLLEXPORT bool ZE_APICALL
 zelCheckIsLoaderInTearDown();
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for registering a callback to indicate teardown.
+/// @details The callback function will be invoked when the loader is in teardown.
+///
+typedef void (*zel_teardown_callback_t)(void);
+
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zelRegisterTeardownCallback(
+   zel_teardown_callback_t callback // [in] Pointer to the callback function
+);
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Exported function for Disabling the Tracing Layer During Runtime.
 ///
 ZE_DLLEXPORT ze_result_t ZE_APICALL

--- a/source/lib/ze_lib.h
+++ b/source/lib/ze_lib.h
@@ -24,6 +24,8 @@
 #include <typeinfo>
 #include <iostream>
 
+typedef void (*zel_teardown_callback_t)(void);
+
 namespace ze_lib
 {
     ///////////////////////////////////////////////////////////////////////////////
@@ -175,12 +177,14 @@ namespace ze_lib
         bool debugTraceEnabled = false;
         bool dynamicTracingSupported = true;
         ze_pfnDriverGet_t loaderDriverGet = nullptr;
+        std::vector<zel_teardown_callback_t> teardownCallbacks;
     };
 
     extern bool destruction;
     extern context_t *context;
     #ifdef DYNAMIC_LOAD_LOADER
     extern bool delayContextDestruction;
+    extern bool loaderTeardownCallbackReceived;
     #endif
 
 } // namespace ze_lib


### PR DESCRIPTION
- Add ability to Register a callback to notify teardown of L0 resources.
- A callback is registered in the Static Loader to provide an improved detection of teardown. 