### PR TITLE
Fix .mako drift from actual headers

### DIFF
--- a/scripts/templates/ze_loader_internal.h.mako
+++ b/scripts/templates/ze_loader_internal.h.mako
@@ -129,6 +129,7 @@ namespace loader
         ~context_t();
         bool intercept_enabled = false;
         bool debugTraceEnabled = false;
+        bool debugTraceAdvanced = false;  // true when ZE_ENABLE_LOADER_DEBUG_TRACE=2 or ZEL_ENABLE_LOADER_LOGGING=2
         bool driverDDIPathDefault = false;
         bool tracingLayerEnabled = false;
         std::once_flag coreDriverSortOnce;


### PR DESCRIPTION
Add missing bool debugTraceAdvanced = false to .mako

This was already in the .h files, it was just not added to the mako, no change to binary output.