### PR TITLE
Fix sysman only init to disallow retrieval of loader context due to version compatibility

### DIFF
--- a/source/lib/ze_lib.cpp
+++ b/source/lib/ze_lib.cpp
@@ -174,16 +174,12 @@ namespace ze_lib
         // Given zesInit, then zesDrivers needs to be used as the sysmanInstanceDrivers;
         bool loaderContextAccessAllowed = true;
 #ifdef DYNAMIC_LOAD_LOADER
+        loaderContextAccessAllowed = false;
         loader::context_t *loaderContext = nullptr;
-        if (loaderGetContext == nullptr) {
-            loaderContextAccessAllowed = false;
-        } else {
-            loaderContext = loaderGetContext();
-        }
 #else
         loader::context_t *loaderContext = loader::context;
 #endif
-        if (sysmanOnly && loaderContextAccessAllowed) {
+        if (sysmanOnly && loaderContextAccessAllowed && loaderContext != nullptr) {
             loaderContext->sysmanInstanceDrivers = &loaderContext->zesDrivers;
         }
 


### PR DESCRIPTION

- Given the static loader will no longer call the sysman apis directly, but thru the dynamic loader, split sysman drivers will be done by the dynamic loader and assignment in the static loader is not needed.
- When the context read from the loader was newer than the context locally, the memory assignment was invalid causing issues.