### PR TITLE
Fix potential SIOF issue with checker layers

### DIFF
--- a/source/layers/validation/checkers/basic_leak/zel_basic_leak_checker.cpp
+++ b/source/layers/validation/checkers/basic_leak/zel_basic_leak_checker.cpp
@@ -26,7 +26,7 @@ namespace validation_layer
             basic_leak_checker.zeValidation = zeChecker;
             basic_leak_checker.zetValidation = zetChecker;
             basic_leak_checker.zesValidation = zesChecker;
-            validation_layer::context.validationHandlers.push_back(&basic_leak_checker);
+            validation_layer::context.getInstance().validationHandlers.push_back(&basic_leak_checker);
         }
     }
 

--- a/source/layers/validation/checkers/events_checker/zel_events_checker.cpp
+++ b/source/layers/validation/checkers/events_checker/zel_events_checker.cpp
@@ -25,7 +25,7 @@ eventsChecker::eventsChecker() {
         events_checker.zesValidation = zesChecker;
         events_checker.zetValidation = zetChecker;
 
-        validation_layer::context.validationHandlers.push_back(&events_checker);
+        validation_layer::context.getInstance().validationHandlers.push_back(&events_checker);
     }
 }
 


### PR DESCRIPTION
Since the order of global initialization is undefined, the context variable, accessed directly from the events and leak checkers, might be unitialized.

This patch fixes this by using the getInstance() accessor method that makes sure that the validation layer context is initialized before use.