### PR TITLE
fix: Init DDI Tables during constructor

### DIFF
--- a/source/lib/ze_lib.cpp
+++ b/source/lib/ze_lib.cpp
@@ -64,6 +64,10 @@ namespace ze_lib
     __zedlllocal context_t::context_t()
     {
         debugTraceEnabled = getenv_tobool( "ZE_ENABLE_LOADER_DEBUG_TRACE" );
+        memset(&initialzeDdiTable, 0, sizeof(ze_dditable_t));
+        memset(&initialzetDdiTable, 0, sizeof(zet_dditable_t));
+        memset(&initialzesDdiTable, 0, sizeof(zes_dditable_t));
+        memset(&initialzerDdiTable, 0, sizeof(zer_dditable_t));
     };
 
     ///////////////////////////////////////////////////////////////////////////////
@@ -211,10 +215,6 @@ namespace ze_lib
 
         if ( ZE_RESULT_SUCCESS == result )
         {
-            memset(&initialzeDdiTable, 0, sizeof(ze_dditable_t));
-            memset(&initialzetDdiTable, 0, sizeof(zet_dditable_t));
-            memset(&initialzesDdiTable, 0, sizeof(zes_dditable_t));
-            memset(&initialzerDdiTable, 0, sizeof(zer_dditable_t));
             ze_lib::context->zeDdiTable.exchange(&ze_lib::context->initialzeDdiTable);
             ze_lib::context->zetDdiTable.exchange(&ze_lib::context->initialzetDdiTable);
             ze_lib::context->zesDdiTable.exchange(&ze_lib::context->initialzesDdiTable);


### PR DESCRIPTION
- To address race conditions during multi-threaded calls between threads using both zeInit and zeInitDrivers, set the ddi tables to 0 during the constructor vs during init to esnure the tables are empty before init, but don't get reset twice.