### PR TITLE
Update for release v1.28.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * Add CONFLICTS, PROVIDES, REPLACES directives in packages
 * Fix: Potential bug when no L0 Drivers initialized the global DDI tables
 * Fix: Potential packaging conflict w/ -devel w/RPM against 'filesystem' package for SLES
-* Add Unit testing during CI to install/remove packages in OS specific docckers.
+* Add Unit testing during CI to install/remove packages in OS specific dockers.
 ## v1.28.4
 * Add README.md and CONTRIBUTING.md changes for Unit Testing
 * Add CMakefile.txt check for PRODUCT_GUID.txt updates before release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Level zero loader changelog
+## v1.28.5
+* Add Canonical Specific packages in CPack (libze1*)
+* Add CONFLICTS, PROVIDES, REPLACES directives in packages
+* Fix: Potential bug when no L0 Drivers initialized the global DDI tables
+* Fix: Potential packaging conflict w/ -devel w/RPM against 'filesystem' package for SLES
+* Add Unit testing during CI to install/remove packages in OS specific docckers.
 ## v1.28.4
 * Add README.md and CONTRIBUTING.md changes for Unit Testing
 * Add CMakefile.txt check for PRODUCT_GUID.txt updates before release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if(MSVC AND (MSVC_VERSION LESS 1900))
 endif()
 
 # This project follows semantic versioning (https://semver.org/)
-project(level-zero VERSION 1.28.4)
+project(level-zero VERSION 1.28.5)
 include(GNUInstallDirs)
 
 find_package(Git)

--- a/PRODUCT_GUID.txt
+++ b/PRODUCT_GUID.txt
@@ -1,2 +1,2 @@
-1.28.4
-cfa0eed1-ba15-4a52-8efe-5d532373fded
+1.28.5
+d7db5e4f-bf72-4dee-aba3-68de0b4c79c9


### PR DESCRIPTION
* Add Canonical Specific packages in CPack (libze1*)
* Add CONFLICTS, PROVIDES, REPLACES directives in packages
* Fix: Potential bug when no L0 Drivers initialized the global DDI tables
* Fix: Potential packaging conflict w/ -devel w/RPM against 'filesystem' package for SLES
* Add Unit testing during CI to install/remove packages in OS specific dockers.