### PR TITLE
Fix closing driver library in context destructor

### DIFF
--- a/source/loader/ze_loader.cpp
+++ b/source/loader/ze_loader.cpp
@@ -824,7 +824,7 @@ namespace loader
             }
         }
 
-        for( auto& drv : allDrivers )
+        for( auto& drv : zeDrivers )
         {
             if (drv.handle) {
                 auto free_result = FREE_DRIVER_LIBRARY( drv.handle );


### PR DESCRIPTION
Loop over zeDrivers (instead of allDrivers) vector in order to free driver libraries. Using allDrivers may not always work since if there's more than one driver discovered, drivers in allDrivers vector have null handles.