### PR TITLE
Fix zer Global table init to be optional and zero init DDI tables

### DIFF
--- a/scripts/templates/ldrddi.cpp.mako
+++ b/scripts/templates/ldrddi.cpp.mako
@@ -532,7 +532,7 @@ ${tbl['export']['name']}(
 
     ${x}_result_t result = ${X}_RESULT_SUCCESS;
 
-    %if tbl['experimental'] is False: #//Experimental Tables may not be implemented in driver
+    %if tbl['experimental'] is False and namespace != "zer": #//Experimental Tables may not be implemented in driver
     bool atLeastOneDriverValid = false;
     %endif
     // Load the device-driver DDI tables
@@ -547,7 +547,7 @@ ${tbl['export']['name']}(
         auto getTable = reinterpret_cast<${tbl['pfn']}>(
             GET_FUNCTION_PTR( drv.handle, "${tbl['export']['name']}") );
         if(!getTable) 
-        %if th.isNewProcTable(tbl['export']['name']) is True:
+        %if th.isNewProcTable(tbl['export']['name']) is True and namespace != "zer":
         {
             atLeastOneDriverValid = true;
             //It is valid to not have this proc addr table
@@ -556,7 +556,7 @@ ${tbl['export']['name']}(
         %else:
             continue; 
         %endif
-        %if tbl['experimental'] is False: #//Experimental Tables may not be implemented in driver
+        %if tbl['experimental'] is False and namespace != "zer": #//Experimental Tables may not be implemented in driver
         auto getTableResult = getTable( version, &drv.dditable.${n}.${tbl['name']});
         if(getTableResult == ZE_RESULT_SUCCESS) {
             atLeastOneDriverValid = true;
@@ -564,7 +564,7 @@ ${tbl['export']['name']}(
         } else
             drv.initStatus = getTableResult;
         %if namespace != "zes":
-        %if tbl['name'] == "Global":
+        %if tbl['name'] == "Global" and namespace != "zer":
         if (drv.dditable.ze.Global.pfnInitDrivers) {
             loader::context->initDriversSupport = true;
         }
@@ -575,7 +575,7 @@ ${tbl['export']['name']}(
         %endif
     }
 
-    %if tbl['experimental'] is False: #//Experimental Tables may not be implemented in driver
+    %if tbl['experimental'] is False and namespace != "zer": #//Experimental Tables may not be implemented in driver
     if(!atLeastOneDriverValid)
         result = ${X}_RESULT_ERROR_UNINITIALIZED;
     else

--- a/source/lib/ze_lib.cpp
+++ b/source/lib/ze_lib.cpp
@@ -206,6 +206,10 @@ namespace ze_lib
 
         if ( ZE_RESULT_SUCCESS == result )
         {
+            memset(&initialzeDdiTable, 0, sizeof(ze_dditable_t));
+            memset(&initialzetDdiTable, 0, sizeof(zet_dditable_t));
+            memset(&initialzesDdiTable, 0, sizeof(zes_dditable_t));
+            memset(&initialzerDdiTable, 0, sizeof(zer_dditable_t));
             ze_lib::context->zeDdiTable.exchange(&ze_lib::context->initialzeDdiTable);
             ze_lib::context->zetDdiTable.exchange(&ze_lib::context->initialzetDdiTable);
             ze_lib::context->zesDdiTable.exchange(&ze_lib::context->initialzesDdiTable);

--- a/source/loader/zer_ldrddi.cpp
+++ b/source/loader/zer_ldrddi.cpp
@@ -141,7 +141,6 @@ zerGetGlobalProcAddrTable(
 
     ze_result_t result = ZE_RESULT_SUCCESS;
 
-    bool atLeastOneDriverValid = false;
     // Load the device-driver DDI tables
     for( auto& drv : loader::context->zeDrivers )
     {
@@ -151,21 +150,9 @@ zerGetGlobalProcAddrTable(
             GET_FUNCTION_PTR( drv.handle, "zerGetGlobalProcAddrTable") );
         if(!getTable) 
             continue; 
-        auto getTableResult = getTable( version, &drv.dditable.zer.Global);
-        if(getTableResult == ZE_RESULT_SUCCESS) {
-            atLeastOneDriverValid = true;
-            loader::context->configured_version = version;
-        } else
-            drv.initStatus = getTableResult;
-        if (drv.dditable.ze.Global.pfnInitDrivers) {
-            loader::context->initDriversSupport = true;
-        }
+        result = getTable( version, &drv.dditable.zer.Global);
     }
 
-    if(!atLeastOneDriverValid)
-        result = ZE_RESULT_ERROR_UNINITIALIZED;
-    else
-        result = ZE_RESULT_SUCCESS;
 
     if( ZE_RESULT_SUCCESS == result )
     {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -620,7 +620,7 @@ function(add_runtime_api_test test_scenario init_method driver_config)
         set(gtest_filter "*GivenLevelZeroLoaderPresentWithLoaderInterceptEnabledAndDdiExtNotSupportedWhenCallingRuntimeApisAfter${init_method}ThenExpectNullDriverIsReachedSuccessfully")
     elseif(test_scenario STREQUAL "ddi_ext_v1_0")
         set(gtest_filter "*GivenLevelZeroLoaderPresentWithLoaderInterceptEnabledAndDdiExtSupportedWithVersion1_0WhenCallingRuntimeApisAfter${init_method}ThenExpectErrorUninitialized")
-    elseif(test_scenario STREQUAL "runtime_api_unsupported")
+    elseif(test_scenario STREQUAL "unsupported")
         set(gtest_filter "*GivenLevelZeroLoaderPresentWithLoaderInterceptEnabledAndRuntimeApiUnsupportedWhenCallingRuntimeApisAfter${init_method}ThenExpectErrorUnsupportedFeature")
     endif()
     
@@ -656,9 +656,8 @@ foreach(init_method IN LISTS init_methods)
         # Add multi-driver tests
         add_runtime_api_test(${test_scenario} ${init_method} "multi_driver")
     endforeach()
-    
     # Add runtime_api_unsupported tests for single driver
-    if(init_method STREQUAL "ZeInitDrivers")
-        add_runtime_api_test("runtime_api_unsupported" ${init_method} "single_driver")
+    if(init_method STREQUAL "ZeInitDrivers" OR init_method STREQUAL "ZeInit")
+        add_runtime_api_test("unsupported" ${init_method} "single_driver")
     endif()
 endforeach()

--- a/test/loader_api.cpp
+++ b/test/loader_api.cpp
@@ -2557,7 +2557,6 @@ TEST_F(DriverOrderingTest,
     EXPECT_EQ(0, strcmp(errorDesc, "ERROR UNSUPPORTED FEATURE"));
   }
 
-  /*
   TEST(
       RuntimeApiLoaderDriverInteraction,
       GivenLevelZeroLoaderPresentWithLoaderInterceptEnabledAndRuntimeApiUnsupportedWhenCallingRuntimeApisAfterZeInitThenExpectErrorUnsupportedFeature)
@@ -2599,7 +2598,6 @@ TEST_F(DriverOrderingTest,
     EXPECT_NE(errorDesc, nullptr);
     EXPECT_EQ(0, strcmp(errorDesc, "ERROR UNSUPPORTED FEATURE"));
   }
-    */
   
 
 } // namespace


### PR DESCRIPTION
- Fix the zer Global Init to be treated like an experimental init that
  cannot affect the ability to use a driver.
- Zero initialize the zer DDI tables to avoid uninitialized memory reads
  when a driver does not implement all DDI functions.