### PR TITLE
Remove unneeded RPMs and DEBs from builds

### DIFF
--- a/.github/workflows/build-multi.yml
+++ b/.github/workflows/build-multi.yml
@@ -199,22 +199,13 @@ jobs:
         	    echo "--- \$pkg ---"
         	    dpkg -c "\$pkg"
         	  done
-        	  echo "=== Installing level-zero (legacy) .deb packages ==="
-        	  dpkg -i ${MOUNT_TARGET}/level-zero-package/level-zero_*.deb \
-        	         ${MOUNT_TARGET}/level-zero-package/level-zero-devel_*.deb
-        	  echo "=== Installed level-zero packages ==="
-        	  dpkg -l 'level-zero*'
-        	  echo "=== Uninstalling legacy packages ==="
-        	  dpkg -r level-zero-devel level-zero
-        	  if ls ${MOUNT_TARGET}/level-zero-package/libze1_*.deb 2>/dev/null; then
-        	    echo "=== Installing libze (new) .deb packages ==="
-        	    dpkg -i ${MOUNT_TARGET}/level-zero-package/libze1_*.deb \
-        	           ${MOUNT_TARGET}/level-zero-package/libze-dev_*.deb
-        	    echo "=== Installed libze packages ==="
-        	    dpkg -l 'libze*'
-        	    echo "=== Uninstalling libze packages ==="
-        	    dpkg -r libze-dev libze1
-        	  fi
+        	  echo "=== Installing libze .deb packages ==="
+        	  dpkg -i ${MOUNT_TARGET}/level-zero-package/libze1_*.deb \
+        	         ${MOUNT_TARGET}/level-zero-package/libze-dev_*.deb
+        	  echo "=== Installed libze packages ==="
+        	  dpkg -l 'libze*'
+        	  echo "=== Uninstalling libze packages ==="
+        	  dpkg -r libze-dev libze1
         	elif [[ '${{ matrix.os.name }}' == 'sles' ]]; then
         	  echo "=== Package contents ==="
         	  for pkg in ${MOUNT_TARGET}/level-zero-package/*.rpm; do

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -416,7 +416,6 @@ if(CPACK_GENERATOR MATCHES "RPM")
 	set(CPACK_RPM_LEVEL-ZERO-DEVEL_FILE_NAME "${PROJECT_NAME}-devel-${PROJECT_VERSION}-${os_name}${os_version}.${CPACK_RPM_PACKAGE_ARCHITECTURE}.rpm")
 	set(CPACK_RPM_LEVEL-ZERO-DEVEL_PACKAGE_REQUIRES "level-zero = ${PROJECT_VERSION}")
 
-
 	set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION
 	  /etc/ld.so.conf.d
 	  /usr/lib64
@@ -437,32 +436,19 @@ if(CPACK_GENERATOR MATCHES "DEB")
 	endif()
 	set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "https://github.com/oneapi-src/level-zero")
 	set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
-	set(CPACK_DEBIAN_LEVEL-ZERO_PACKAGE_NAME "${PROJECT_NAME}")
-	set(CPACK_DEBIAN_LEVEL-ZERO-DEVEL_PACKAGE_NAME "${PROJECT_NAME}-devel")
-    set(CPACK_DEBIAN_LEVEL-ZERO_FILE_NAME "${PROJECT_NAME}_${PROJECT_VERSION}+${os_name}${os_version}_${CPACK_DEBIAN_PACKAGE_ARCHITECTURE}.deb")
-    set(CPACK_DEBIAN_LEVEL-ZERO-DEVEL_FILE_NAME "${PROJECT_NAME}-devel_${PROJECT_VERSION}+${os_name}${os_version}_${CPACK_DEBIAN_PACKAGE_ARCHITECTURE}.deb")
-    set(CPACK_DEBIAN_LEVEL-ZERO-DEVEL_PACKAGE_DEPENDS "level-zero(=${PROJECT_VERSION})")
-    # Mutual exclusion with the canonical libze1 / libze-dev packages
-    set(CPACK_DEBIAN_LEVEL-ZERO_PACKAGE_CONFLICTS "libze1")
-    set(CPACK_DEBIAN_LEVEL-ZERO_PACKAGE_PROVIDES "libze1")
-    set(CPACK_DEBIAN_LEVEL-ZERO_PACKAGE_REPLACES "libze1")
-    set(CPACK_DEBIAN_LEVEL-ZERO-DEVEL_PACKAGE_CONFLICTS "libze-dev")
-    set(CPACK_DEBIAN_LEVEL-ZERO-DEVEL_PACKAGE_PROVIDES "libze-dev")
-    set(CPACK_DEBIAN_LEVEL-ZERO-DEVEL_PACKAGE_REPLACES "libze-dev")
+	set(CPACK_DEBIAN_PACKAGE_DESCRIPTION "oneAPI Level Zero")
+	set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "oneAPI Level Zero")
 
     # Canonical Ubuntu naming: libze1 (runtime) and libze-dev (development)
+    # For Debian/Ubuntu, only produce libze1 and libze-dev packages, not level-zero and level-zero-devel
+    get_cmake_property(CPACK_COMPONENTS_ALL COMPONENTS)
+    list(REMOVE_ITEM CPACK_COMPONENTS_ALL "level-zero" "level-zero-devel")
+
     set(CPACK_DEBIAN_LIBZE1_PACKAGE_NAME "libze1")
     set(CPACK_DEBIAN_LIBZE-DEV_PACKAGE_NAME "libze-dev")
     set(CPACK_DEBIAN_LIBZE1_FILE_NAME "libze1_${PROJECT_VERSION}+${os_name}${os_version}_${CPACK_DEBIAN_PACKAGE_ARCHITECTURE}.deb")
     set(CPACK_DEBIAN_LIBZE-DEV_FILE_NAME "libze-dev_${PROJECT_VERSION}+${os_name}${os_version}_${CPACK_DEBIAN_PACKAGE_ARCHITECTURE}.deb")
     set(CPACK_DEBIAN_LIBZE-DEV_PACKAGE_DEPENDS "libze1 (= ${PROJECT_VERSION})")
-    # Mutual exclusion with the level-zero / level-zero-devel packages
-    set(CPACK_DEBIAN_LIBZE1_PACKAGE_CONFLICTS "level-zero")
-    set(CPACK_DEBIAN_LIBZE1_PACKAGE_PROVIDES "level-zero")
-    set(CPACK_DEBIAN_LIBZE1_PACKAGE_REPLACES "level-zero")
-    set(CPACK_DEBIAN_LIBZE-DEV_PACKAGE_CONFLICTS "level-zero-devel")
-    set(CPACK_DEBIAN_LIBZE-DEV_PACKAGE_PROVIDES "level-zero-devel")
-    set(CPACK_DEBIAN_LIBZE-DEV_PACKAGE_REPLACES "level-zero-devel")
 
     set(CPACK_DEB_COMPONENT_INSTALL ON)
     set(CPACK_ARCHIVE_COMPONENT_INSTALL ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -450,6 +450,15 @@ if(CPACK_GENERATOR MATCHES "DEB")
     set(CPACK_DEBIAN_LIBZE-DEV_FILE_NAME "libze-dev_${PROJECT_VERSION}+${os_name}${os_version}_${CPACK_DEBIAN_PACKAGE_ARCHITECTURE}.deb")
     set(CPACK_DEBIAN_LIBZE-DEV_PACKAGE_DEPENDS "libze1 (= ${PROJECT_VERSION})")
 
+    # Mutual exclusion with the level-zero / level-zero-devel packages
+    # Allows seamless upgrade from old naming to new Canonical naming
+    set(CPACK_DEBIAN_LIBZE1_PACKAGE_CONFLICTS "level-zero")
+    set(CPACK_DEBIAN_LIBZE1_PACKAGE_PROVIDES "level-zero")
+    set(CPACK_DEBIAN_LIBZE1_PACKAGE_REPLACES "level-zero")
+    set(CPACK_DEBIAN_LIBZE-DEV_PACKAGE_CONFLICTS "level-zero-devel")
+    set(CPACK_DEBIAN_LIBZE-DEV_PACKAGE_PROVIDES "level-zero-devel")
+    set(CPACK_DEBIAN_LIBZE-DEV_PACKAGE_REPLACES "level-zero-devel")
+
     set(CPACK_DEB_COMPONENT_INSTALL ON)
     set(CPACK_ARCHIVE_COMPONENT_INSTALL ON)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,7 +224,9 @@ set(TARGET_LOADER_NAME ze_loader)
 
 # Canonical Ubuntu/Debian package names (libze1 / libze-dev)
 # produced alongside the existing level-zero / level-zero-devel packages.
-if(NOT BUILD_INSTALLER)
+# Restricted to Debian/Ubuntu systems only; RPM-based distros (SLES, RHEL, …)
+# must not produce libze1/libze-dev packages.
+if(NOT BUILD_INSTALLER AND EXISTS "/etc/debian_version")
     set(CANONICAL_LIB_COMPONENT "libze1")
     set(CANONICAL_SDK_COMPONENT "libze-dev")
 endif()


### PR DESCRIPTION
Unnecessary packages were being produced after the Canonical specific libze1* packages
were added to the CPack output, this removes them.