### PR TITLE
fix(pyzes): resolve libze_loader via portable path fallback (fixes non-Debian Linux)

### DIFF
--- a/bindings/sysman/python/source/pyzes.py
+++ b/bindings/sysman/python/source/pyzes.py
@@ -86,6 +86,7 @@ def _LoadZeLibrary():
 
             library_loaded = False
             load_errors = []
+            last_error = None
             for path in possible_paths:
                 try:
                     gpuLib = CDLL(path)
@@ -93,12 +94,17 @@ def _LoadZeLibrary():
                     break
                 except OSError as error:
                     load_errors.append(f"{path}: {error}")
+                    last_error = error
 
             if not library_loaded:
-                raise Exception(
+                # Raise OSError (the type ctypes.CDLL itself raises on a failed
+                # dlopen) so callers that handle OSError specifically keep
+                # working, while still surfacing the aggregated per-path
+                # diagnostics.
+                raise OSError(
                     "Failed to load Level Zero loader on Linux. "
                     f"Tried paths: {possible_paths}. Errors: {load_errors}"
-                )
+                ) from last_error
         else:
             libName = libName + ".dll"
 

--- a/bindings/sysman/python/source/pyzes.py
+++ b/bindings/sysman/python/source/pyzes.py
@@ -69,7 +69,36 @@ def _LoadZeLibrary():
         # load the library
         libName = "ze_loader"
         if sys.platform.startswith("linux"):
-            libName = "/usr/lib/x86_64-linux-gnu/lib" + libName + ".so.1"
+            soName = "lib" + libName + ".so.1"
+            # Try the bare soname first so the dynamic linker resolves it via
+            # the standard search path (LD_LIBRARY_PATH, ld.so.cache, RUNPATH).
+            # This works on every Linux distro. The explicit paths are kept as
+            # fallbacks: the Debian/Ubuntu multiarch location and the
+            # RHEL/SUSE/Fedora lib64 location. Hardcoding only the Debian path
+            # broke on non-Debian systems (e.g. HPC RHEL/SLES images), where
+            # the loader lives in /usr/lib64.
+            possible_paths = [
+                soName,
+                "/usr/lib/x86_64-linux-gnu/" + soName,
+                "/usr/lib64/" + soName,
+                "/usr/lib/" + soName,
+            ]
+
+            library_loaded = False
+            load_errors = []
+            for path in possible_paths:
+                try:
+                    gpuLib = CDLL(path)
+                    library_loaded = True
+                    break
+                except OSError as error:
+                    load_errors.append(f"{path}: {error}")
+
+            if not library_loaded:
+                raise Exception(
+                    "Failed to load Level Zero loader on Linux. "
+                    f"Tried paths: {possible_paths}. Errors: {load_errors}"
+                )
         else:
             libName = libName + ".dll"
 
@@ -106,9 +135,6 @@ def _LoadZeLibrary():
                     "Failed to load Level Zero loader on Windows. "
                     f"Tried paths: {possible_paths}. Errors: {load_errors}"
                 )
-
-        if sys.platform.startswith("linux"):
-            gpuLib = CDLL(libName)
 
         if gpuLib is None:
             raise Exception("Failed to load library: " + str(libName))


### PR DESCRIPTION
Fixes #485.

## Problem

`pyzes._LoadZeLibrary` hardcodes the Debian/Ubuntu multiarch path on Linux:

```python
libName = "/usr/lib/x86_64-linux-gnu/lib" + libName + ".so.1"
```

On non-Debian systems (RHEL/SUSE/Fedora, and HPC images such as ALCF
Aurora/Sunspot) the Level-Zero loader lives in `/usr/lib64`, so `import pyzes` —
and therefore `torch.xpu.is_available()` / `torch.xpu.device_count()`, which
import it — fails with:

```
OSError: /usr/lib/x86_64-linux-gnu/libze_loader.so.1:
cannot open shared object file: No such file or directory
```

## Fix

Give the Linux branch the same `possible_paths` fallback that the Windows branch
already uses. Try the **bare soname** first so the dynamic linker resolves it via
the standard search path (`LD_LIBRARY_PATH` / `ld.so.cache` / RUNPATH) — this
works on every distro, **including Debian** (where `/usr/lib/x86_64-linux-gnu`
is already on the default search path). Then fall back to explicit locations:
the Debian multiarch dir (preserves the old behavior), `/usr/lib64`
(RHEL/SUSE/Fedora), and `/usr/lib`. Collect and report per-path errors on total
failure, matching the Windows branch. The now-redundant trailing
`if linux: gpuLib = CDLL(libName)` is removed.

## Why not `ctypes.util.find_library("ze_loader")` (suggested in #485)

`find_library` works but has drawbacks on the exact systems that hit this bug:
it invokes `gcc`/`objdump`/`ldconfig` at runtime (slow, and often unavailable on
minimal HPC compute images), and its results for versioned `.so.1` sonames are
inconsistent across platforms. Handing the bare soname `libze_loader.so.1`
directly to `CDLL` lets the loader do the resolution with no subprocess and no
extra toolchain dependency, and the explicit fallbacks cover the non-default
locations.

## Testing

ALCF Sunspot (Intel Data Center GPU Max 1550, RHEL-family, oneAPI 2026.1.0),
inside a compute-node allocation:

- **Before:** `import pyzes` -> `OSError` (path above); `torch.xpu.is_available()` -> `False`, `device_count()` -> `0`.
- **After:** `torch.xpu.is_available()` -> `True`, `torch.xpu.device_count()` -> `12`.

`+30 / -4`, no API change. `pyzes.py` is hand-written (not `.mako`-generated),
so no template regeneration is required. Commit is DCO signed-off.