### PR TITLE
Add ability to Register a TeardownCallback to notify release of L0 resources

### DIFF
--- a/include/loader/ze_loader.h
+++ b/include/loader/ze_loader.h
@@ -95,17 +95,19 @@ ZE_DLLEXPORT bool ZE_APICALL
 zelCheckIsLoaderInTearDown();
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Exported function for registering a callback to indicate teardown.
-/// @details The callback function will be invoked when the loader is in teardown.
-///
+/// @brief Exported function for registering a teardown callback.
+/// @details The provided application callback will be invoked when the loader enters teardown.
+///          The loader's callback and the index for this application's callback reference are returned for later reference.
+///          The loader's callback will be invoked when the application is torndown to inform the loader that the application
+///          is being torn down and cannot be called to inform the loader of its teardown.
 typedef void (*zel_loader_teardown_callback_t)();
 typedef void (*zel_application_teardown_callback_t)(uint32_t index);
 
 ZE_DLLEXPORT ze_result_t ZE_APICALL
 zelRegisterTeardownCallback(
-   zel_loader_teardown_callback_t application_callback, // [in] Pointer to the user's application callback function
-   zel_application_teardown_callback_t *loader_callback,      // [out] Pointer to the L0 Loader's callback function 
-   uint32_t *index // [out] Index of the callback function
+   zel_loader_teardown_callback_t application_callback, // [in] Application's callback function to be called during loader teardown
+   zel_application_teardown_callback_t *loader_callback, // [out] Pointer to the loader's callback function
+   uint32_t *index // [out] Index assigned to the registered callback
 );
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/include/loader/ze_loader.h
+++ b/include/loader/ze_loader.h
@@ -95,6 +95,20 @@ ZE_DLLEXPORT bool ZE_APICALL
 zelCheckIsLoaderInTearDown();
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for registering a callback to indicate teardown.
+/// @details The callback function will be invoked when the loader is in teardown.
+///
+typedef void (*zel_loader_teardown_callback_t)();
+typedef void (*zel_application_teardown_callback_t)(uint32_t index);
+
+ZE_DLLEXPORT ze_result_t ZE_APICALL
+zelRegisterTeardownCallback(
+   zel_loader_teardown_callback_t application_callback, // [in] Pointer to the user's application callback function
+   zel_application_teardown_callback_t *loader_callback,      // [out] Pointer to the L0 Loader's callback function 
+   uint32_t *index // [out] Index of the callback function
+);
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Exported function for Disabling the Tracing Layer During Runtime.
 ///
 ZE_DLLEXPORT ze_result_t ZE_APICALL

--- a/include/loader/ze_loader.h
+++ b/include/loader/ze_loader.h
@@ -104,6 +104,16 @@ typedef void (*zel_application_teardown_callback_t)(uint32_t index);
  * when the loader is being torn down. The loader will also provide its own callback function
  * and assign an index to the registered callback.
  *
+ * The application_callback is required to be a function that takes no arguments and returns void.
+ * In addition, the application_callback should be thread-safe and not block to prevent deadlocking the
+ * loader teardown process.
+ *
+ * For example, the application_callback used by the static loader is:
+ *  void staticLoaderTeardownCallback() {
+ *    loaderTeardownCallbackReceived = true;
+ *  }
+ * The application_callback should provide a simple notification to the application that the loader is being torn down.
+ *
  * @param[in] application_callback  Application's callback function to be called during loader teardown.
  * @param[out] loader_callback      Pointer to the loader's callback function.
  * @param[out] index                Index assigned to the registered callback.

--- a/include/loader/ze_loader.h
+++ b/include/loader/ze_loader.h
@@ -94,15 +94,24 @@ zelEnableTracingLayer();
 ZE_DLLEXPORT bool ZE_APICALL
 zelCheckIsLoaderInTearDown();
 
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Exported function for registering a teardown callback.
-/// @details The provided application callback will be invoked when the loader enters teardown.
-///          The loader's callback and the index for this application's callback reference are returned for later reference.
-///          The loader's callback will be invoked when the application is torndown to inform the loader that the application
-///          is being torn down and cannot be called to inform the loader of its teardown.
 typedef void (*zel_loader_teardown_callback_t)();
 typedef void (*zel_application_teardown_callback_t)(uint32_t index);
 
+/**
+ * @brief Registers a teardown callback to be invoked during loader teardown.
+ *
+ * This function allows the application to register a callback function that will be called
+ * when the loader is being torn down. The loader will also provide its own callback function
+ * and assign an index to the registered callback.
+ *
+ * @param[in] application_callback  Application's callback function to be called during loader teardown.
+ * @param[out] loader_callback      Pointer to the loader's callback function.
+ * @param[out] index                Index assigned to the registered callback.
+ *
+ * @return
+ *     - ZE_RESULT_SUCCESS if the callback was successfully registered.
+ *     - Appropriate error code otherwise.
+ */
 ZE_DLLEXPORT ze_result_t ZE_APICALL
 zelRegisterTeardownCallback(
    zel_loader_teardown_callback_t application_callback, // [in] Application's callback function to be called during loader teardown

--- a/source/lib/ze_lib.cpp
+++ b/source/lib/ze_lib.cpp
@@ -520,21 +520,16 @@ zelRegisterTeardownCallback(
     return result;
 }
 
-/**
- * @brief Checks if the loader is in the process of tearing down.
- *
- * This function determines whether the loader is in a teardown state by
- * checking the destruction flag or the context pointer. If the loader is
- * dynamically loaded thru the static loader code path, then it performs
- * an additional stability check using a separate thread that could be killed.
- *
- * @return true if the loader is in teardown based on the stack variablrs
- *         or the stability check fails; false otherwise.
- *
- * @note If the macro DYNAMIC_LOAD_LOADER is defined, a stability checker
- *       thread is launched to perform additional checks. Any exceptions
- *       or errors during this process are logged if debug tracing is enabled.
- */
+/// @brief Checks if the Level Zero loader is currently in the teardown state.
+///
+/// This function determines whether the loader is in the process of being destroyed or is otherwise
+/// unavailable for further API calls. It performs several checks, including:
+/// - Whether the loader's destruction flag is set or the context is null.
+/// - On Windows with dynamic loading, it checks for loader teardown notifications,
+///   registration status, and the stability of the loader by attempting to call `loaderDriverGet`.
+/// - If any of these checks indicate the loader is in teardown or unstable, the function returns true.
+///
+/// @return true if the loader is in teardown or unstable; false otherwise.
 bool ZE_APICALL
 zelCheckIsLoaderInTearDown() {
     if (ze_lib::destruction || ze_lib::context == nullptr) {

--- a/source/lib/ze_lib.cpp
+++ b/source/lib/ze_lib.cpp
@@ -373,7 +373,9 @@ namespace ze_lib
                 uint32_t*);
             auto pfnZelRegisterTeardownCallback = reinterpret_cast<zelRegisterTeardownCallback_t>(
                 GET_FUNCTION_PTR(loader, "zelRegisterTeardownCallback"));
-            pfnZelRegisterTeardownCallback(staticLoaderTeardownCallback, &loaderTeardownCallback, &loaderTeardownCallbackIndex);
+            if (pfnZelRegisterTeardownCallback != nullptr) {
+                pfnZelRegisterTeardownCallback(staticLoaderTeardownCallback, &loaderTeardownCallback, &loaderTeardownCallbackIndex);
+            }
         });
         #endif
         return result;

--- a/source/lib/ze_lib.cpp
+++ b/source/lib/ze_lib.cpp
@@ -29,12 +29,10 @@ namespace ze_lib
     bool delayContextDestruction = false;
     bool loaderTeardownCallbackReceived = false;
     void staticLoaderTeardownCallback() {
-        printf("ze_lib Static Teardown Callback\n");
         loaderTeardownCallbackReceived = true;
     }
     #endif
     void applicationTeardownCallback(uint32_t index) {
-        printf("ze_lib Application Teardown Callback %d\n", index);
         if (ze_lib::context->teardownCallbacks.find(index) != ze_lib::context->teardownCallbacks.end()) {
             ze_lib::context->teardownCallbacks.erase(index);
         }
@@ -50,9 +48,6 @@ namespace ze_lib
     ///////////////////////////////////////////////////////////////////////////////
     __zedlllocal context_t::~context_t()
     {
-        if (debugTraceEnabled) {
-            debug_trace_message("ze_lib Context Destructor", "");
-        }
 #ifdef DYNAMIC_LOAD_LOADER
         if (!loaderTeardownCallbackReceived) {
             loaderTeardownCallback(loaderTeardownCallbackIndex);
@@ -368,8 +363,8 @@ namespace ze_lib
             }
             // Get the function pointer for zelRegisterTeardownCallback from the loader
             typedef ze_result_t (ZE_APICALL *zelRegisterTeardownCallback_t)(
-                zel_loader_teardown_callback_t, 
-                zel_application_teardown_callback_t*, 
+                zel_loader_teardown_callback_t,
+                zel_application_teardown_callback_t*,
                 uint32_t*);
             auto pfnZelRegisterTeardownCallback = reinterpret_cast<zelRegisterTeardownCallback_t>(
                 GET_FUNCTION_PTR(loader, "zelRegisterTeardownCallback"));
@@ -514,11 +509,11 @@ void stabilityCheck(std::promise<int> stabilityPromise) {
 }
 #endif
 
-ZE_DLLEXPORT ze_result_t ZE_APICALL
+ze_result_t ZE_APICALL
 zelRegisterTeardownCallback(
-   zel_loader_teardown_callback_t application_callback, // [in] Pointer to the user's application callback function
-   zel_application_teardown_callback_t *loader_callback,      // [out] Pointer to the L0 Loader's callback function 
-   uint32_t *index // [out] Index of the callback function
+   zel_loader_teardown_callback_t application_callback, // [in] Application's callback function to be called during loader teardown
+   zel_application_teardown_callback_t *loader_callback, // [out] Pointer to the loader's callback function
+   uint32_t *index // [out] Index assigned to the registered callback
 ) {
     ze_result_t result = ZE_RESULT_SUCCESS;
     if (nullptr == application_callback) {

--- a/source/lib/ze_lib.cpp
+++ b/source/lib/ze_lib.cpp
@@ -50,6 +50,10 @@ namespace ze_lib
      */
     void applicationTeardownCallback(uint32_t index) {
         if (ze_lib::context->teardownCallbacks.find(index) != ze_lib::context->teardownCallbacks.end()) {
+            if (ze_lib::context->debugTraceEnabled) {
+                std::string message = "applicationTeardownCallback received for index: " + std::to_string(index);
+                ze_lib::context->debug_trace_message(message, "");
+            }
             ze_lib::context->teardownCallbacks.erase(index);
         }
     }

--- a/source/lib/ze_lib.h
+++ b/source/lib/ze_lib.h
@@ -24,6 +24,9 @@
 #include <typeinfo>
 #include <iostream>
 
+typedef void (*zel_loader_teardown_callback_t)();
+typedef void (*zel_application_teardown_callback_t)(uint32_t index);
+
 namespace ze_lib
 {
     ///////////////////////////////////////////////////////////////////////////////
@@ -175,12 +178,20 @@ namespace ze_lib
         bool debugTraceEnabled = false;
         bool dynamicTracingSupported = true;
         ze_pfnDriverGet_t loaderDriverGet = nullptr;
+        std::atomic<uint32_t> teardownCallbacksCount{0};
+        std::map<uint32_t, zel_loader_teardown_callback_t> teardownCallbacks;
+        #ifdef DYNAMIC_LOAD_LOADER
+        std::once_flag initTeardownCallbacksOnce;
+        zel_application_teardown_callback_t loaderTeardownCallback = nullptr;
+        uint32_t loaderTeardownCallbackIndex = 0;
+        #endif
     };
 
     extern bool destruction;
     extern context_t *context;
     #ifdef DYNAMIC_LOAD_LOADER
     extern bool delayContextDestruction;
+    extern bool loaderTeardownCallbackReceived;
     #endif
 
 } // namespace ze_lib

--- a/source/lib/ze_lib.h
+++ b/source/lib/ze_lib.h
@@ -17,15 +17,13 @@
 #include "layers/zel_tracing_api.h"
 #include "layers/zel_tracing_ddi.h"
 #include "../utils/logging.h"
+#include "loader/ze_loader.h"
 #include "ze_util.h"
 #include <vector>
 #include <mutex>
 #include <atomic>
 #include <typeinfo>
 #include <iostream>
-
-typedef void (*zel_loader_teardown_callback_t)();
-typedef void (*zel_application_teardown_callback_t)(uint32_t index);
 
 namespace ze_lib
 {

--- a/source/lib/ze_lib.h
+++ b/source/lib/ze_lib.h
@@ -190,6 +190,7 @@ namespace ze_lib
     #ifdef DYNAMIC_LOAD_LOADER
     extern bool delayContextDestruction;
     extern bool loaderTeardownCallbackReceived;
+    extern bool loaderTeardownRegistrationEnabled;
     #endif
 
 } // namespace ze_lib

--- a/source/lib/ze_lib.h
+++ b/source/lib/ze_lib.h
@@ -178,6 +178,7 @@ namespace ze_lib
         ze_pfnDriverGet_t loaderDriverGet = nullptr;
         std::atomic<uint32_t> teardownCallbacksCount{0};
         std::map<uint32_t, zel_loader_teardown_callback_t> teardownCallbacks;
+        std::mutex teardownCallbacksMutex;
         #ifdef DYNAMIC_LOAD_LOADER
         std::once_flag initTeardownCallbacksOnce;
         zel_application_teardown_callback_t loaderTeardownCallback = nullptr;


### PR DESCRIPTION
This pull request introduces a new teardown callback mechanism for the Level Zero loader, enabling applications to register and handle callbacks during the loader teardown process. It also removes the old stability check mechanism and replaces it with a more robust teardown notification system. Below are the most important changes grouped by themes:

### Teardown Callback Mechanism:

* Added a new API function, `zelRegisterTeardownCallback`, allowing applications to register teardown callbacks. This includes defining the function prototype and its implementation in both `ze_loader.h` and `ze_lib.cpp` (`zelRegisterTeardownCallback`) [[1]](diffhunk://#diff-c5151f6444314ba87fb74ab4543a0d4aa5a972c4a0910a8af4497c1c12722201R97-R121) [[2]](diffhunk://#diff-5930a3ebf943c96c7aadfd77296d3cc83a6f2f7231582ee9d748e434d290dfc1L411-L473).
* Introduced new data structures in `ze_lib.h`, such as `teardownCallbacks` (a map) and `teardownCallbacksCount` (an atomic counter), to manage registered callbacks and their indices (`teardownCallbacks`, `teardownCallbacksCount`).

### Loader Teardown Handling:

* Implemented logic in the `context_t` destructor to invoke registered teardown callbacks and clear the callback registry during loader teardown (`teardownCallbacks.clear()`) [[1]](diffhunk://#diff-5930a3ebf943c96c7aadfd77296d3cc83a6f2f7231582ee9d748e434d290dfc1R72-R84) [[2]](diffhunk://#diff-5930a3ebf943c96c7aadfd77296d3cc83a6f2f7231582ee9d748e434d290dfc1R455-R463).
* Added `staticLoaderTeardownCallback` and `applicationTeardownCallback` functions to handle loader teardown events and remove callbacks from the registry (`staticLoaderTeardownCallback`, `applicationTeardownCallback`).

### Initialization and Registration:

* Updated `ze_lib` context initialization to dynamically load the `zelRegisterTeardownCallback` function and register the static loader callback if available (`zelRegisterTeardownCallback`).

### Stability Check Removal:

* Removed the old stability check mechanism, including the `stabilityCheck` function and related code, replacing it with the new teardown callback system [[1]](diffhunk://#diff-5930a3ebf943c96c7aadfd77296d3cc83a6f2f7231582ee9d748e434d290dfc1L411-L473) [[2]](diffhunk://#diff-5930a3ebf943c96c7aadfd77296d3cc83a6f2f7231582ee9d748e434d290dfc1L496-R590).

### Debugging and Logging Enhancements:

* Enhanced debug tracing to log messages when teardown callbacks are registered, invoked, or when the loader enters a teardown state (`debug_trace_message`) [[1]](diffhunk://#diff-5930a3ebf943c96c7aadfd77296d3cc83a6f2f7231582ee9d748e434d290dfc1R455-R463) [[2]](diffhunk://#diff-5930a3ebf943c96c7aadfd77296d3cc83a6f2f7231582ee9d748e434d290dfc1L496-R590).