### PR TITLE
Allow Pc File Install With Window MSI Installer

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -87,7 +87,6 @@ if(CANONICAL_LIB_COMPONENT)
     )
 endif()
 
-if(NOT BUILD_INSTALLER)
 file(RELATIVE_PATH pkgconfig_prefix "${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig" "${CMAKE_INSTALL_PREFIX}")
 file(RELATIVE_PATH pkgconfig_include_dir "${CMAKE_INSTALL_PREFIX}" "${CMAKE_INSTALL_FULL_INCLUDEDIR}")
 file(RELATIVE_PATH pkgconfig_lib_dir "${CMAKE_INSTALL_PREFIX}" "${CMAKE_INSTALL_FULL_LIBDIR}")
@@ -97,13 +96,12 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/level-zero.pc.in ${CMAKE_CURRENT_BINA
 
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libze_loader.pc"
               "${CMAKE_CURRENT_BINARY_DIR}/level-zero.pc"
-        DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig" COMPONENT ${SDK_COMPONENT_STRING})
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig" COMPONENT ${SDK_COMPONENT_STRING})
 
 if(CANONICAL_SDK_COMPONENT)
     # EXCLUDE_FROM_ALL: CPack-only; avoids duplicate install_manifest.txt entries.
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libze_loader.pc"
                   "${CMAKE_CURRENT_BINARY_DIR}/level-zero.pc"
-            DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig" COMPONENT ${CANONICAL_SDK_COMPONENT}
+            DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig" COMPONENT ${CANONICAL_SDK_COMPONENT}
             EXCLUDE_FROM_ALL)
-endif()
 endif()


### PR DESCRIPTION
Tested with:

```console
cmake -S . -B build -D BUILD_INSTALLER=1
cmake --build build --config Release --target package
```

Install generated msi and setup environment.

```batch
C:\Users\a_user>pkg-config --list-all
libze_loader Level Zero Loader - Runtime Library Loader for Level Zero
level-zero   Level Zero - Level Zero
```