### PR TITLE
Fix to zer Handle init to address replacement of ze driver handles

### DIFF
--- a/scripts/templates/ze_loader_internal.h.mako
+++ b/scripts/templates/ze_loader_internal.h.mako
@@ -69,6 +69,7 @@ namespace loader
         bool legacyInitAttempted = false;
         bool driverDDIHandleSupportQueried = false;
         ze_driver_handle_t zerDriverHandle = nullptr;
+        bool zerDriverDDISupported = true;
     };
 
     using driver_vector_t = std::vector< driver_t >;

--- a/source/loader/ze_ldrddi.cpp
+++ b/source/loader/ze_ldrddi.cpp
@@ -63,7 +63,6 @@ namespace loader
             if (!loader::context->sortingInProgress.exchange(true) && !loader::context->instrumentationEnabled) {
                 std::call_once(loader::context->coreDriverSortOnce, []() {
                     loader::context->driverSorting(&loader::context->zeDrivers, nullptr, false);
-                    loader::context->defaultZerDriverHandle = loader::context->zeDrivers.front().zerDriverHandle;
                     loader::defaultZerDdiTable = &loader::context->zeDrivers.front().dditable.zer;
                 });
                 loader::context->sortingInProgress.store(false);
@@ -128,6 +127,7 @@ namespace loader
                                     if (strcmp(extensionProperties[extIndex].name, ZE_DRIVER_DDI_HANDLES_EXT_NAME) == 0 && (!(extensionProperties[extIndex].version >= ZE_DRIVER_DDI_HANDLES_EXT_VERSION_1_1))) {
                                         // Driver supports DDI Handles but not the required version for ZER APIs so set the driverHandle to nullptr
                                         drv.zerDriverHandle = nullptr;
+                                        drv.zerDriverDDISupported = false;
                                         break;
                                     }
                                 }
@@ -157,8 +157,7 @@ namespace loader
                             phDrivers[ driver_index ] = reinterpret_cast<ze_driver_handle_t>(
                                 context->ze_driver_factory.getInstance( phDrivers[ driver_index ], &drv.dditable ) );
                             if (drv.zerDriverHandle != nullptr) {
-                                drv.zerDriverHandle = reinterpret_cast<ze_driver_handle_t>(
-                                    context->ze_driver_factory.getInstance( drv.zerDriverHandle, &drv.dditable ) );
+                                drv.zerDriverHandle = phDrivers[ driver_index ];
                             }
                         } else if (drv.properties.flags & ZE_DRIVER_DDI_HANDLE_EXT_FLAG_DDI_HANDLE_EXT_SUPPORTED) {
                             if (loader::context->debugTraceEnabled) {
@@ -183,6 +182,10 @@ namespace loader
         if (total_driver_handle_count > 0) {
             result = ZE_RESULT_SUCCESS;
         }
+        if (loader::context->zeDrivers.front().zerDriverDDISupported)
+            loader::context->defaultZerDriverHandle = loader::context->zeDrivers.front().zerDriverHandle;
+        else
+            loader::context->defaultZerDriverHandle = nullptr;
 
         return result;
     }
@@ -212,7 +215,6 @@ namespace loader
             if (!loader::context->sortingInProgress.exchange(true) && !loader::context->instrumentationEnabled) {
                 std::call_once(loader::context->coreDriverSortOnce, [desc]() {
                     loader::context->driverSorting(&loader::context->zeDrivers, desc, false);
-                    loader::context->defaultZerDriverHandle = loader::context->zeDrivers.front().zerDriverHandle;
                     loader::defaultZerDdiTable = &loader::context->zeDrivers.front().dditable.zer;
                 });
                 loader::context->sortingInProgress.store(false);
@@ -279,6 +281,7 @@ namespace loader
                                     if (strcmp(extensionProperties[extIndex].name, ZE_DRIVER_DDI_HANDLES_EXT_NAME) == 0 && (!(extensionProperties[extIndex].version >= ZE_DRIVER_DDI_HANDLES_EXT_VERSION_1_1))) {
                                         // Driver supports DDI Handles but not the required version for ZER APIs so set the driverHandle to nullptr
                                         drv.zerDriverHandle = nullptr;
+                                        drv.zerDriverDDISupported = false;
                                         break;
                                     }
                                 }
@@ -308,8 +311,7 @@ namespace loader
                             phDrivers[ driver_index ] = reinterpret_cast<ze_driver_handle_t>(
                                 context->ze_driver_factory.getInstance( phDrivers[ driver_index ], &drv.dditable ) );
                             if (drv.zerDriverHandle != nullptr) {
-                                drv.zerDriverHandle = reinterpret_cast<ze_driver_handle_t>(
-                                    context->ze_driver_factory.getInstance( drv.zerDriverHandle, &drv.dditable ) );
+                                drv.zerDriverHandle = phDrivers[ driver_index ];
                             }
                         } else if (drv.properties.flags & ZE_DRIVER_DDI_HANDLE_EXT_FLAG_DDI_HANDLE_EXT_SUPPORTED) {
                             if (loader::context->debugTraceEnabled) {
@@ -334,6 +336,10 @@ namespace loader
         if (total_driver_handle_count > 0) {
             result = ZE_RESULT_SUCCESS;
         }
+        if (loader::context->zeDrivers.front().zerDriverDDISupported)
+            loader::context->defaultZerDriverHandle = loader::context->zeDrivers.front().zerDriverHandle;
+        else
+            loader::context->defaultZerDriverHandle = nullptr;
 
         return result;
     }

--- a/source/loader/ze_loader.cpp
+++ b/source/loader/ze_loader.cpp
@@ -355,9 +355,11 @@ namespace loader
                         if (strcmp(extensionProperties[extIndex].name, ZE_DRIVER_DDI_HANDLES_EXT_NAME) == 0 && (!(extensionProperties[extIndex].version >= ZE_DRIVER_DDI_HANDLES_EXT_VERSION_1_1))) {
                             // Driver supports DDI Handles but not the required version for ZER APIs so set the driverHandle to nullptr
                             driver.zerDriverHandle = nullptr;
+                            driver.zerDriverDDISupported = false;
                             break;
                         }
                     }
+
                 }
                 driver.properties = {};
                 driver.properties.stype = ZE_STRUCTURE_TYPE_DRIVER_DDI_HANDLES_EXT_PROPERTIES;
@@ -379,10 +381,6 @@ namespace loader
                     if (debugTraceEnabled) {
                         std::string message = "driverSorting: Driver DDI Handles Not Supported for " + driver.name;
                         debug_trace_message(message, "");
-                    }
-                    if (driver.zerDriverHandle != nullptr) {
-                        driver.zerDriverHandle = reinterpret_cast<ze_driver_handle_t>(
-                            loader::context->ze_driver_factory.getInstance(driver.zerDriverHandle, &driver.dditable));
                     }
                 } else {
                     if (debugTraceEnabled) {
@@ -568,7 +566,10 @@ namespace loader
             return ZE_RESULT_ERROR_UNINITIALIZED;
 
         // Set default driver handle and DDI table to the first driver in the list before sorting.
-        loader::context->defaultZerDriverHandle = loader::context->zeDrivers.front().zerDriverHandle;
+        if (loader::context->zeDrivers.front().zerDriverDDISupported)
+            loader::context->defaultZerDriverHandle = loader::context->zeDrivers.front().zerDriverHandle;
+        else
+            loader::context->defaultZerDriverHandle = nullptr;
         loader::defaultZerDdiTable = &loader::context->zeDrivers.front().dditable.zer;
         return ZE_RESULT_SUCCESS;
     }

--- a/source/loader/ze_loader_internal.h
+++ b/source/loader/ze_loader_internal.h
@@ -60,6 +60,7 @@ namespace loader
         bool legacyInitAttempted = false;
         bool driverDDIHandleSupportQueried = false;
         ze_driver_handle_t zerDriverHandle = nullptr;
+        bool zerDriverDDISupported = true;
     };
 
     using driver_vector_t = std::vector< driver_t >;

--- a/source/loader/zes_ldrddi.cpp
+++ b/source/loader/zes_ldrddi.cpp
@@ -105,7 +105,6 @@ namespace loader
                 {
                     for( uint32_t i = 0; i < library_driver_handle_count; ++i ) {
                         uint32_t driver_index = total_driver_handle_count + i;
-                        drv.zerDriverHandle = phDrivers[ driver_index ];
                         phDrivers[ driver_index ] = reinterpret_cast<zes_driver_handle_t>(
                             context->zes_driver_factory.getInstance( phDrivers[ driver_index ], &drv.dditable ) );
                     }
@@ -125,7 +124,6 @@ namespace loader
         if (total_driver_handle_count > 0) {
             result = ZE_RESULT_SUCCESS;
         }
-
         return result;
     }
 

--- a/test/loader_api.cpp
+++ b/test/loader_api.cpp
@@ -2400,6 +2400,10 @@ TEST_F(DriverOrderingTest,
     EXPECT_EQ(ZE_RESULT_SUCCESS, zeInit(0));
     EXPECT_EQ(ZE_RESULT_SUCCESS, zeDriverGet(&driverGetCount, nullptr));
     EXPECT_GT(driverGetCount, 0);
+    std::vector<ze_driver_handle_t> drivers;
+    drivers.resize(driverGetCount);
+    EXPECT_EQ(ZE_RESULT_SUCCESS, zeDriverGet(&driverGetCount, drivers.data()));
+    EXPECT_GT(driverGetCount, 0);
 
     const char *errorString = nullptr;
     uint32_t deviceId = 0;


### PR DESCRIPTION
- Removed generation of zerDriver Handles and reuse the ze driver handles when running in legacy ddi table modes.
- Fixed ULT for driverget to properly read handles.