### PR TITLE
Fix the clang issue due to empty structure in the Tracing Layer

### DIFF
--- a/include/layers/zel_tracing_register_cb.h
+++ b/include/layers/zel_tracing_register_cb.h
@@ -2721,26 +2721,16 @@ typedef void (ZE_APICALL *zer_pfnTranslateIdentifierToDeviceHandleCb_t)(
     void** ppTracerInstanceUserData
     );
 
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerGetDefaultContext
-/// @details Each entry is a pointer to the parameter passed to the function;
-///     allowing the callback the ability to modify the parameter's value
-
-typedef struct _zer_get_default_context_params_t
-{
-    void* dummy;  // Placeholder for empty parameter list
-} zer_get_default_context_params_t;
-
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Callback function-pointer for zerGetDefaultContext
-/// @param[in] params Parameters passed to this instance
+/// @param[in] params Parameters passed to this instance (NULL for parameter-less functions)
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
 
 typedef void (ZE_APICALL *zer_pfnGetDefaultContextCb_t)(
-    zer_get_default_context_params_t* params,
+    void* params,
     ze_context_handle_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData

--- a/include/layers/zel_tracing_register_cb.h
+++ b/include/layers/zel_tracing_register_cb.h
@@ -2728,6 +2728,7 @@ typedef void (ZE_APICALL *zer_pfnTranslateIdentifierToDeviceHandleCb_t)(
 
 typedef struct _zer_get_default_context_params_t
 {
+    void* dummy;  // Placeholder for empty parameter list
 } zer_get_default_context_params_t;
 
 

--- a/scripts/templates/tracing/trc_setters.h.mako
+++ b/scripts/templates/tracing/trc_setters.h.mako
@@ -45,32 +45,39 @@ typedef struct _zel_tracer_handle_t *zel_tracer_handle_t;
 <%
     ret_type = obj['return_type']
     param_lines = th.make_param_lines(n, tags, obj, format=["type*", "name"])
-%>///////////////////////////////////////////////////////////////////////////////
+%>\
+%if param_lines:
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Callback function parameters for ${th.make_func_name(n, tags, obj)}
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
 
 typedef struct _${th.make_pfncb_param_type(n, tags, obj)}
 {
-    %if param_lines:
     %for line in param_lines:
     ${line};
     %endfor
-    %else:
-    void* dummy;  // Placeholder for empty parameter list
-    %endif
 } ${th.make_pfncb_param_type(n, tags, obj)};
 
+%endif
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Callback function-pointer for ${th.make_func_name(n, tags, obj)}
-/// @param[in] params Parameters passed to this instance
+/// @param[in] params Parameters passed to this instance\
+%if not param_lines:
+ (NULL for parameter-less functions)\
+%endif
+
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
 
 typedef void (${X}_APICALL *${th.make_pfncb_type(n, tags, obj)})(
+    %if param_lines:
     ${th.make_pfncb_param_type(n, tags, obj)}* params,
+    %else:
+    void* params,
+    %endif
     ${ret_type} result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData

--- a/scripts/templates/tracing/trc_setters.h.mako
+++ b/scripts/templates/tracing/trc_setters.h.mako
@@ -44,6 +44,7 @@ typedef struct _zel_tracer_handle_t *zel_tracer_handle_t;
 %for obj in tbl['functions']:
 <%
     ret_type = obj['return_type']
+    param_lines = th.make_param_lines(n, tags, obj, format=["type*", "name"])
 %>///////////////////////////////////////////////////////////////////////////////
 /// @brief Callback function parameters for ${th.make_func_name(n, tags, obj)}
 /// @details Each entry is a pointer to the parameter passed to the function;
@@ -51,9 +52,13 @@ typedef struct _zel_tracer_handle_t *zel_tracer_handle_t;
 
 typedef struct _${th.make_pfncb_param_type(n, tags, obj)}
 {
-    %for line in th.make_param_lines(n, tags, obj, format=["type*", "name"]):
+    %if param_lines:
+    %for line in param_lines:
     ${line};
     %endfor
+    %else:
+    void* dummy;  // Placeholder for empty parameter list
+    %endif
 } ${th.make_pfncb_param_type(n, tags, obj)};
 
 

--- a/scripts/templates/tracing/trcddi.cpp.mako
+++ b/scripts/templates/tracing/trcddi.cpp.mako
@@ -58,11 +58,11 @@ namespace tracing_layer
 );
 
         // capture parameters
-        ${th.make_pfncb_param_type(n, tags, obj)} tracerParams = {
 %if not is_void_params:
+        ${th.make_pfncb_param_type(n, tags, obj)} tracerParams = {
             &${",\n            &".join(params_list)}
-%endif
         };
+%endif
 
         tracing_layer::APITracerCallbackDataImp<${th.make_pfncb_type(n, tags, obj)}> apiCallbackData;
 
@@ -70,7 +70,11 @@ namespace tracing_layer
 
 
         return tracing_layer::APITracerWrapperImp<${ret_type}>(context.${n}DdiTable.${th.get_table_name(n, tags, obj)}.${th.make_pfn_name(n, tags, obj)},
+                                                  %if not is_void_params:
                                                   &tracerParams,
+                                                  %else:
+                                                  nullptr,
+                                                  %endif
                                                   apiCallbackData.apiOrdinal,
                                                   apiCallbackData.prologCallbacks,
                                                   apiCallbackData.epilogCallbacks\

--- a/source/layers/tracing/zer_trcddi.cpp
+++ b/source/layers/tracing/zer_trcddi.cpp
@@ -125,8 +125,6 @@ namespace tracing_layer
         ZE_HANDLE_TRACER_RECURSION(context.zerDdiTable.Global.pfnGetDefaultContext);
 
         // capture parameters
-        zer_get_default_context_params_t tracerParams = {
-        };
 
         tracing_layer::APITracerCallbackDataImp<zer_pfnGetDefaultContextCb_t> apiCallbackData;
 
@@ -134,7 +132,7 @@ namespace tracing_layer
 
 
         return tracing_layer::APITracerWrapperImp<ze_context_handle_t>(context.zerDdiTable.Global.pfnGetDefaultContext,
-                                                  &tracerParams,
+                                                  nullptr,
                                                   apiCallbackData.apiOrdinal,
                                                   apiCallbackData.prologCallbacks,
                                                   apiCallbackData.epilogCallbacks);

--- a/test/loader_tracing_layer.cpp
+++ b/test/loader_tracing_layer.cpp
@@ -422,7 +422,7 @@ namespace
             data->incrementZerPrologueCallCount("zerTranslateIdentifierToDeviceHandle");
         }
 
-        static void zerGetDefaultContextPrologueCallback(zer_get_default_context_params_t *params, ze_context_handle_t result, void *pTracerUserData, void **ppTracerInstanceUserData)
+        static void zerGetDefaultContextPrologueCallback(void *params, ze_context_handle_t result, void *pTracerUserData, void **ppTracerInstanceUserData)
         {
             TracingData *data = static_cast<TracingData *>(pTracerUserData);
             data->incrementZerPrologueCallCount("zerGetDefaultContext");
@@ -446,7 +446,7 @@ namespace
             data->incrementZerEpilogueCallCount("zerTranslateIdentifierToDeviceHandle");
         }
 
-        static void zerGetDefaultContextEpilogueCallback(zer_get_default_context_params_t *params, ze_context_handle_t result, void *pTracerUserData, void **ppTracerInstanceUserData)
+        static void zerGetDefaultContextEpilogueCallback(void *params, ze_context_handle_t result, void *pTracerUserData, void **ppTracerInstanceUserData)
         {
             TracingData *data = static_cast<TracingData *>(pTracerUserData);
             data->incrementZerEpilogueCallCount("zerGetDefaultContext");


### PR DESCRIPTION
Use void* instead of empty zer_get_default_context_params_t structure for parameter-less callbacks to fix Clang compilation.

Related-To: NEO-17790

Signed-off-by: Pratik Bari <pratik.bari@intel.com>